### PR TITLE
feat(codex): preserve source roots for multi-home usage

### DIFF
--- a/apps/ccusage/src/adapter/codex/index.ts
+++ b/apps/ccusage/src/adapter/codex/index.ts
@@ -1,5 +1,6 @@
 import type { AdapterContext, AdapterOptions, AgentUsageRow, ReportKind } from '../types.ts';
 import type { CodexGroup, CodexModelUsage, CodexReportRow } from './types.ts';
+import path from 'node:path';
 import { isDirectorySyncSafe } from '@ccusage/internal/fs';
 import { LiteLLMPricingFetcher } from '@ccusage/internal/pricing';
 import { compareStrings } from '@ccusage/internal/sort';
@@ -69,14 +70,19 @@ async function aggregateCodexUsageGroups(
 					: kind === 'monthly'
 						? formatMonthKey(event.timestamp, options.timezone)
 						: date;
-			const group = groups.get(period) ?? {
+			const groupKey =
+				kind === 'session' && event.sourceRoot != null
+					? `${event.sourceRoot}\0${event.sessionId}`
+					: period;
+			const group = groups.get(groupKey) ?? {
 				row: createEmptyRow(period, 'codex'),
 				models: new Map<string, CodexModelUsage>(),
 				reasoningOutputTokens: 0,
 				lastActivity: event.timestamp,
+				...(kind === 'session' && event.sourceRoot != null ? { sourceRoot: event.sourceRoot } : {}),
 			};
-			if (!groups.has(period)) {
-				groups.set(period, group);
+			if (!groups.has(groupKey)) {
+				groups.set(groupKey, group);
 			}
 
 			group.row.inputTokens += event.inputTokens;
@@ -147,8 +153,9 @@ export async function loadCodexReportRows(
 	context: AdapterContext,
 ): Promise<CodexReportRow[]> {
 	const { groups, pricingByModel } = await aggregateCodexUsageGroups(kind, options, context);
-	return Array.from(groups.entries(), ([period, group]) => {
+	return Array.from(groups.values(), (group) => {
 		const { row, reasoningOutputTokens, lastActivity } = group;
+		const period = row.period;
 		const models: Record<string, CodexModelUsage> = {};
 		for (const [model, usage] of group.models) {
 			models[model] = { ...usage };
@@ -169,11 +176,19 @@ export async function loadCodexReportRows(
 			return { month: period, ...base };
 		}
 		const separatorIndex = period.lastIndexOf('/');
+		const relativeDirectory = separatorIndex >= 0 ? period.slice(0, separatorIndex) : '';
+		const directory =
+			group.sourceRoot == null || group.sourceRoot === ''
+				? relativeDirectory
+				: relativeDirectory === ''
+					? group.sourceRoot
+					: `${group.sourceRoot}/${relativeDirectory}`;
 		return {
 			sessionId: period,
+			...(group.sourceRoot == null ? {} : { sourceRoot: group.sourceRoot }),
 			lastActivity,
 			sessionFile: separatorIndex >= 0 ? period.slice(separatorIndex + 1) : period,
-			directory: separatorIndex >= 0 ? period.slice(0, separatorIndex) : '',
+			directory,
 			...base,
 		};
 	}).sort((a, b) => {
@@ -373,6 +388,73 @@ if (import.meta.vitest != null) {
 				},
 			});
 			expect(rows[0]!.costUSD).toBeCloseTo(0.000115);
+		});
+
+		it('keeps identical session ids from different CODEX_HOME roots separate', async () => {
+			const sessionLines = [
+				JSON.stringify({
+					timestamp: '2026-01-03T00:00:00.000Z',
+					type: 'turn_context',
+					payload: { model: 'gpt-5' },
+				}),
+				JSON.stringify({
+					timestamp: '2026-01-03T00:00:01.000Z',
+					type: 'event_msg',
+					payload: {
+						type: 'token_count',
+						info: {
+							last_token_usage: {
+								input_tokens: 100,
+								cached_input_tokens: 10,
+								output_tokens: 20,
+								reasoning_output_tokens: 5,
+								total_tokens: 120,
+							},
+						},
+					},
+				}),
+			].join('\n');
+			await using fixture1 = await createFixture({
+				sessions: {
+					'project/shared.jsonl': sessionLines,
+				},
+			});
+			await using fixture2 = await createFixture({
+				sessions: {
+					'project/shared.jsonl': sessionLines,
+				},
+			});
+
+			vi.stubEnv('CODEX_HOME', `${fixture1.path},${fixture2.path}`);
+			const rows = await loadCodexReportRows(
+				'session',
+				{ offline: true, timezone: 'UTC' },
+				{
+					pricingFetcher: new LiteLLMPricingFetcher({
+						offline: true,
+						offlineLoader: async () => ({
+							'gpt-5': {
+								input_cost_per_token: 1e-6,
+								output_cost_per_token: 2e-6,
+								cache_read_input_token_cost: 1e-7,
+							},
+						}),
+					}),
+				},
+			);
+
+			expect(rows).toHaveLength(2);
+			expect(rows.map((row) => ('sourceRoot' in row ? row.sourceRoot : undefined))).toEqual([
+				path.basename(fixture1.path),
+				path.basename(fixture2.path),
+			]);
+			expect(rows.map((row) => ('directory' in row ? row.directory : undefined))).toEqual([
+				`${path.basename(fixture1.path)}/project`,
+				`${path.basename(fixture2.path)}/project`,
+			]);
+			expect(rows.every((row) => 'sessionId' in row && row.sessionId === 'project/shared')).toBe(
+				true,
+			);
 		});
 
 		it.skipIf(!isDirectorySyncSafe(getCodexSessionsPath()))(

--- a/apps/ccusage/src/adapter/codex/parser.ts
+++ b/apps/ccusage/src/adapter/codex/parser.ts
@@ -21,7 +21,7 @@ import { Result } from '@praha/byethrow';
 import { regex } from 'arkregex';
 import { createFixture } from 'fs-fixture';
 import { logger } from '../../logger.ts';
-import { getCodexSessionsPaths } from './paths.ts';
+import { getCodexSessionSources } from './paths.ts';
 
 const LEGACY_FALLBACK_MODEL = 'gpt-5';
 const CODEX_JSONL_MARKERS = ['turn_context', '"type":"token_count"', '"type": "token_count"'];
@@ -112,7 +112,7 @@ function subtractRawUsage(current: RawUsage, previous: RawUsage | null): RawUsag
 
 function convertToEventUsage(
 	raw: RawUsage,
-): Omit<TokenUsageEvent, 'timestamp' | 'sessionId' | 'model'> {
+): Omit<TokenUsageEvent, 'timestamp' | 'sessionId' | 'sourceRoot' | 'model'> {
 	const cached = Math.min(raw.cached_input_tokens, raw.input_tokens);
 	return {
 		inputTokens: raw.input_tokens,
@@ -132,7 +132,7 @@ function convertToEventUsage(
 
 function createTokenUsageEventKey(event: TokenUsageEvent): string {
 	const separator = TOKEN_USAGE_EVENT_KEY_SEPARATOR;
-	return `${event.timestamp}${separator}${event.model ?? ''}${separator}${event.inputTokens}${separator}${event.cachedInputTokens}${separator}${event.outputTokens}${separator}${event.reasoningOutputTokens}${separator}${event.totalTokens}`;
+	return `${event.sourceRoot ?? ''}${separator}${event.timestamp}${separator}${event.model ?? ''}${separator}${event.inputTokens}${separator}${event.cachedInputTokens}${separator}${event.outputTokens}${separator}${event.reasoningOutputTokens}${separator}${event.totalTokens}`;
 }
 
 function deduplicateTokenUsageEvents(events: TokenUsageEvent[]): TokenUsageEvent[] {
@@ -200,6 +200,7 @@ function extractTurnContextModelFast(line: string): string | undefined {
 async function parseCodexSessionFile(
 	directoryPath: string,
 	file: string,
+	sourceRoot?: string,
 ): Promise<TokenUsageEvent[]> {
 	const relativeSessionPath = path.relative(directoryPath, file);
 	const normalizedSessionPath = relativeSessionPath.split(path.sep).join('/');
@@ -249,6 +250,7 @@ async function parseCodexSessionFile(
 
 		events.push({
 			sessionId,
+			...(sourceRoot == null ? {} : { sourceRoot }),
 			timestamp: parsed.timestamp,
 			model,
 			...usage,
@@ -338,6 +340,7 @@ function getCodexWorkerThreadCount(fileCount: number): number {
 async function collectCodexEventsWithWorkers(
 	directoryPath: string,
 	files: string[],
+	sourceRoot?: string,
 ): Promise<TokenUsageEvent[] | null> {
 	const workerCount = getCodexWorkerThreadCount(files.length);
 	const fileEvents = await collectIndexedFileWorkerResults<
@@ -353,6 +356,7 @@ async function collectCodexEventsWithWorkers(
 			({
 				kind: 'ccusage:codex-worker',
 				directoryPath,
+				...(sourceRoot == null ? {} : { sourceRoot }),
 				items,
 			}) satisfies CodexWorkerData,
 	});
@@ -362,6 +366,7 @@ async function collectCodexEventsWithWorkers(
 function encodeTokenUsageEvents(events: TokenUsageEvent[]): EncodedTokenUsageEvents {
 	const timestamps: string[] = [];
 	const sessionIds: string[] = [];
+	const sourceRoots: string[] = [];
 	const models: string[] = [];
 	const modelIndexes = new Int32Array(events.length);
 	const numbers = new Float64Array(events.length * ENCODED_CODEX_EVENT_NUMBER_STRIDE);
@@ -372,6 +377,7 @@ function encodeTokenUsageEvents(events: TokenUsageEvent[]): EncodedTokenUsageEve
 		const event = events[index]!;
 		timestamps.push(event.timestamp);
 		sessionIds.push(event.sessionId);
+		sourceRoots.push(event.sourceRoot ?? '');
 		if (event.model == null) {
 			modelIndexes[index] = -1;
 		} else {
@@ -393,7 +399,7 @@ function encodeTokenUsageEvents(events: TokenUsageEvent[]): EncodedTokenUsageEve
 		flags[index] = event.isFallbackModel === true ? 1 : 0;
 	}
 
-	return { timestamps, sessionIds, models, modelIndexes, numbers, flags };
+	return { timestamps, sessionIds, sourceRoots, models, modelIndexes, numbers, flags };
 }
 
 function decodeTokenUsageEvents(encoded: EncodedTokenUsageEvents): TokenUsageEvent[] {
@@ -404,6 +410,7 @@ function decodeTokenUsageEvents(encoded: EncodedTokenUsageEvents): TokenUsageEve
 		events.push({
 			timestamp: encoded.timestamps[index]!,
 			sessionId: encoded.sessionIds[index]!,
+			...(encoded.sourceRoots[index] === '' ? {} : { sourceRoot: encoded.sourceRoots[index] }),
 			...(modelIndex >= 0 ? { model: encoded.models[modelIndex] } : {}),
 			inputTokens: encoded.numbers[numberOffset] ?? 0,
 			cachedInputTokens: encoded.numbers[numberOffset + 1] ?? 0,
@@ -418,6 +425,7 @@ function decodeTokenUsageEvents(encoded: EncodedTokenUsageEvents): TokenUsageEve
 
 async function loadTokenUsageEventsFromDirectory(
 	directoryPath: string,
+	sourceRoot?: string,
 ): Promise<TokenUsageEvent[]> {
 	const statResult = await Result.try({
 		try: async () => stat(directoryPath),
@@ -428,20 +436,22 @@ async function loadTokenUsageEventsFromDirectory(
 	}
 
 	const files = await collectFilesRecursive(directoryPath, { extension: '.jsonl' });
-	const workerEvents = await collectCodexEventsWithWorkers(directoryPath, files);
+	const workerEvents = await collectCodexEventsWithWorkers(directoryPath, files, sourceRoot);
 	if (workerEvents != null) {
 		return workerEvents.sort((a, b) => compareStrings(a.timestamp, b.timestamp));
 	}
 
 	const fileEvents = await Promise.all(
-		files.map(async (file) => parseCodexSessionFile(directoryPath, file)),
+		files.map(async (file) => parseCodexSessionFile(directoryPath, file, sourceRoot)),
 	);
 	return fileEvents.flat().sort((a, b) => compareStrings(a.timestamp, b.timestamp));
 }
 
 export async function loadTokenUsageEvents(): Promise<TokenUsageEvent[]> {
 	const directoryEvents = await Promise.all(
-		getCodexSessionsPaths().map(loadTokenUsageEventsFromDirectory),
+		getCodexSessionSources().map(async (source) =>
+			loadTokenUsageEventsFromDirectory(source.sessionsPath, source.sourceRoot),
+		),
 	);
 	return deduplicateTokenUsageEvents(directoryEvents.flat()).sort((a, b) =>
 		compareStrings(a.timestamp, b.timestamp),
@@ -452,7 +462,9 @@ async function runCodexWorker(data: CodexWorkerData): Promise<void> {
 	const results = [];
 	const transferList: ArrayBuffer[] = [];
 	for (const { index, item } of data.items) {
-		const result = encodeTokenUsageEvents(await parseCodexSessionFile(data.directoryPath, item));
+		const result = encodeTokenUsageEvents(
+			await parseCodexSessionFile(data.directoryPath, item, data.sourceRoot),
+		);
 		transferList.push(
 			result.modelIndexes.buffer as ArrayBuffer,
 			result.numbers.buffer as ArrayBuffer,
@@ -766,6 +778,50 @@ if (import.meta.vitest != null) {
 			await expect(loadTokenUsageEvents()).resolves.toMatchObject([
 				{ sessionId: 'a', model: 'gpt-5.1', inputTokens: 10 },
 				{ sessionId: 'b', model: 'gpt-5.2', inputTokens: 20 },
+			]);
+		});
+
+		it('keeps identical events from different CODEX_HOME roots separate', async () => {
+			const sessionLines = [
+				JSON.stringify({
+					timestamp: '2026-01-01T00:00:00.000Z',
+					type: 'turn_context',
+					payload: { model: 'gpt-5.2' },
+				}),
+				JSON.stringify({
+					timestamp: '2026-01-01T00:00:01.000Z',
+					type: 'event_msg',
+					payload: {
+						type: 'token_count',
+						info: {
+							last_token_usage: {
+								input_tokens: 10,
+								output_tokens: 1,
+								total_tokens: 11,
+							},
+						},
+					},
+				}),
+			].join('\n');
+			await using fixture1 = await createFixture({
+				sessions: {
+					'shared.jsonl': sessionLines,
+				},
+			});
+			await using fixture2 = await createFixture({
+				sessions: {
+					'shared.jsonl': sessionLines,
+				},
+			});
+			vi.stubEnv('CODEX_HOME', `${fixture1.path},${fixture2.path}`);
+
+			const events = await loadTokenUsageEvents();
+
+			expect(events).toHaveLength(2);
+			expect(new Set(events.map((event) => event.sourceRoot)).size).toBe(2);
+			expect(events).toMatchObject([
+				{ sessionId: 'shared', model: 'gpt-5.2', inputTokens: 10 },
+				{ sessionId: 'shared', model: 'gpt-5.2', inputTokens: 10 },
 			]);
 		});
 

--- a/apps/ccusage/src/adapter/codex/paths.ts
+++ b/apps/ccusage/src/adapter/codex/paths.ts
@@ -9,12 +9,50 @@ export const CODEX_HOME_ENV = 'CODEX_HOME';
 const DEFAULT_CODEX_DIR = path.join(os.homedir(), '.codex');
 const DEFAULT_SESSION_SUBDIR = 'sessions';
 
+export type CodexSessionSource = {
+	homePath: string;
+	sessionsPath: string;
+	sourceRoot?: string;
+};
+
 export function getCodexHomePaths(): string[] {
 	return normalizePathList(process.env[CODEX_HOME_ENV], [DEFAULT_CODEX_DIR]);
 }
 
+function buildCodexSourceRootLabels(homePaths: readonly string[]): Map<string, string> {
+	if (homePaths.length < 2) {
+		return new Map();
+	}
+
+	const basenameCounts = new Map<string, number>();
+	for (const homePath of homePaths) {
+		const resolvedBasename = path.basename(homePath);
+		const basename = resolvedBasename === '' ? homePath : resolvedBasename;
+		basenameCounts.set(basename, (basenameCounts.get(basename) ?? 0) + 1);
+	}
+
+	return new Map(
+		homePaths.map((homePath) => {
+			const resolvedBasename = path.basename(homePath);
+			const basename = resolvedBasename === '' ? homePath : resolvedBasename;
+			const label = (basenameCounts.get(basename) ?? 0) > 1 ? homePath : basename;
+			return [homePath, label];
+		}),
+	);
+}
+
+export function getCodexSessionSources(): CodexSessionSource[] {
+	const homePaths = getCodexHomePaths();
+	const sourceRootLabels = buildCodexSourceRootLabels(homePaths);
+	return homePaths.map((homePath) => ({
+		homePath,
+		sessionsPath: path.join(homePath, DEFAULT_SESSION_SUBDIR),
+		sourceRoot: sourceRootLabels.get(homePath),
+	}));
+}
+
 export function getCodexSessionsPaths(): string[] {
-	return getCodexHomePaths().map((codexHome) => path.join(codexHome, DEFAULT_SESSION_SUBDIR));
+	return getCodexSessionSources().map((source) => source.sessionsPath);
 }
 
 export function getCodexSessionsPath(): string {
@@ -69,6 +107,29 @@ if (import.meta.vitest != null) {
 			expect(getCodexSessionsPaths()).toEqual([
 				fixture1.getPath('sessions'),
 				fixture2.getPath('sessions'),
+			]);
+		});
+
+		it('labels multiple CODEX_HOME entries for source-aware session reports', async () => {
+			await using fixture1 = await createFixture({
+				sessions: {},
+			});
+			await using fixture2 = await createFixture({
+				sessions: {},
+			});
+			vi.stubEnv(CODEX_HOME_ENV, `${fixture1.path},${fixture2.path}`);
+
+			expect(getCodexSessionSources()).toEqual([
+				{
+					homePath: path.resolve(fixture1.path),
+					sessionsPath: fixture1.getPath('sessions'),
+					sourceRoot: path.basename(fixture1.path),
+				},
+				{
+					homePath: path.resolve(fixture2.path),
+					sessionsPath: fixture2.getPath('sessions'),
+					sourceRoot: path.basename(fixture2.path),
+				},
 			]);
 		});
 	});

--- a/apps/ccusage/src/adapter/codex/types.ts
+++ b/apps/ccusage/src/adapter/codex/types.ts
@@ -19,6 +19,7 @@ export type ParsedTokenCountLine = {
 export type TokenUsageEvent = {
 	timestamp: string;
 	sessionId: string;
+	sourceRoot?: string;
 	model?: string;
 	isFallbackModel?: boolean;
 	inputTokens: number;
@@ -42,17 +43,20 @@ export type CodexGroup = {
 	models: Map<string, CodexModelUsage>;
 	reasoningOutputTokens: number;
 	lastActivity: string;
+	sourceRoot?: string;
 };
 
 export type CodexSpeed = 'standard' | 'fast';
 
 export type CodexWorkerData = IndexedWorkerData<'ccusage:codex-worker', string> & {
 	directoryPath: string;
+	sourceRoot?: string;
 };
 
 export type EncodedTokenUsageEvents = {
 	timestamps: string[];
 	sessionIds: string[];
+	sourceRoots: string[];
 	models: string[];
 	modelIndexes: Int32Array;
 	numbers: Float64Array;
@@ -84,6 +88,7 @@ export type CodexReportRow =
 	  }
 	| {
 			sessionId: string;
+			sourceRoot?: string;
 			lastActivity: string;
 			sessionFile: string;
 			directory: string;


### PR DESCRIPTION
## Summary
- rebuild multi-home Codex support against the unified `ccusage` adapter implementation
- carry `sourceRoot` through Codex path discovery, JSONL parsing, worker encoding, and report rows
- keep copied branch-history deduplication within one Codex home while preventing cross-home events from being collapsed
- keep `ccusage codex session` rows distinct when different `CODEX_HOME` roots contain the same session path

## Testing
- `CODEX_HOME=/tmp/ccusage-no-codex-sessions pnpm --filter ccusage exec vitest run src/adapter/codex/paths.ts src/adapter/codex/parser.ts src/adapter/codex/index.ts src/commands/codex.ts`
- `pnpm --filter ccusage typecheck`
- `pnpm --filter ccusage lint`
- manual: `CODEX_HOME="/Volumes/usb_main/home/index_ailuntz/codex_macmini3,/Volumes/usb_main/home/index_ailuntz/codex_macmini2" pnpm --filter ccusage exec bun ./src/cli.ts codex daily --offline --json`
- manual: `CODEX_HOME="/Volumes/usb_main/home/index_ailuntz/codex_macmini3,/Volumes/usb_main/home/index_ailuntz/codex_macmini2" pnpm --filter ccusage exec bun ./src/cli.ts codex session --offline --json --since 20260414`

Note: full `pnpm --filter ccusage test` was attempted, but the local-environment Claude default-path integration test failed and the suite was stopped after it hung on local data; the targeted Codex tests above pass.

Closes #968

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add source-aware multi-home Codex support in `ccusage`. Sessions and events from different `CODEX_HOME` roots stay separate and their source is shown in session reports.

- **New Features**
  - Propagate `sourceRoot` through path discovery, parsing, worker encoding, grouping, and report rows.
  - Group session usage by `sourceRoot + sessionId` to avoid collapsing identical paths across homes.
  - Scope copied-branch-history deduplication to a single Codex home; no cross-home dedup.
  - Add source-aware session discovery: each `CODEX_HOME` yields a labeled `sessionsPath`, with stable labels when basenames collide.
  - Session rows now include `sourceRoot`; `directory` is prefixed with the source label when present.

<sup>Written for commit 38b380f411a2c1b7b700aef2cdb2a5d7de0f6762. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1051?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session tracking and deduplication to properly handle multiple Codex installation roots. Sessions with identical IDs from different CODEX_HOME directories are now correctly separated and tracked individually in usage reports, improving accuracy of attribution and reporting metrics when multiple Codex instances are configured.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->