### PR TITLE
feat(remote): Tailscale/SSH source for Claude usage logs (library only, wiring follow-up)

### DIFF
--- a/apps/ccusage/src/remote/index.ts
+++ b/apps/ccusage/src/remote/index.ts
@@ -1,0 +1,250 @@
+import type {
+	MaterializedRemoteClaudeRoots,
+	RemoteFetchFailure,
+	RemoteFetchSuccess,
+	RemoteHostSpec,
+	RemoteOptions,
+} from './types.ts';
+import { rmSync } from 'node:fs';
+import { mkdtemp, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import process from 'node:process';
+import { logger } from '../logger.ts';
+import { fetchClaudeProjectsViaSSH, parseHostSpec } from './ssh.ts';
+import { listTailscalePeers } from './tailscale.ts';
+
+const CLAUDE_CONFIG_DIR_ENV = 'CLAUDE_CONFIG_DIR';
+const TMP_PREFIX = 'ccusage-remote-';
+
+export type CommandRemoteArgs = {
+	remoteHost?: string;
+	remoteTailscale?: boolean;
+	remoteTmp?: string;
+};
+
+export function parseRemoteHostsArg(value: string | undefined): RemoteHostSpec[] {
+	if (value == null || value.trim() === '') {
+		return [];
+	}
+	const specs: RemoteHostSpec[] = [];
+	const seen = new Set<string>();
+	for (const entry of value.split(',')) {
+		const spec = parseHostSpec(entry);
+		if (spec == null) {
+			logger.warn(`Ignoring invalid --remote-host entry: ${entry}`);
+			continue;
+		}
+		if (seen.has(spec.label)) {
+			continue;
+		}
+		seen.add(spec.label);
+		specs.push(spec);
+	}
+	return specs;
+}
+
+export function shouldUseRemote(args: CommandRemoteArgs): boolean {
+	if (args.remoteTailscale === true) {
+		return true;
+	}
+	const hostStr = args.remoteHost ?? '';
+	return hostStr.trim() !== '';
+}
+
+export async function materializeRemoteClaudeRoots(
+	options: RemoteOptions,
+): Promise<MaterializedRemoteClaudeRoots> {
+	const baseSpecs: RemoteHostSpec[] = [];
+	const seen = new Set<string>();
+	for (const host of options.hosts) {
+		const spec = parseHostSpec(host);
+		if (spec == null || seen.has(spec.label)) {
+			continue;
+		}
+		seen.add(spec.label);
+		baseSpecs.push(spec);
+	}
+	if (options.useTailscale) {
+		const discovered = await safelyListTailscalePeers();
+		for (const spec of discovered) {
+			if (seen.has(spec.label)) {
+				continue;
+			}
+			seen.add(spec.label);
+			baseSpecs.push(spec);
+		}
+	}
+
+	if (baseSpecs.length === 0) {
+		return {
+			rootPaths: [],
+			successes: [],
+			failures: [],
+			dispose: async () => {},
+		};
+	}
+
+	const tmpRoot = await mkdtemp(path.join(options.tmpRoot ?? os.tmpdir(), TMP_PREFIX));
+	// Process may exit synchronously via `process.exit(0)` inside a command
+	// body, which skips async finally blocks. The synchronous rmSync hook
+	// guarantees the temp tree is cleaned up even on hard exit.
+	const exitListener = (): void => {
+		try {
+			rmSync(tmpRoot, { recursive: true, force: true });
+		} catch {
+			// Best-effort cleanup; surface nothing during interpreter teardown.
+		}
+	};
+	process.once('exit', exitListener);
+	const successes: RemoteFetchSuccess[] = [];
+	const failures: RemoteFetchFailure[] = [];
+
+	const settled = await Promise.allSettled(
+		baseSpecs.map(async (spec) => {
+			const rootPath = path.join(tmpRoot, sanitizeLabelForPath(spec.label));
+			await fetchClaudeProjectsViaSSH(spec, rootPath);
+			return { spec, rootPath } satisfies RemoteFetchSuccess;
+		}),
+	);
+	for (const [index, outcome] of settled.entries()) {
+		const spec = baseSpecs[index]!;
+		if (outcome.status === 'fulfilled') {
+			successes.push(outcome.value);
+			logger.info(`Fetched Claude usage from ${spec.label}`);
+			continue;
+		}
+		const reason =
+			outcome.reason instanceof Error ? outcome.reason.message : String(outcome.reason);
+		failures.push({ host: spec.label, reason });
+		logger.warn(`Skipped ${spec.label}: ${reason}`);
+	}
+
+	const dispose = async (): Promise<void> => {
+		process.off('exit', exitListener);
+		await rm(tmpRoot, { recursive: true, force: true });
+	};
+
+	return {
+		rootPaths: successes.map((entry) => entry.rootPath),
+		successes,
+		failures,
+		dispose,
+	};
+}
+
+export async function withRemoteClaudeRoots<T>(
+	args: CommandRemoteArgs,
+	run: () => Promise<T>,
+): Promise<T> {
+	if (!shouldUseRemote(args)) {
+		return run();
+	}
+	const materialized = await materializeRemoteClaudeRoots({
+		hosts: parseRemoteHostsArg(args.remoteHost).map((spec) => spec.label),
+		useTailscale: args.remoteTailscale === true,
+		tmpRoot: args.remoteTmp,
+	});
+	if (materialized.rootPaths.length === 0) {
+		await materialized.dispose();
+		logger.warn('No remote Claude roots were materialized; continuing with local data only.');
+		return run();
+	}
+	const restore = augmentClaudeConfigDir(materialized.rootPaths);
+	try {
+		return await run();
+	} finally {
+		restore();
+		await materialized.dispose();
+	}
+}
+
+function augmentClaudeConfigDir(additionalRoots: readonly string[]): () => void {
+	const previous = process.env[CLAUDE_CONFIG_DIR_ENV];
+	const existing = previous == null || previous.trim() === '' ? [] : [previous];
+	const merged = [...existing, ...additionalRoots].join(',');
+	process.env[CLAUDE_CONFIG_DIR_ENV] = merged;
+	return () => {
+		if (previous == null) {
+			delete process.env[CLAUDE_CONFIG_DIR_ENV];
+		} else {
+			process.env[CLAUDE_CONFIG_DIR_ENV] = previous;
+		}
+	};
+}
+
+function sanitizeLabelForPath(label: string): string {
+	return label.replaceAll('@', '_at_').replaceAll('/', '_');
+}
+
+async function safelyListTailscalePeers(): Promise<RemoteHostSpec[]> {
+	try {
+		return await listTailscalePeers();
+	} catch (error) {
+		const reason = error instanceof Error ? error.message : String(error);
+		logger.warn(`Failed to list Tailscale peers: ${reason}`);
+		return [];
+	}
+}
+
+if (import.meta.vitest != null) {
+	describe('parseRemoteHostsArg', () => {
+		it('parses comma-separated host list', () => {
+			expect(parseRemoteHostsArg('ca-20036826, ogosh@home-mac-main').map((s) => s.label)).toEqual([
+				'ca-20036826',
+				'ogosh@home-mac-main',
+			]);
+		});
+
+		it('drops empty values and duplicates', () => {
+			expect(parseRemoteHostsArg(', , host-a, host-a ,host-b').map((s) => s.label)).toEqual([
+				'host-a',
+				'host-b',
+			]);
+		});
+
+		it('returns empty for blank input', () => {
+			expect(parseRemoteHostsArg(undefined)).toEqual([]);
+			expect(parseRemoteHostsArg('')).toEqual([]);
+			expect(parseRemoteHostsArg('   ')).toEqual([]);
+		});
+
+		it('drops invalid entries', () => {
+			expect(parseRemoteHostsArg('-evil,good-host').map((s) => s.label)).toEqual(['good-host']);
+		});
+	});
+
+	describe('shouldUseRemote', () => {
+		it('returns false when both options are absent', () => {
+			expect(shouldUseRemote({})).toBe(false);
+		});
+
+		it('returns true on explicit hosts', () => {
+			expect(shouldUseRemote({ remoteHost: 'ca-20036826' })).toBe(true);
+		});
+
+		it('returns true on tailscale flag', () => {
+			expect(shouldUseRemote({ remoteTailscale: true })).toBe(true);
+		});
+	});
+
+	describe('withRemoteClaudeRoots', () => {
+		const original = process.env[CLAUDE_CONFIG_DIR_ENV];
+
+		afterEach(() => {
+			if (original == null) {
+				delete process.env[CLAUDE_CONFIG_DIR_ENV];
+			} else {
+				process.env[CLAUDE_CONFIG_DIR_ENV] = original;
+			}
+		});
+
+		it('passes through when no remote args', async () => {
+			let captured = 'unset';
+			await withRemoteClaudeRoots({}, async () => {
+				captured = process.env[CLAUDE_CONFIG_DIR_ENV] ?? 'unset';
+			});
+			expect(captured).toBe(original ?? 'unset');
+		});
+	});
+}

--- a/apps/ccusage/src/remote/ssh.ts
+++ b/apps/ccusage/src/remote/ssh.ts
@@ -1,0 +1,201 @@
+import type { Buffer } from 'node:buffer';
+import type { Readable, Writable } from 'node:stream';
+import type { RemoteHostSpec } from './types.ts';
+import { spawn } from 'node:child_process';
+import { mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { pipeline } from 'node:stream/promises';
+
+// Why these patterns: we never want a user-controlled string to reach `ssh`
+// with a leading dash (option spoofing such as `-oProxyCommand=...`) or with
+// shell-metacharacters that could escape the constant remote command.
+const SSH_USER_PATTERN = /^\w[\w.-]{0,63}$/u;
+const SSH_HOST_PATTERN = /^\w[\w.-]{0,253}$/u;
+
+// `~/.claude/projects` only. We deliberately do not include `~/.claude/`
+// itself or any sibling files such as `.credentials.json`.
+const REMOTE_TAR_TARGET = '.claude/projects';
+const REMOTE_TAR_COMMAND = `tar -czf - -C "$HOME" ${REMOTE_TAR_TARGET}`;
+
+const SSH_CONNECT_TIMEOUT_SECONDS = 10;
+
+export type SSHCommand = {
+	program: string;
+	args: string[];
+};
+
+export function parseHostSpec(raw: string): RemoteHostSpec | null {
+	const trimmed = raw.trim();
+	if (trimmed === '') {
+		return null;
+	}
+	const atIndex = trimmed.indexOf('@');
+	if (atIndex === -1) {
+		if (!SSH_HOST_PATTERN.test(trimmed)) {
+			return null;
+		}
+		return { raw: trimmed, host: trimmed, label: trimmed };
+	}
+	const user = trimmed.slice(0, atIndex);
+	const host = trimmed.slice(atIndex + 1);
+	if (!SSH_USER_PATTERN.test(user) || !SSH_HOST_PATTERN.test(host)) {
+		return null;
+	}
+	return { raw: trimmed, user, host, label: `${user}@${host}` };
+}
+
+export function buildSSHFetchCommand(spec: RemoteHostSpec): SSHCommand {
+	const target = spec.user != null ? `${spec.user}@${spec.host}` : spec.host;
+	return {
+		program: 'ssh',
+		args: [
+			'-o',
+			'BatchMode=yes',
+			'-o',
+			`ConnectTimeout=${SSH_CONNECT_TIMEOUT_SECONDS}`,
+			target,
+			REMOTE_TAR_COMMAND,
+		],
+	};
+}
+
+export function buildTarExtractCommand(destDir: string): SSHCommand {
+	return {
+		program: 'tar',
+		args: ['-xzf', '-', '-C', destDir],
+	};
+}
+
+type SpawnLike = (
+	program: string,
+	args: string[],
+) => {
+	stdin: Writable | null;
+	stdout: Readable | null;
+	stderr: Readable | null;
+	on: (event: 'exit', listener: (code: number | null) => void) => void;
+	kill: (signal?: NodeJS.Signals) => void;
+};
+
+export type FetchDependencies = {
+	spawnProcess?: SpawnLike;
+};
+
+export async function fetchClaudeProjectsViaSSH(
+	spec: RemoteHostSpec,
+	destDir: string,
+	deps: FetchDependencies = {},
+): Promise<void> {
+	await mkdir(destDir, { recursive: true });
+	const launcher: SpawnLike =
+		deps.spawnProcess ??
+		((program, args) => spawn(program, args, { stdio: ['ignore', 'pipe', 'pipe'], shell: false }));
+
+	const sshCmd = buildSSHFetchCommand(spec);
+	const tarCmd = buildTarExtractCommand(destDir);
+	const ssh = launcher(sshCmd.program, sshCmd.args);
+	const tar = launcher(tarCmd.program, tarCmd.args);
+
+	const sshErrChunks: string[] = [];
+	const tarErrChunks: string[] = [];
+	ssh.stderr?.on('data', (chunk: Buffer) => sshErrChunks.push(chunk.toString('utf8')));
+	tar.stderr?.on('data', (chunk: Buffer) => tarErrChunks.push(chunk.toString('utf8')));
+
+	const sshExit = new Promise<number | null>((resolve) => ssh.on('exit', resolve));
+	const tarExit = new Promise<number | null>((resolve) => tar.on('exit', resolve));
+
+	if (ssh.stdout == null || tar.stdin == null) {
+		ssh.kill('SIGTERM');
+		tar.kill('SIGTERM');
+		throw new Error(`Failed to wire ssh/tar pipeline for ${spec.label}`);
+	}
+
+	try {
+		await pipeline(ssh.stdout, tar.stdin);
+	} catch (error) {
+		ssh.kill('SIGTERM');
+		tar.kill('SIGTERM');
+		throw new Error(
+			`Failed to stream ${spec.label}: ${error instanceof Error ? error.message : String(error)}`,
+		);
+	}
+
+	const [sshCode, tarCode] = await Promise.all([sshExit, tarExit]);
+	if (sshCode !== 0) {
+		throw new Error(
+			`ssh ${spec.label} exited with code ${String(sshCode)}: ${sshErrChunks.join('').trim()}`,
+		);
+	}
+	if (tarCode !== 0) {
+		throw new Error(
+			`tar extract for ${spec.label} exited with code ${String(tarCode)}: ${tarErrChunks.join('').trim()}`,
+		);
+	}
+}
+
+export function expectedExtractRoot(destDir: string): string {
+	return path.resolve(destDir);
+}
+
+if (import.meta.vitest != null) {
+	describe('parseHostSpec', () => {
+		it('accepts bare host names', () => {
+			expect(parseHostSpec('ca-20036826')).toEqual({
+				raw: 'ca-20036826',
+				host: 'ca-20036826',
+				label: 'ca-20036826',
+			});
+		});
+
+		it('accepts user@host', () => {
+			expect(parseHostSpec('ogosh@home-mac-main')).toEqual({
+				raw: 'ogosh@home-mac-main',
+				user: 'ogosh',
+				host: 'home-mac-main',
+				label: 'ogosh@home-mac-main',
+			});
+		});
+
+		it('rejects hosts starting with a dash to avoid ssh option spoofing', () => {
+			expect(parseHostSpec('-oProxyCommand=evil')).toBeNull();
+			expect(parseHostSpec('alice@-evil')).toBeNull();
+		});
+
+		it('rejects shell metacharacters', () => {
+			expect(parseHostSpec('host;rm -rf /')).toBeNull();
+			expect(parseHostSpec('host$(whoami)')).toBeNull();
+			expect(parseHostSpec('host with space')).toBeNull();
+		});
+
+		it('rejects empty input', () => {
+			expect(parseHostSpec('')).toBeNull();
+			expect(parseHostSpec('   ')).toBeNull();
+		});
+	});
+
+	describe('buildSSHFetchCommand', () => {
+		it('uses BatchMode and a fixed remote tar command', () => {
+			const { program, args } = buildSSHFetchCommand({
+				raw: 'ca-20036826',
+				host: 'ca-20036826',
+				label: 'ca-20036826',
+			});
+			expect(program).toBe('ssh');
+			expect(args).toContain('BatchMode=yes');
+			expect(args).toContain('ca-20036826');
+			expect(args[args.length - 1]).toContain('.claude/projects');
+			expect(args[args.length - 1]).not.toContain(';');
+			expect(args[args.length - 1]).not.toContain('|');
+		});
+
+		it('targets user@host when a user is given', () => {
+			const { args } = buildSSHFetchCommand({
+				raw: 'ogosh@home-mac-main',
+				user: 'ogosh',
+				host: 'home-mac-main',
+				label: 'ogosh@home-mac-main',
+			});
+			expect(args).toContain('ogosh@home-mac-main');
+		});
+	});
+}

--- a/apps/ccusage/src/remote/tailscale.ts
+++ b/apps/ccusage/src/remote/tailscale.ts
@@ -1,0 +1,122 @@
+import type { Buffer } from 'node:buffer';
+import type { RemoteHostSpec } from './types.ts';
+import { spawn } from 'node:child_process';
+import { parseHostSpec } from './ssh.ts';
+
+type RawTailscalePeer = {
+	HostName?: unknown;
+	DNSName?: unknown;
+	Online?: unknown;
+	OS?: unknown;
+};
+
+type RawTailscaleStatus = {
+	Self?: RawTailscalePeer;
+	Peer?: Record<string, RawTailscalePeer>;
+};
+
+// macOS reports "macOS", linux reports "linux". Phase 1 only fetches from
+// Unix-like remotes because the fetch command embeds `$HOME`.
+const SSH_REACHABLE_OS = new Set(['macOS', 'linux', 'freebsd', 'openbsd']);
+
+export function parseTailscaleStatus(jsonText: string): RemoteHostSpec[] {
+	let parsed: RawTailscaleStatus;
+	try {
+		parsed = JSON.parse(jsonText) as RawTailscaleStatus;
+	} catch {
+		return [];
+	}
+	const peers = parsed.Peer != null && typeof parsed.Peer === 'object' ? parsed.Peer : {};
+	const results: RemoteHostSpec[] = [];
+	const seen = new Set<string>();
+	for (const peer of Object.values(peers)) {
+		if (peer.Online !== true) {
+			continue;
+		}
+		if (typeof peer.OS === 'string' && !SSH_REACHABLE_OS.has(peer.OS)) {
+			continue;
+		}
+		const hostName = typeof peer.HostName === 'string' ? peer.HostName : null;
+		if (hostName == null) {
+			continue;
+		}
+		const spec = parseHostSpec(hostName);
+		if (spec == null || seen.has(spec.host)) {
+			continue;
+		}
+		seen.add(spec.host);
+		results.push(spec);
+	}
+	return results;
+}
+
+export async function listTailscalePeers(): Promise<RemoteHostSpec[]> {
+	const status = await readTailscaleStatus();
+	return parseTailscaleStatus(status);
+}
+
+async function readTailscaleStatus(): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const child = spawn('tailscale', ['status', '--json'], {
+			stdio: ['ignore', 'pipe', 'pipe'],
+			shell: false,
+		});
+		const stdout: string[] = [];
+		const stderr: string[] = [];
+		child.stdout.on('data', (chunk: Buffer) => stdout.push(chunk.toString('utf8')));
+		child.stderr.on('data', (chunk: Buffer) => stderr.push(chunk.toString('utf8')));
+		child.on('error', reject);
+		child.on('exit', (code) => {
+			if (code === 0) {
+				resolve(stdout.join(''));
+				return;
+			}
+			reject(new Error(`tailscale status exited ${String(code)}: ${stderr.join('').trim()}`));
+		});
+	});
+}
+
+if (import.meta.vitest != null) {
+	describe('parseTailscaleStatus', () => {
+		it('returns active Unix-like peers and skips offline ones', () => {
+			const fixture = JSON.stringify({
+				Self: { HostName: 'ultra2025', Online: true, OS: 'windows' },
+				Peer: {
+					a: { HostName: 'ca-20036826', Online: true, OS: 'macOS' },
+					b: { HostName: 'home-mac-main', Online: true, OS: 'macOS' },
+					c: { HostName: 'iphone-17', Online: false, OS: 'iOS' },
+					d: { HostName: 'nicoyuri', Online: false, OS: 'windows' },
+					e: { HostName: 'nicolas2025', Online: true, OS: 'windows' },
+				},
+			});
+			expect(parseTailscaleStatus(fixture).map((s) => s.host)).toEqual([
+				'ca-20036826',
+				'home-mac-main',
+			]);
+		});
+
+		it('returns an empty list for malformed JSON', () => {
+			expect(parseTailscaleStatus('not json')).toEqual([]);
+		});
+
+		it('skips peers with missing or unsafe host names', () => {
+			const fixture = JSON.stringify({
+				Peer: {
+					a: { Online: true, OS: 'macOS' },
+					b: { HostName: 'good-host', Online: true, OS: 'linux' },
+					c: { HostName: '-evil', Online: true, OS: 'linux' },
+					d: { HostName: 'good-host', Online: true, OS: 'linux' },
+				},
+			});
+			expect(parseTailscaleStatus(fixture).map((s) => s.host)).toEqual(['good-host']);
+		});
+
+		it('treats Self as not a peer', () => {
+			const fixture = JSON.stringify({
+				Self: { HostName: 'ultra2025', Online: true, OS: 'linux' },
+				Peer: {},
+			});
+			expect(parseTailscaleStatus(fixture)).toEqual([]);
+		});
+	});
+}

