### PR TITLE
docs: list ccusage-mqtt under community projects

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -161,6 +161,10 @@ Check out [ccusage: The Claude Code cost scorecard that went viral](https://www.
     </picture>
 </a>
 
+## Community Projects
+
+- [ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt) — wraps `ccusage blocks --json --offline` and publishes Claude Code usage to Home Assistant via MQTT (15 sensors, auto-discovery, mood classifier).
+
 ## License
 
 [MIT](LICENSE) © [@ryoppippi](https://github.com/ryoppippi)


### PR DESCRIPTION
Hey @ryoppippi — thanks for ccusage, it's the cleanest way to get block-level Claude Code usage. I built [ccusage-mqtt](https://github.com/george-vice/ccusage-mqtt), which shells out to `ccusage blocks --json --offline` (pinned to a known-good version) for token / $ totals and republishes them to Home Assistant via MQTT alongside Anthropic's ratelimit-header data. Net result is an HA device with 15 sensors + a pre-built Lovelace card.

Adding a one-line entry under a community/built-with section. Happy to revise the wording / placement, or close this if it doesn't fit. Thanks again for the upstream. 🙏

- Repo: https://github.com/george-vice/ccusage-mqtt
- Landing: https://george-vice.github.io/ccusage-mqtt/

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Community Projects section to the `ccusage` README and lists `ccusage-mqtt`, which wraps `ccusage blocks --json --offline` to publish Claude Code usage to Home Assistant via MQTT (15 sensors, auto-discovery, mood classifier).

<sup>Written for commit 5f95cdef7fa61028a8416c616f34deaf3eb17314. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Community Projects section to the README, showcasing an external project that integrates ccusage with Home Assistant. The featured project publishes Claude Code usage metrics via MQTT, including sensor information and auto-discovery features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1048?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->