### PR TITLE
fix: normalize date filter bounds

### DIFF
--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -14,8 +14,8 @@ use crate::{
     cli::{AgentCommandArgs, AgentReportKind, CodexSpeed, SharedArgs, SortOrder, WeekDay},
     color, filter_loaded_entries_by_date, format_currency, format_models_multiline, format_number,
     json_float, print_box_title, print_json_or_jq, short_model_name, summarize_by_key,
-    summarize_summaries_by_bucket, wants_json, Align, BucketKind, CodexGroup, Color, LoadedEntry,
-    ModelBreakdown, PricingMap, Result, SessionAccumulator, SimpleTable, UsageSummary,
+    summarize_summaries_by_bucket, wants_json, Align, BucketKind, CodexGroup, Color, DateFilter,
+    LoadedEntry, ModelBreakdown, PricingMap, Result, SessionAccumulator, SimpleTable, UsageSummary,
 };
 
 #[derive(Debug, Clone)]
@@ -573,15 +573,15 @@ fn summarize_entry_sessions(
 }
 
 fn filter_session_summaries(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
-    if shared.since.is_some() || shared.until.is_some() {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if !date_filter.is_empty() {
         rows.retain(|row| {
             let date = row
                 .last_activity
                 .as_deref()
                 .unwrap_or_default()
                 .replace('-', "");
-            shared.since.as_ref().is_none_or(|since| &date >= since)
-                && shared.until.as_ref().is_none_or(|until| &date <= until)
+            date_filter.contains_compact_date(&date)
         });
     }
 }

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -15,7 +15,7 @@ use crate::{
     color, format_currency, format_date_tz, format_models_multiline, format_number, json_float,
     json_value_u64, log_level, parse_ts_timestamp, parse_tz, print_box_title, print_json_or_jq,
     wants_json, week_start, Align, CodexGroup, CodexModelUsage, CodexTokenUsageEvent, Color,
-    PricingMap, Result, SimpleTable,
+    DateFilter, PricingMap, Result, SimpleTable,
 };
 
 type CodexEventKey = (String, Option<String>, u64, u64, u64, u64, u64);
@@ -225,8 +225,9 @@ fn aggregate_file(
     seen: &CodexDedupeShards,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
     crate::visit_codex_session_file(sessions_dir, file, |event| {
-        add_event_to_groups(&event, kind, timezone, shared, seen, groups)
+        add_event_to_groups(&event, kind, timezone, &date_filter, seen, groups)
     })
 }
 
@@ -234,7 +235,7 @@ fn add_event_to_groups(
     event: &CodexTokenUsageEvent,
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
-    shared: &SharedArgs,
+    date_filter: &DateFilter,
     seen: &CodexDedupeShards,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
@@ -247,13 +248,8 @@ fn add_event_to_groups(
     let timestamp = parse_ts_timestamp(&event.timestamp)
         .ok_or_else(|| crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp)))?;
     let date = format_date_tz(timestamp, timezone);
-    if shared.since.is_some() || shared.until.is_some() {
-        let date_key = date.replace('-', "");
-        if shared.since.as_ref().is_some_and(|since| &date_key < since)
-            || shared.until.as_ref().is_some_and(|until| &date_key > until)
-        {
-            return Ok(());
-        }
+    if !date_filter.is_empty() && !date_filter.contains_iso_date(&date) {
+        return Ok(());
     }
     let period = match kind {
         AgentReportKind::Daily => date,
@@ -389,7 +385,8 @@ pub(crate) fn filter_events_by_date(
     events: &mut Vec<CodexTokenUsageEvent>,
     shared: &SharedArgs,
 ) -> Result<()> {
-    if shared.since.is_none() && shared.until.is_none() {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if date_filter.is_empty() {
         return Ok(());
     }
     let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
@@ -399,9 +396,7 @@ pub(crate) fn filter_events_by_date(
             crate::cli_error(format!("Invalid Codex timestamp: {}", event.timestamp))
         })?;
         let date = format_date_tz(timestamp, timezone.as_ref()).replace('-', "");
-        if shared.since.as_ref().is_none_or(|since| &date >= since)
-            && shared.until.as_ref().is_none_or(|until| &date <= until)
-        {
+        if date_filter.contains_compact_date(&date) {
             kept.push(event);
         }
     }
@@ -674,7 +669,8 @@ mod tests {
         )
         .unwrap();
         let shared = SharedArgs {
-            since: Some("20260103".to_string()),
+            since: Some("2026-01-03".to_string()),
+            until: Some("2026-01-03".to_string()),
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -7,7 +7,7 @@ use crate::{
     cli::{AgentCommandArgs, AgentReportKind, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, print_json_or_jq, print_usage_table, sort_summaries,
     summarize_by_key, summarize_summaries_by_bucket, totals_json, wants_json, BucketKind,
-    LoadedEntry, Result, SessionAccumulator,
+    DateFilter, LoadedEntry, Result, SessionAccumulator,
 };
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
@@ -103,17 +103,15 @@ fn rows_key(kind: AgentReportKind) -> &'static str {
 }
 
 fn filter_session_summaries(rows: &mut Vec<crate::UsageSummary>, shared: &SharedArgs) {
-    if shared.since.is_some() || shared.until.is_some() {
-        let since = shared.since.as_deref().map(|value| value.replace('-', ""));
-        let until = shared.until.as_deref().map(|value| value.replace('-', ""));
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if !date_filter.is_empty() {
         rows.retain(|row| {
             let date = row
                 .last_activity
                 .as_deref()
                 .unwrap_or_default()
                 .replace('-', "");
-            since.as_ref().is_none_or(|bound| &date >= bound)
-                && until.as_ref().is_none_or(|bound| &date <= bound)
+            date_filter.contains_compact_date(&date)
         });
     }
 }

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -7,8 +7,8 @@ use crate::{
     cli::{SharedArgs, SortOrder},
     color, format_currency, format_date, format_models_multiline, format_number,
     format_rfc3339_millis, format_utc_second, hour_12, json_float, local_parts, print_box_title,
-    terminal_width, utc_now, Align, BurnRate, Color, LoadedEntry, Projection, SessionBlock,
-    SimpleTable, TimestampMs, TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD,
+    terminal_width, utc_now, Align, BurnRate, Color, DateFilter, LoadedEntry, Projection,
+    SessionBlock, SimpleTable, TimestampMs, TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD,
     BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
 };
 
@@ -125,13 +125,13 @@ fn create_gap_block(last: TimestampMs, next: TimestampMs, duration: i64) -> Sess
 }
 
 pub(crate) fn filter_blocks_by_date(blocks: &mut Vec<SessionBlock>, shared: &SharedArgs) {
-    if shared.since.is_none() && shared.until.is_none() {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if date_filter.is_empty() {
         return;
     }
     blocks.retain(|block| {
         let date = format_date(block.start_time, shared.timezone.as_deref()).replace('-', "");
-        shared.since.as_ref().is_none_or(|since| &date >= since)
-            && shared.until.as_ref().is_none_or(|until| &date <= until)
+        date_filter.contains_compact_date(&date)
     });
 }
 

--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -17,8 +17,8 @@ use crate::{
     calculate_cost, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
     cli_error, debug_log, format_date_tz, home, log_level, parse_ts_timestamp, parse_tz, progress,
-    LoadedEntry, LoadedFile, ModelBreakdown, PricingMap, Result, Speed, TimestampMs, TokenCounts,
-    TokenUsageRaw, UsageEntry, UsageSummary,
+    DateFilter, LoadedEntry, LoadedFile, ModelBreakdown, PricingMap, Result, Speed, TimestampMs,
+    TokenCounts, TokenUsageRaw, UsageEntry, UsageSummary,
 };
 
 pub(crate) fn load_entries(
@@ -172,13 +172,13 @@ fn load_entries_inner(
 }
 
 pub(crate) fn filter_loaded_entries_by_date(entries: &mut Vec<LoadedEntry>, shared: &SharedArgs) {
-    if shared.since.is_none() && shared.until.is_none() {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if date_filter.is_empty() {
         return;
     }
     entries.retain(|entry| {
         let date = entry.date.replace('-', "");
-        shared.since.as_ref().is_none_or(|since| &date >= since)
-            && shared.until.as_ref().is_none_or(|until| &date <= until)
+        date_filter.contains_compact_date(&date)
     });
 }
 

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -23,7 +23,7 @@ use crate::{
     print_active_block_detail, print_blocks_table, print_json_or_jq, print_usage_table,
     session_summary_json, sort_blocks, sort_summaries, summarize_by_key,
     summarize_summaries_by_bucket, summary_json, total_usage_tokens, totals_json, utc_now,
-    wants_json, BucketKind, Color, Context, Result, SessionAccumulator, TimestampMs,
+    wants_json, BucketKind, Color, Context, DateFilter, Result, SessionAccumulator, TimestampMs,
     DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS, MILLIS_PER_DAY, MILLIS_PER_MINUTE,
 };
 
@@ -168,21 +168,18 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
     for group in grouped {
         rows.push(group.into_summary(session_shared.timezone.as_deref())?);
     }
-    if session_shared.since.is_some() || session_shared.until.is_some() {
+    let date_filter = DateFilter::new(
+        session_shared.since.as_deref(),
+        session_shared.until.as_deref(),
+    );
+    if !date_filter.is_empty() {
         rows.retain(|row| {
             let date = row
                 .last_activity
                 .as_deref()
                 .unwrap_or_default()
                 .replace('-', "");
-            session_shared
-                .since
-                .as_ref()
-                .is_none_or(|since| &date >= since)
-                && session_shared
-                    .until
-                    .as_ref()
-                    .is_none_or(|until| &date <= until)
+            date_filter.contains_compact_date(&date)
         });
     }
     rows.retain(|row| {

--- a/rust/crates/ccusage/src/date_utils.rs
+++ b/rust/crates/ccusage/src/date_utils.rs
@@ -28,6 +28,12 @@ pub(crate) struct IsoDate {
     pub(crate) day: u32,
 }
 
+#[derive(Debug, Clone, Default)]
+pub(crate) struct DateFilter {
+    since: Option<String>,
+    until: Option<String>,
+}
+
 impl TimestampMs {
     pub(crate) const UNIX_EPOCH: Self = Self(0);
 
@@ -97,6 +103,42 @@ impl IsoDate {
         let days = self.days_since_epoch().checked_add(days)?;
         let (year, month, day) = civil_from_days(days);
         Some(Self { year, month, day })
+    }
+}
+
+impl DateFilter {
+    pub(crate) fn new(since: Option<&str>, until: Option<&str>) -> Self {
+        Self {
+            since: since.map(normalize_date_filter_bound),
+            until: until.map(normalize_date_filter_bound),
+        }
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.since.is_none() && self.until.is_none()
+    }
+
+    pub(crate) fn contains_compact_date(&self, date: &str) -> bool {
+        self.since
+            .as_ref()
+            .is_none_or(|since| date >= since.as_str())
+            && self
+                .until
+                .as_ref()
+                .is_none_or(|until| date <= until.as_str())
+    }
+
+    pub(crate) fn contains_iso_date(&self, date: &str) -> bool {
+        let date = date.replace('-', "");
+        self.contains_compact_date(&date)
+    }
+}
+
+pub(crate) fn normalize_date_filter_bound(value: &str) -> String {
+    if parse_iso_date(value).is_some() {
+        value.replace('-', "")
+    } else {
+        value.to_string()
     }
 }
 
@@ -316,5 +358,23 @@ pub(crate) fn am_pm(hour: u32) -> &'static str {
         "AM"
     } else {
         "PM"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn date_filter_accepts_iso_and_compact_bounds() {
+        let iso = DateFilter::new(Some("2026-01-02"), Some("2026-01-03"));
+        let compact = DateFilter::new(Some("20260102"), Some("20260103"));
+
+        for filter in [iso, compact] {
+            assert!(!filter.contains_iso_date("2026-01-01"));
+            assert!(filter.contains_iso_date("2026-01-02"));
+            assert!(filter.contains_iso_date("2026-01-03"));
+            assert!(!filter.contains_iso_date("2026-01-04"));
+        }
     }
 }

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -5,8 +5,8 @@ use std::{
 
 use crate::{
     cli::{SharedArgs, SortOrder, WeekDay},
-    cli_error, format_date, format_naive_date, parse_iso_date, LoadedEntry, ModelBreakdown, Result,
-    TimestampMs, TokenCounts, UsageSummary,
+    cli_error, format_date, format_naive_date, parse_iso_date, DateFilter, LoadedEntry,
+    ModelBreakdown, Result, TimestampMs, TokenCounts, UsageSummary,
 };
 
 pub(crate) fn summarize_by_key<F, M>(
@@ -258,11 +258,11 @@ pub(crate) fn filter_and_sort_summaries<F>(
 ) where
     F: Fn(&UsageSummary) -> &str,
 {
-    if shared.since.is_some() || shared.until.is_some() {
+    let date_filter = DateFilter::new(shared.since.as_deref(), shared.until.as_deref());
+    if !date_filter.is_empty() {
         rows.retain(|row| {
             let date = date_fn(row).replace('-', "");
-            shared.since.as_ref().is_none_or(|since| &date >= since)
-                && shared.until.as_ref().is_none_or(|until| &date <= until)
+            date_filter.contains_compact_date(&date)
         });
     }
     sort_summaries(rows, &shared.order, date_fn);


### PR DESCRIPTION
  ## Bugfix

  Fix Codex usage date filtering when `--since` / `--until` are provided in ISO date format, such as `2026-05-06`.

  Previously, Codex daily usage data used compact dates like `20260506` internally, while CLI filter bounds could remain in `YYYY-MM-DD` format. This caused string comparisons to incorrectly exclude valid records, resulting in `No Codex usage data found`.

  This change normalizes date filter bounds before comparison and applies the same helper across Codex, Claude, Qwen, summary, blocks, and command-level filtering paths.

  Verified with:

  - `cargo fmt --manifest-path rust/Cargo.toml --all`
  - `cargo test --manifest-path rust/Cargo.toml --workspace`
  - `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets -- -D warnings`
  - `ccusage codex daily --since 2026-05-06 --until 2026-05-20`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date filtering when `--since`/`--until` are given as ISO dates (YYYY-MM-DD), so valid usage data is no longer excluded. Accepts both ISO and compact (YYYYMMDD) bounds across all reports.

- **Bug Fixes**
  - Added a `DateFilter` helper that normalizes bounds to `YYYYMMDD`.
  - Replaced ad-hoc string checks with `DateFilter` across Codex, Claude, Qwen, summaries, blocks, and session commands.
  - Prevents false “No Codex usage data found” by comparing consistent date formats.

<sup>Written for commit 8d4827002a15a4e0b54f773bb388a14dfd200c1b. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1092?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated date-range filtering logic across multiple components using a centralized utility, supporting both ISO (`YYYY-MM-DD`) and compact (`YYYYMMDD`) date formats.
  * Standardized date filtering behavior to use consistent normalization and range-checking methods throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1092?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->