--- a/apps/ccusage/src/remote/types.ts
+++ b/apps/ccusage/src/remote/types.ts
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Remote Claude log fetch type definitions.
+ *
+ * Phase 1 only handles read-only fetch of `~/.claude/projects/` from
+ * Unix-like remote hosts over SSH (Tailscale SSH is a transport). Credential
+ * stores such as `~/.claude/.credentials.json` are intentionally never
+ * transferred — see `REMOTE_TAR_TARGET` in `./ssh.ts`.
+ */
+
+export type RemoteHostSpec = {
+	raw: string;
+	user?: string;
+	host: string;
+	label: string;
+};
+
+export type RemoteFetchFailure = {
+	host: string;
+	reason: string;
+};
+
+export type RemoteFetchSuccess = {
+	spec: RemoteHostSpec;
+	rootPath: string;
+};
+
+export type MaterializedRemoteClaudeRoots = {
+	rootPaths: string[];
+	successes: RemoteFetchSuccess[];
+	failures: RemoteFetchFailure[];
+	dispose: () => Promise<void>;
+};
+
+export type RemoteOptions = {
+	hosts: string[];
+	useTailscale: boolean;
+	tmpRoot?: string;
+};

--- a/apps/ccusage/src/shared-args.ts
+++ b/apps/ccusage/src/shared-args.ts
@@ -103,6 +103,21 @@ export const sharedArgs = {
 		description: 'Force compact mode for narrow displays (better for screenshots)',
 		default: false,
 	},
