### PR TITLE
fix(terminal): query Windows console for actual width

### DIFF
--- a/rust/crates/ccusage-terminal/src/lib.rs
+++ b/rust/crates/ccusage-terminal/src/lib.rs
@@ -457,12 +457,12 @@ pub fn terminal_width() -> usize {
         .ok()
         .and_then(|value| value.parse::<usize>().ok())
         .filter(|width| *width > 0)
-        .or_else(terminal_width_from_ioctl)
+        .or_else(terminal_width_from_os)
         .unwrap_or(DEFAULT_TERMINAL_WIDTH)
 }
 
 #[cfg(unix)]
-fn terminal_width_from_ioctl() -> Option<usize> {
+fn terminal_width_from_os() -> Option<usize> {
     if !io::stdout().is_terminal() {
         return None;
     }
@@ -487,14 +487,88 @@ fn terminal_width_from_ioctl() -> Option<usize> {
     }
 }
 
-#[cfg(not(unix))]
-fn terminal_width_from_ioctl() -> Option<usize> {
+#[cfg(windows)]
+#[repr(C)]
+struct ConsoleCoord {
+    x: i16,
+    y: i16,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct ConsoleSmallRect {
+    left: i16,
+    top: i16,
+    right: i16,
+    bottom: i16,
+}
+
+#[cfg(windows)]
+#[repr(C)]
+struct ConsoleScreenBufferInfo {
+    size: ConsoleCoord,
+    cursor_position: ConsoleCoord,
+    attributes: u16,
+    window: ConsoleSmallRect,
+    maximum_window_size: ConsoleCoord,
+}
+
+#[cfg(windows)]
+fn terminal_width_from_os() -> Option<usize> {
+    if !io::stdout().is_terminal() {
+        return None;
+    }
+    const STD_OUTPUT_HANDLE: u32 = -11i32 as u32;
+    const INVALID_HANDLE_VALUE: *mut std::ffi::c_void = -1isize as *mut std::ffi::c_void;
+    let mut info = ConsoleScreenBufferInfo {
+        size: ConsoleCoord { x: 0, y: 0 },
+        cursor_position: ConsoleCoord { x: 0, y: 0 },
+        attributes: 0,
+        window: ConsoleSmallRect {
+            left: 0,
+            top: 0,
+            right: 0,
+            bottom: 0,
+        },
+        maximum_window_size: ConsoleCoord { x: 0, y: 0 },
+    };
+    let handle = unsafe { GetStdHandle(STD_OUTPUT_HANDLE) };
+    if handle.is_null() || handle == INVALID_HANDLE_VALUE {
+        return None;
+    }
+    let ok = unsafe { GetConsoleScreenBufferInfo(handle, &mut info) };
+    if ok == 0 {
+        return None;
+    }
+    console_window_width(info.window.left, info.window.right)
+}
+
+#[cfg(not(any(unix, windows)))]
+fn terminal_width_from_os() -> Option<usize> {
     None
 }
 
 #[cfg(unix)]
 extern "C" {
     fn ioctl(fd: i32, request: usize, ...) -> i32;
+}
+
+#[cfg(windows)]
+extern "system" {
+    fn GetStdHandle(n_std_handle: u32) -> *mut std::ffi::c_void;
+    fn GetConsoleScreenBufferInfo(
+        h_console_output: *mut std::ffi::c_void,
+        lp_console_screen_buffer_info: *mut ConsoleScreenBufferInfo,
+    ) -> i32;
+}
+
+fn console_window_width(left: i16, right: i16) -> Option<usize> {
+    let span = i32::from(right) - i32::from(left) + 1;
+    if span > 0 {
+        Some(span as usize)
+    } else {
+        None
+    }
 }
 
 pub fn print_box_title(title: &str, style: impl Into<TerminalStyle>) {
@@ -621,5 +695,20 @@ mod tests {
         let truncated = truncate_visible("\x1b[33mvery-long-value\x1b[0m", 8);
 
         assert!(truncated.ends_with("\x1b[0m…"));
+    }
+
+    #[test]
+    fn console_window_width_returns_inclusive_span() {
+        assert_eq!(console_window_width(0, 216), Some(217));
+    }
+
+    #[test]
+    fn console_window_width_handles_single_column_window() {
+        assert_eq!(console_window_width(0, 0), Some(1));
+    }
+
+    #[test]
+    fn console_window_width_rejects_inverted_bounds() {
+        assert_eq!(console_window_width(10, 5), None);
     }
 }


### PR DESCRIPTION
Closes #1089

## Summary

On Windows, `terminal_width()` always returned the 120-column default — the `terminal_width_from_ioctl` helper at [`ccusage-terminal/src/lib.rs:490-493`](https://github.com/ryoppippi/ccusage/blob/main/rust/crates/ccusage-terminal/src/lib.rs#L490-L493) was a `None`-returning stub outside `cfg(unix)`. Without `$COLUMNS` set, every Windows user got the compact table layout regardless of their actual terminal width, with token totals truncated like `232,678,…`.

Mirror the Unix path with raw FFI to `GetStdHandle` + `GetConsoleScreenBufferInfo` and derive the visible window width from `srWindow.right - srWindow.left + 1`. Also rename `terminal_width_from_ioctl` → `terminal_width_from_os` (it isn't an ioctl on Windows) and extract `console_window_width` as a small testable helper.

No new dependencies — matches the style of the existing Unix `ioctl` extern declaration.

## Test plan

- [x] `cargo test -p ccusage-terminal` — 8/8 pass, including three new `console_window_width_*` cases (inclusive span, single-column window, inverted bounds → `None`).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- [x] `cargo fmt --all` — clean.
- [x] `pnpm typecheck` — clean (apps/ccusage, docs).
- [x] `pnpm --filter ccusage run test:vitest` — 26/26 pass.
- [x] Reproduced the bug locally on Windows 11 / Windows Terminal (217-col PowerShell) by running published `ccusage@20.0.0` — observed `232,678,…` truncation.
- [ ] **Visual confirmation needed**: build this branch with `cargo build --release --manifest-path rust/Cargo.toml -p ccusage` and run `target/release/ccusage.exe daily` directly from a wide PowerShell window. Expect the table to expand to the full terminal width with no `…` truncation. *(The unit tests cover the width math, but cargo test runs piped so `is_terminal()` short-circuits the live Win32 call. Posting once a reviewer can sanity-check.)*

## Notes

- Two pre-existing test failures on `main` (`tests::formats_dates_with_timezone`, `adapter::hermes::tests::loads_billable_hermes_sessions_from_state_db`) reproduce identically on this branch — not introduced by this change. The TZ test relies on `TZ=UTC` which isn't propagated by `pnpm test:rust`; the Hermes test hits a Windows file-locking race on SQLite.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Windows terminal width detection so `terminal_width()` uses the actual console window width instead of the 120-column default. This prevents forced compact tables and number truncation when `$COLUMNS` isn’t set.

- **Bug Fixes**
  - Implemented Windows path via FFI to `GetStdHandle` and `GetConsoleScreenBufferInfo`, computing width as `srWindow.right - srWindow.left + 1`.
  - Renamed `terminal_width_from_ioctl` to `terminal_width_from_os`.
  - Added `console_window_width` helper with unit tests (inclusive span, single-column, inverted bounds).
  - Preserves `is_terminal()` guard; non-Unix/non-Windows returns `None`. No new dependencies.

<sup>Written for commit 40bc680a21b013bab7c9319967b802cd0b96a6d1. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1088?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced terminal width detection to use platform-specific methods for improved accuracy across Unix and Windows systems.

* **Tests**
  * Added unit tests to validate terminal width calculations across various terminal configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1088?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->