+	remoteHost: {
+		type: 'string',
+		description:
+			'Comma-separated SSH hosts to fetch Claude usage from (e.g. "ca-20036826,ogosh@home-mac-main"). Requires ssh and tar on the local machine; remote hosts must be Unix-like.',
+	},
+	remoteTailscale: {
+		type: 'boolean',
+		description:
+			'Discover active Tailscale peers via "tailscale status --json" and fetch Claude usage from each over SSH.',
+		default: false,
+	},
+	remoteTmp: {
+		type: 'string',
+		description: 'Override the temp directory used when extracting remote Claude logs.',
+	},
 } as const satisfies Args;
 
 /**


### PR DESCRIPTION
## Summary

Adds library-level support for fetching Claude usage logs from Tailscale-connected or SSH-reachable Unix-like hosts and aggregating them alongside local logs. CLI flags are defined but not yet wired into the report commands — that wiring is intended as a follow-up so this PR stays small and reviewable.

## What's in this PR

- **New module `apps/ccusage/src/remote/`**
  - `types.ts` — `RemoteHostSpec`, `RemoteOptions`, `MaterializedRemoteClaudeRoots`.
  - `ssh.ts` — host whitelist validator, `buildSSHFetchCommand` (`ssh -o BatchMode=yes -o ConnectTimeout=10 <host> 'tar -czf - -C "$HOME" .claude/projects'`), and `fetchClaudeProjectsViaSSH` that pipes ssh stdout into `tar -xz`.
  - `tailscale.ts` — `parseTailscaleStatus` for `tailscale status --json`, returns active `macOS`/`linux`/`*bsd` peers.
  - `index.ts` — `materializeRemoteClaudeRoots`, `withRemoteClaudeRoots` (augments `CLAUDE_CONFIG_DIR`, restores on finally, cleans up tmp via async `rm` plus a `process.once('exit', rmSync)` fallback for `process.exit(0)` paths).
- **Shared CLI flags** (`apps/ccusage/src/shared-args.ts`)
  - `--remote-host <host[,host,...]>`
  - `--remote-tailscale`
  - `--remote-tmp <path>`
- **In-source vitest** for: `parseHostSpec`, `buildSSHFetchCommand`, `parseTailscaleStatus`, `parseRemoteHostsArg`, `shouldUseRemote`, `withRemoteClaudeRoots` passthrough.

## Out of scope (deliberate)

- Wiring `withRemoteClaudeRoots` into `daily/weekly/monthly/session/blocks` — this PR is library-only. CLI flags will surface as no-ops until wired.
- Windows remote hosts (the fetch command embeds `$HOME` and assumes Unix-like remote shell).
- Per-host row breakdown / `--per-host` output mode.
- Docs site updates (per repo `CLAUDE.md`: "Do not proactively create documentation files unless explicitly requested").

## Security notes

- Only `~/.claude/projects` is transferred. `~/.claude/.credentials.json` and other sibling files are never read.
- Host/user names pass a strict whitelist (`^\w[\w.-]*$`) to block ssh option spoofing (`-oProxyCommand=...`) and shell metacharacter escapes.
- `ssh -o BatchMode=yes` disables interactive prompts; agent/key auth only.
- All child processes use `child_process.spawn` with `shell: false`.
- Tmp directories are created under `os.tmpdir()` with `mkdtemp` and removed on dispose (async) or interpreter exit (sync fallback).

## Test plan

- [x] `pnpm typecheck` — green
- [x] `pnpm run format` — green
- [x] `pnpm run test` — new module 19 tests all pass; remaining 24 failures match `main` baseline on Windows (`paths.ts` test asserts POSIX root, `cli.ts` bun path test) and are not introduced by this PR.
- [ ] Manual smoke once wiring lands (follow-up): `ccusage daily --remote-host ca-20036826 --offline`

## Follow-ups

1. Wire `withRemoteClaudeRoots` into report commands so the flags become end-user usable.
2. Optional: `--per-host` for row-level breakdown using `agent` metadata.
3. Optional: `ccusage.config.json` `remoteHosts` entry.

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds library support to fetch Claude usage logs from SSH and Tailscale-reachable Unix-like hosts and merge them with local data. CLI flags are defined but not yet wired into report commands.

- New Features
  - Fetches `~/.claude/projects` over SSH from explicit hosts and from active Tailscale peers discovered via `tailscale status --json`.
  - Materializes remote data into a temp dir and augments `CLAUDE_CONFIG_DIR` so reports can aggregate remote and local logs.
  - Adds CLI flags: `--remote-host`, `--remote-tailscale`, `--remote-tmp` (no-op until follow-up wiring).
  - Safety: transfers only `~/.claude/projects`, enforces strict host/user validation, uses `ssh -o BatchMode=yes` with `shell: false`, and cleans up temp dirs on exit.

<sup>Written for commit fdca3ead11482ec60fcdfe2883e3197c800467e0. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1015?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

