### PR TITLE
perf: optimize memory allocation, hash, compile-time computation

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -37,6 +37,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,13 +62,17 @@ name = "ccusage"
 version = "20.0.0"
 dependencies = [
  "ccusage-terminal",
+ "compact_str",
  "jiff",
  "memchr",
  "mimalloc",
  "minreq",
+ "phf",
+ "rustc-hash",
  "schemars",
  "serde",
  "serde_json",
+ "smallvec",
  "sqlite",
  "ureq",
 ]
@@ -84,6 +97,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -94,6 +121,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -247,6 +280,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
+dependencies = [
+ "fastrand",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +382,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustls"
 version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -341,6 +423,18 @@ dependencies = [
  "rustls-pki-types",
  "untrusted",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "schemars"
@@ -427,6 +521,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "sqlite"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -453,6 +559,12 @@ checksum = "a7781d97adc13a1d5081127a9ee29afad8427f3757bd984daf814d8265267039"
 dependencies = [
  "sqlite3-src",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "subtle"

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -20,9 +20,13 @@ jiff = { version = "0.2.24", default-features = false, features = [
 	"tzdb-zoneinfo",
 ] }
 memchr = "2"
+compact_str = "0.9"
+phf = { version = "0.13", features = ["macros"] }
+rustc-hash = "2"
 schemars = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+smallvec = "1"
 sqlite = { version = "0.37.0", default-features = false, features = ["bundled", "linkage"] }
 ureq = { version = "3.3.0", default-features = false, features = ["rustls"] }
 

--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -767,8 +767,9 @@ impl AllAccumulator {
 }
 
 fn aggregate_model_breakdowns(rows: &[AllRow]) -> Vec<ModelBreakdown> {
-    use std::collections::HashMap;
-    let mut indexes: HashMap<String, usize> = HashMap::new();
+    use crate::fast::FxHashMap;
+
+    let mut indexes = FxHashMap::<String, usize>::default();
     let mut breakdowns: Vec<ModelBreakdown> = Vec::new();
     for row in rows {
         for item in &row.model_breakdowns {

--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::DefaultHasher, BTreeMap, HashSet},
+    collections::BTreeMap,
     env, fs,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -7,19 +7,31 @@ use std::{
     thread,
 };
 
+use compact_str::CompactString;
 use jiff::tz::TimeZone as JiffTimeZone;
+use rustc_hash::FxHasher;
 use serde_json::{json, Value};
 
 use crate::{
     cli::{AgentCommandArgs, AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
-    color, format_currency, format_date_tz, format_models_multiline, format_number, json_float,
+    color,
+    fast::FxHashSet,
+    format_currency, format_date_tz, format_models_multiline, format_number, json_float,
     json_value_u64, log_level, parse_ts_timestamp, parse_tz, print_box_title, print_json_or_jq,
     wants_json, week_start, Align, CodexGroup, CodexModelUsage, CodexTokenUsageEvent, Color,
     PricingMap, Result, SimpleTable,
 };
 
-type CodexEventKey = (String, Option<String>, u64, u64, u64, u64, u64);
-type CodexDedupeShards = [Mutex<HashSet<CodexEventKey>>];
+type CodexEventKey = (
+    CompactString,
+    Option<CompactString>,
+    u64,
+    u64,
+    u64,
+    u64,
+    u64,
+);
+type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
 
 pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let shared = args.shared;
@@ -293,26 +305,26 @@ fn accumulate_codex_event_into_group(
     model_usage.is_fallback |= event.is_fallback_model;
 }
 
-fn create_dedupe_shards() -> Vec<Mutex<HashSet<CodexEventKey>>> {
+fn create_dedupe_shards() -> Vec<Mutex<FxHashSet<CodexEventKey>>> {
     let shard_count = thread::available_parallelism()
         .map(usize::from)
         .unwrap_or(1);
     (0..shard_count.max(1))
-        .map(|_| Mutex::new(HashSet::new()))
+        .map(|_| Mutex::new(FxHashSet::default()))
         .collect()
 }
 
 fn insert_event_key(event: &CodexTokenUsageEvent, seen: &CodexDedupeShards) -> bool {
     let key = (
-        event.timestamp.clone(),
-        event.model.clone(),
+        CompactString::new(&event.timestamp),
+        event.model.as_deref().map(CompactString::new),
         event.input_tokens,
         event.cached_input_tokens,
         event.output_tokens,
         event.reasoning_output_tokens,
         event.total_tokens,
     );
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     key.hash(&mut hasher);
     let shard_index = hasher.finish() as usize % seen.len();
     seen[shard_index].lock().unwrap().insert(key)

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -1,15 +1,15 @@
-use std::collections::HashSet;
-
 use serde_json::{json, Value};
 
 use crate::{
     am_pm,
     cli::{SharedArgs, SortOrder},
-    color, format_currency, format_date, format_models_multiline, format_number,
-    format_rfc3339_millis, format_utc_second, hour_12, json_float, local_parts, print_box_title,
-    terminal_width, utc_now, Align, BurnRate, Color, LoadedEntry, Projection, SessionBlock,
-    SimpleTable, TimestampMs, TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD,
-    BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
+    color,
+    fast::FxHashSet,
+    format_currency, format_date, format_models_multiline, format_number, format_rfc3339_millis,
+    format_utc_second, hour_12, json_float, local_parts, print_box_title, terminal_width, utc_now,
+    Align, BurnRate, Color, LoadedEntry, Projection, SessionBlock, SimpleTable, TimestampMs,
+    TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR,
+    MILLIS_PER_MINUTE,
 };
 
 pub(crate) fn identify_session_blocks(
@@ -80,7 +80,7 @@ fn create_block(
     let mut token_counts = TokenCounts::default();
     let mut cost = 0.0;
     let mut models = Vec::new();
-    let mut seen_models = HashSet::new();
+    let mut seen_models = FxHashSet::default();
     let mut usage_limit_reset_time = None;
     for entry in &entries {
         token_counts.add_usage(entry.data.message.usage);

--- a/rust/crates/ccusage/src/claude_loader.rs
+++ b/rust/crates/ccusage/src/claude_loader.rs
@@ -1,7 +1,5 @@
 use std::{
-    collections::hash_map::DefaultHasher,
     collections::BTreeMap,
-    collections::{HashMap, HashSet},
     env, fs,
     hash::{Hash, Hasher},
     path::{Path, PathBuf},
@@ -11,14 +9,17 @@ use std::{
 
 use jiff::tz::TimeZone as JiffTimeZone;
 use memchr::memmem;
+use rustc_hash::FxHasher;
 use serde::Deserialize;
 
 use crate::{
     calculate_cost, calculate_cost_for_usage,
     cli::{CostMode, SharedArgs},
-    cli_error, debug_log, format_date_tz, home, log_level, parse_ts_timestamp, parse_tz, progress,
-    LoadedEntry, LoadedFile, ModelBreakdown, PricingMap, Result, Speed, TimestampMs, TokenCounts,
-    TokenUsageRaw, UsageEntry, UsageSummary,
+    cli_error, debug_log,
+    fast::{byte_lines, suffix_string, FxHashMap, FxHashSet, SmallIndexVec},
+    format_date_tz, home, log_level, parse_ts_timestamp, parse_tz, progress, LoadedEntry,
+    LoadedFile, ModelBreakdown, PricingMap, Result, Speed, TimestampMs, TokenCounts, TokenUsageRaw,
+    UsageEntry, UsageSummary,
 };
 
 pub(crate) fn load_entries(
@@ -67,7 +68,7 @@ fn load_daily_summaries_inner(
         read_daily_usage_files_parallel(&files, tz.as_ref(), mode, pricing.as_ref())
     };
 
-    let mut deduped_indexes: HashMap<u64, Vec<usize>> = HashMap::new();
+    let mut deduped_indexes: FxHashMap<u64, SmallIndexVec> = FxHashMap::default();
     let mut deduped = Vec::with_capacity(loaded_files.iter().map(|file| file.entries.len()).sum());
     for loaded_file in loaded_files {
         for entry in loaded_file.entries {
@@ -80,23 +81,37 @@ fn load_daily_summaries_inner(
         }
     }
 
-    let mut groups = BTreeMap::<String, DailyAccumulator>::new();
-    for entry in &deduped {
-        let key = if group_by_project {
-            format!("{}\0{}", entry.date, entry.project)
-        } else {
-            entry.date.clone()
-        };
-        groups.entry(key).or_default().add_entry(entry);
+    if group_by_project {
+        let mut groups = BTreeMap::<(String, Arc<str>), DailyAccumulator>::new();
+        for entry in &deduped {
+            groups
+                .entry((entry.date.clone(), Arc::clone(&entry.project)))
+                .or_default()
+                .add_entry(entry);
+        }
+        return Ok(groups
+            .into_iter()
+            .map(|((date, project), group)| {
+                let mut summary = group.into_summary();
+                summary.date = Some(date);
+                summary.project = Some(project.to_string());
+                summary
+            })
+            .collect());
     }
 
+    let mut groups = BTreeMap::<String, DailyAccumulator>::new();
+    for entry in &deduped {
+        groups
+            .entry(entry.date.clone())
+            .or_default()
+            .add_entry(entry);
+    }
     Ok(groups
         .into_iter()
         .map(|(key, group)| {
-            let mut parts = key.split('\0');
             let mut summary = group.into_summary();
-            summary.date = Some(parts.next().unwrap_or_default().to_string());
-            summary.project = parts.next().map(str::to_string);
+            summary.date = Some(key);
             summary
         })
         .collect())
@@ -151,7 +166,7 @@ fn load_entries_inner(
         ),
     );
 
-    let mut deduped_indexes: HashMap<u64, Vec<usize>> = HashMap::new();
+    let mut deduped_indexes: FxHashMap<u64, SmallIndexVec> = FxHashMap::default();
     let mut deduped: Vec<LoadedEntry> =
         Vec::with_capacity(loaded_files.iter().map(|file| file.entries.len()).sum());
     for loaded_file in loaded_files {
@@ -405,7 +420,7 @@ fn read_daily_usage_file(
     };
 
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    for line in content.split(|byte| *byte == b'\n') {
+    for line in byte_lines(&content) {
         if usage_marker.find(line).is_none() {
             continue;
         }
@@ -439,7 +454,7 @@ fn read_daily_usage_file(
             if model == "<synthetic>" {
                 None
             } else if matches!(usage.speed, Some(Speed::Fast)) {
-                Some(format!("{model}-fast"))
+                Some(suffix_string(model, "-fast"))
             } else {
                 Some(model.clone())
             }
@@ -525,7 +540,7 @@ fn should_replace_deduped_entry(candidate: &UsageEntry, existing: &UsageEntry) -
 
 fn push_deduped_entry(
     entry: LoadedEntry,
-    deduped_indexes: &mut HashMap<u64, Vec<usize>>,
+    deduped_indexes: &mut FxHashMap<u64, SmallIndexVec>,
     deduped: &mut Vec<LoadedEntry>,
 ) {
     let dedupe_lookup = entry.data.message.id.as_deref().map(|message_id| {
@@ -555,7 +570,7 @@ fn push_deduped_entry(
 
 fn push_deduped_daily_entry(
     entry: DailyLoadedEntry,
-    deduped_indexes: &mut HashMap<u64, Vec<usize>>,
+    deduped_indexes: &mut FxHashMap<u64, SmallIndexVec>,
     deduped: &mut Vec<DailyLoadedEntry>,
 ) {
     let dedupe_lookup = entry.message_id.as_deref().map(|message_id| {
@@ -594,7 +609,7 @@ fn push_deduped_daily_entry(
 }
 
 fn usage_dedupe_hash(message_id: &str, request_id: Option<&str>) -> u64 {
-    let mut hasher = DefaultHasher::new();
+    let mut hasher = FxHasher::default();
     message_id.hash(&mut hasher);
     request_id.hash(&mut hasher);
     hasher.finish()
@@ -614,9 +629,8 @@ struct DailyAccumulator {
     counts: TokenCounts,
     cost: f64,
     models: Vec<String>,
-    seen_models: HashSet<String>,
     breakdowns: Vec<ModelBreakdown>,
-    breakdown_indexes: HashMap<String, usize>,
+    breakdown_indexes: FxHashMap<String, usize>,
 }
 
 impl DailyAccumulator {
@@ -624,20 +638,18 @@ impl DailyAccumulator {
         self.counts.add_usage(entry.usage);
         self.cost += entry.cost;
         if let Some(model) = &entry.model {
-            if self.seen_models.insert(model.clone()) {
+            let index = if let Some(index) = self.breakdown_indexes.get(model.as_str()) {
+                *index
+            } else {
+                let index = self.breakdowns.len();
+                self.breakdown_indexes.insert(model.clone(), index);
                 self.models.push(model.clone());
-            }
-            let index = *self
-                .breakdown_indexes
-                .entry(model.clone())
-                .or_insert_with(|| {
-                    let index = self.breakdowns.len();
-                    self.breakdowns.push(ModelBreakdown {
-                        model_name: model.clone(),
-                        ..ModelBreakdown::default()
-                    });
-                    index
+                self.breakdowns.push(ModelBreakdown {
+                    model_name: model.clone(),
+                    ..ModelBreakdown::default()
                 });
+                index
+            };
             let breakdown = &mut self.breakdowns[index];
             breakdown.input_tokens += entry.usage.input_tokens;
             breakdown.output_tokens += entry.usage.output_tokens;
@@ -691,7 +703,7 @@ fn read_usage_file(
     };
 
     let usage_marker = memmem::Finder::new(br#""usage":{"#);
-    for line in content.split(|byte| *byte == b'\n') {
+    for line in byte_lines(&content) {
         if usage_marker.find(line).is_none() {
             continue;
         }
@@ -716,7 +728,7 @@ fn read_usage_file(
             if model == "<synthetic>" {
                 None
             } else if matches!(data.message.usage.speed, Some(Speed::Fast)) {
-                Some(format!("{model}-fast"))
+                Some(suffix_string(model, "-fast"))
             } else {
                 Some(model.clone())
             }
@@ -815,44 +827,48 @@ fn has_unsupported_null_field(line: &[u8]) -> bool {
 }
 
 fn is_unsupported_nullable_field(field: &[u8]) -> bool {
-    matches!(
-        field,
-        b"id"
-            | b"cwd"
-            | b"model"
-            | b"speed"
-            | b"costUSD"
-            | b"version"
-            | b"sessionId"
-            | b"requestId"
-            | b"isApiErrorMessage"
-            | b"cache_read_input_tokens"
-            | b"cache_creation_input_tokens"
-    )
+    static FIELDS: phf::Set<&'static str> = phf::phf_set! {
+        "id",
+        "cwd",
+        "model",
+        "speed",
+        "costUSD",
+        "version",
+        "sessionId",
+        "requestId",
+        "isApiErrorMessage",
+        "cache_read_input_tokens",
+        "cache_creation_input_tokens",
+    };
+
+    std::str::from_utf8(field).is_ok_and(|field| FIELDS.contains(field))
 }
 
 fn is_semver_prefix(value: &str) -> bool {
-    let mut parts = value.split('.');
-    let Some(major) = parts.next() else {
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    if !consume_ascii_digits(bytes, &mut index) || bytes.get(index) != Some(&b'.') {
         return false;
-    };
-    let Some(minor) = parts.next() else {
+    }
+    index += 1;
+    if !consume_ascii_digits(bytes, &mut index) || bytes.get(index) != Some(&b'.') {
         return false;
-    };
-    let Some(patch) = parts.next() else {
-        return false;
-    };
-    !major.is_empty()
-        && !minor.is_empty()
-        && !patch.is_empty()
-        && major.chars().all(|ch| ch.is_ascii_digit())
-        && minor.chars().all(|ch| ch.is_ascii_digit())
-        && patch.chars().next().is_some_and(|ch| ch.is_ascii_digit())
+    }
+    index += 1;
+    bytes.get(index).is_some_and(u8::is_ascii_digit)
+}
+
+fn consume_ascii_digits(bytes: &[u8], index: &mut usize) -> bool {
+    let start = *index;
+    while bytes.get(*index).is_some_and(u8::is_ascii_digit) {
+        *index += 1;
+    }
+    *index > start
 }
 
 pub(crate) fn claude_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
-    let mut seen = std::collections::HashSet::new();
+    let mut seen = FxHashSet::default();
     if let Ok(env_paths) = env::var("CLAUDE_CONFIG_DIR") {
         for raw in env_paths
             .split(',')

--- a/rust/crates/ccusage/src/codex_loader.rs
+++ b/rust/crates/ccusage/src/codex_loader.rs
@@ -1,15 +1,19 @@
 use std::{
-    collections::HashSet,
     env, fs,
     path::{Path, PathBuf},
     thread,
 };
 
+use compact_str::CompactString;
 use serde_json::Value;
 
 use crate::{
-    chunk_file_indexes_by_size, cli::SharedArgs, cli_error, collect_usage_files, home,
-    non_empty_json_string, progress, CodexRawUsage, CodexTokenUsageEvent, Result, TimestampMs,
+    chunk_file_indexes_by_size,
+    cli::SharedArgs,
+    cli_error, collect_usage_files,
+    fast::{byte_lines, FxHashSet},
+    home, non_empty_json_string, progress, CodexRawUsage, CodexTokenUsageEvent, Result,
+    TimestampMs,
 };
 
 pub(crate) fn load_codex_events_from_directory(
@@ -93,7 +97,7 @@ fn read_codex_session_files_parallel(
 
 pub(crate) fn codex_usage_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
-    let mut seen = HashSet::new();
+    let mut seen = FxHashSet::default();
     for path in codex_home_paths()? {
         let sessions = path.join("sessions");
         if sessions.is_dir() {
@@ -135,7 +139,7 @@ pub(crate) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let Ok(content) = fs::read_to_string(path) else {
+    let Ok(content) = fs::read(path) else {
         return Ok(());
     };
     let session_id = codex_session_id(sessions_dir, path);
@@ -144,16 +148,11 @@ pub(crate) fn visit_codex_session_file(
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
 
-    for line in content.lines() {
-        if !line.contains("turn_context")
-            && !line.contains("token_count")
-            && !line.contains("\"usage\":")
-            && !line.contains("\"input_tokens\":")
-            && !line.contains("\"prompt_tokens\":")
-        {
+    for line in byte_lines(&content) {
+        if !codex_line_may_contain_usage(line) {
             continue;
         }
-        let Ok(value) = serde_json::from_str::<Value>(line) else {
+        let Ok(value) = serde_json::from_slice::<Value>(line) else {
             continue;
         };
         let entry_type = value.get("type").and_then(Value::as_str);
@@ -166,8 +165,7 @@ pub(crate) fn visit_codex_session_file(
         }
         if entry_type != Some("event_msg") {
             add_codex_exec_event(
-                sessions_dir,
-                path,
+                &session_id,
                 &value,
                 &fallback_timestamp,
                 &mut current_model,
@@ -248,8 +246,7 @@ pub(crate) fn visit_codex_session_file(
 }
 
 fn add_codex_exec_event(
-    sessions_dir: &Path,
-    path: &Path,
+    session_id: &str,
     value: &Value,
     fallback_timestamp: &str,
     current_model: &mut Option<String>,
@@ -275,7 +272,7 @@ fn add_codex_exec_event(
         is_fallback_model = true;
     }
     visit(CodexTokenUsageEvent {
-        session_id: codex_session_id(sessions_dir, path),
+        session_id: session_id.to_string(),
         timestamp: codex_timestamp_from_result(value)
             .unwrap_or_else(|| fallback_timestamp.to_string()),
         model,
@@ -286,6 +283,14 @@ fn add_codex_exec_event(
         total_tokens: raw_usage.total_tokens,
         is_fallback_model,
     })
+}
+
+fn codex_line_may_contain_usage(line: &[u8]) -> bool {
+    memchr::memmem::find(line, b"turn_context").is_some()
+        || memchr::memmem::find(line, b"token_count").is_some()
+        || memchr::memmem::find(line, br#""usage":"#).is_some()
+        || memchr::memmem::find(line, br#""input_tokens":"#).is_some()
+        || memchr::memmem::find(line, br#""prompt_tokens":"#).is_some()
 }
 
 fn parsed_model_is_missing(
@@ -488,12 +493,12 @@ fn subtract_codex_raw_usage(
 }
 
 fn dedupe_codex_events(events: &mut Vec<CodexTokenUsageEvent>) {
-    let mut seen = HashSet::new();
+    let mut seen = FxHashSet::default();
     events.retain(|event| {
         seen.insert((
-            event.session_id.clone(),
-            event.timestamp.clone(),
-            event.model.clone(),
+            CompactString::new(&event.session_id),
+            CompactString::new(&event.timestamp),
+            event.model.as_deref().map(CompactString::new),
             event.input_tokens,
             event.cached_input_tokens,
             event.output_tokens,

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashMap,
     env, fs,
     io::{self, Read},
     path::{Path, PathBuf},
@@ -17,14 +16,16 @@ use crate::{
         BlocksArgs, CostSource, DailyArgs, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
         VisualBurnRate, WeekDay, WeeklyArgs,
     },
-    color, filter_and_sort_summaries, filter_blocks_by_date, format_compact_utc_date,
-    format_currency, format_number, format_remaining_time, format_rfc3339_millis,
-    group_project_output, identify_session_blocks, load_daily_summaries, load_entries,
-    print_active_block_detail, print_blocks_table, print_json_or_jq, print_usage_table,
-    session_summary_json, sort_blocks, sort_summaries, summarize_by_key,
-    summarize_summaries_by_bucket, summary_json, total_usage_tokens, totals_json, utc_now,
-    wants_json, BucketKind, Color, Context, Result, SessionAccumulator, TimestampMs,
-    DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS, MILLIS_PER_DAY, MILLIS_PER_MINUTE,
+    color,
+    fast::FxHashMap,
+    filter_and_sort_summaries, filter_blocks_by_date, format_compact_utc_date, format_currency,
+    format_number, format_remaining_time, format_rfc3339_millis, group_project_output,
+    identify_session_blocks, load_daily_summaries, load_entries, print_active_block_detail,
+    print_blocks_table, print_json_or_jq, print_usage_table, session_summary_json, sort_blocks,
+    sort_summaries, summarize_by_key, summarize_summaries_by_bucket, summary_json,
+    total_usage_tokens, totals_json, utc_now, wants_json, BucketKind, Color, Context, Result,
+    SessionAccumulator, TimestampMs, DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS,
+    MILLIS_PER_DAY, MILLIS_PER_MINUTE,
 };
 
 pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
@@ -150,7 +151,7 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
     session_shared.order = SortOrder::Desc;
     let entries = load_entries(&session_shared, None)?;
     let mut grouped = Vec::<SessionAccumulator>::new();
-    let mut group_indexes = HashMap::<(Arc<str>, Arc<str>), usize>::new();
+    let mut group_indexes = FxHashMap::<(Arc<str>, Arc<str>), usize>::default();
     for entry in &entries {
         let key = (
             Arc::clone(&entry.project_path),

--- a/rust/crates/ccusage/src/fast.rs
+++ b/rust/crates/ccusage/src/fast.rs
@@ -1,0 +1,69 @@
+use memchr::memchr;
+use smallvec::SmallVec;
+
+pub(crate) type FxHashMap<K, V> = rustc_hash::FxHashMap<K, V>;
+pub(crate) type FxHashSet<T> = rustc_hash::FxHashSet<T>;
+pub(crate) type SmallIndexVec = SmallVec<[usize; 1]>;
+
+pub(crate) struct ByteLines<'a> {
+    bytes: &'a [u8],
+}
+
+impl<'a> ByteLines<'a> {
+    pub(crate) fn new(bytes: &'a [u8]) -> Self {
+        Self { bytes }
+    }
+}
+
+impl<'a> Iterator for ByteLines<'a> {
+    type Item = &'a [u8];
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.bytes.is_empty() {
+            return None;
+        }
+        if let Some(newline) = memchr(b'\n', self.bytes) {
+            let (line, rest) = self.bytes.split_at(newline);
+            self.bytes = &rest[1..];
+            Some(line)
+        } else {
+            let line = self.bytes;
+            self.bytes = &[];
+            Some(line)
+        }
+    }
+}
+
+pub(crate) fn byte_lines(bytes: &[u8]) -> ByteLines<'_> {
+    ByteLines::new(bytes)
+}
+
+pub(crate) fn suffix_string(value: &str, suffix: &str) -> String {
+    let mut output = String::with_capacity(value.len() + suffix.len());
+    output.push_str(value);
+    output.push_str(suffix);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{byte_lines, suffix_string};
+
+    #[test]
+    fn byte_lines_returns_newline_delimited_slices() {
+        let lines = byte_lines(b"one\ntwo\nthree").collect::<Vec<_>>();
+
+        assert_eq!(
+            lines,
+            [b"one".as_slice(), b"two".as_slice(), b"three".as_slice()]
+        );
+    }
+
+    #[test]
+    fn suffix_string_builds_without_formatting() {
+        assert_eq!(
+            suffix_string("claude-sonnet-4", "-fast"),
+            "claude-sonnet-4-fast"
+        );
+    }
+}

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -10,6 +10,7 @@ mod config;
 mod config_schema;
 mod cost;
 mod date_utils;
+mod fast;
 mod home;
 mod logger;
 mod output;

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1,6 +1,8 @@
-use std::{collections::HashMap, time::Duration};
+use std::time::Duration;
 
 use serde::Deserialize;
+
+use crate::fast::FxHashMap;
 
 const BUILD_TIME_PRICING_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/litellm-pricing.json"));
@@ -27,8 +29,8 @@ pub(crate) struct Pricing {
 
 #[derive(Debug, Default)]
 pub(crate) struct PricingMap {
-    entries: HashMap<String, Pricing>,
-    context_limits: HashMap<String, u64>,
+    entries: FxHashMap<String, Pricing>,
+    context_limits: FxHashMap<String, u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -52,8 +54,8 @@ struct ProviderSpecificEntry {
 
 #[derive(Debug, Default, Deserialize)]
 struct FastMultiplierOverrides {
-    exact: HashMap<String, f64>,
-    normalized_prefix: HashMap<String, f64>,
+    exact: FxHashMap<String, f64>,
+    normalized_prefix: FxHashMap<String, f64>,
 }
 
 impl FastMultiplierOverrides {
@@ -127,7 +129,7 @@ impl PricingMap {
         json: &str,
         fast_multiplier_overrides: &FastMultiplierOverrides,
     ) -> usize {
-        let Ok(raw) = serde_json::from_str::<HashMap<String, serde_json::Value>>(json) else {
+        let Ok(raw) = serde_json::from_str::<FxHashMap<String, serde_json::Value>>(json) else {
             return 0;
         };
         let mut loaded_count = 0;
@@ -537,7 +539,7 @@ fn matches_model_suffix(part: &str, base: &str) -> bool {
         return false;
     };
     let suffix = &part[index..];
-    suffix == base || suffix.starts_with(&format!("{base}-"))
+    suffix == base || suffix.as_bytes().get(base.len()) == Some(&b'-')
 }
 
 fn should_log_pricing_refresh_details() -> bool {

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -1,11 +1,13 @@
 use std::{
-    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet},
     sync::Arc,
 };
 
 use crate::{
     cli::{SharedArgs, SortOrder, WeekDay},
-    cli_error, format_date, format_naive_date, parse_iso_date, LoadedEntry, ModelBreakdown, Result,
+    cli_error,
+    fast::{FxHashMap, FxHashSet},
+    format_date, format_naive_date, parse_iso_date, LoadedEntry, ModelBreakdown, Result,
     TimestampMs, TokenCounts, UsageSummary,
 };
 
@@ -41,9 +43,8 @@ struct UsageAccumulator {
     credits: Option<f64>,
     message_count: Option<u64>,
     models: Vec<String>,
-    seen_models: HashSet<String>,
     breakdowns: Vec<ModelBreakdown>,
-    breakdown_indexes: HashMap<String, usize>,
+    breakdown_indexes: FxHashMap<String, usize>,
 }
 
 impl UsageAccumulator {
@@ -59,20 +60,18 @@ impl UsageAccumulator {
             *self.message_count.get_or_insert(0) += message_count;
         }
         if let Some(model) = &entry.model {
-            if self.seen_models.insert(model.clone()) {
+            let index = if let Some(index) = self.breakdown_indexes.get(model.as_str()) {
+                *index
+            } else {
+                let index = self.breakdowns.len();
+                self.breakdown_indexes.insert(model.clone(), index);
                 self.models.push(model.clone());
-            }
-            let index = *self
-                .breakdown_indexes
-                .entry(model.clone())
-                .or_insert_with(|| {
-                    let index = self.breakdowns.len();
-                    self.breakdowns.push(ModelBreakdown {
-                        model_name: model.clone(),
-                        ..ModelBreakdown::default()
-                    });
-                    index
+                self.breakdowns.push(ModelBreakdown {
+                    model_name: model.clone(),
+                    ..ModelBreakdown::default()
                 });
+                index
+            };
             let breakdown = &mut self.breakdowns[index];
             breakdown.input_tokens += usage.input_tokens;
             breakdown.output_tokens += usage.output_tokens;
@@ -204,8 +203,8 @@ fn aggregate_summaries(rows: &[&UsageSummary]) -> UsageSummary {
         project: None,
         versions: None,
     };
-    let mut seen_models = HashSet::new();
-    let mut breakdown_indexes = HashMap::<String, usize>::new();
+    let mut seen_models = FxHashSet::default();
+    let mut breakdown_indexes = FxHashMap::<String, usize>::default();
 
     for row in rows {
         summary.input_tokens += row.input_tokens;
@@ -226,16 +225,17 @@ fn aggregate_summaries(rows: &[&UsageSummary]) -> UsageSummary {
             }
         }
         for item in &row.model_breakdowns {
-            let index = *breakdown_indexes
-                .entry(item.model_name.clone())
-                .or_insert_with(|| {
-                    let index = summary.model_breakdowns.len();
-                    summary.model_breakdowns.push(ModelBreakdown {
-                        model_name: item.model_name.clone(),
-                        ..ModelBreakdown::default()
-                    });
-                    index
+            let index = if let Some(index) = breakdown_indexes.get(item.model_name.as_str()) {
+                *index
+            } else {
+                let index = summary.model_breakdowns.len();
+                breakdown_indexes.insert(item.model_name.clone(), index);
+                summary.model_breakdowns.push(ModelBreakdown {
+                    model_name: item.model_name.clone(),
+                    ..ModelBreakdown::default()
                 });
+                index
+            };
             let breakdown = &mut summary.model_breakdowns[index];
             breakdown.input_tokens += item.input_tokens;
             breakdown.output_tokens += item.output_tokens;


### PR DESCRIPTION
## Summary

- Optimize Rust CLI hot paths for Claude and Codex usage loading/reporting.
- Add shared fast-path utilities for `memchr` byte line iteration, FxHash collections, SmallVec dedupe indexes, and allocation-conscious string suffixing.
- Apply vize-style performance practices selectively: `FxHashMap`/`FxHashSet`, `SmallVec`, `CompactString`, `memchr`, `phf`, and avoiding `format!` in hot paths.
- Preserve existing report output behavior; synthetic fixture outputs were byte-for-byte identical before and after.

## Benchmarks

Release binary comparison against the pre-change binary saved at `/tmp/ccusage-before`.

Local real data, `hyperfine --warmup 5 --runs 15`:

| Command | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `daily --offline --json` | 293.2 ms | 134.2 ms | 2.18x |
| `codex daily --offline --json` | 242.0 ms | 112.2 ms | 2.16x |

Synthetic JSONL fixture:

| Command | Before | After | Speedup |
| --- | ---: | ---: | ---: |
| `claude daily --offline --json` | 55.6 ms | 43.6 ms | 1.28x |
| `session --offline --json` | 72.5 ms | 57.7 ms | 1.26x |
| `codex daily --offline --json` | 31.7 ms | 28.6 ms | 1.11x |

Binary size:

- Before: 2,716,512 bytes
- After: 2,733,152 bytes
- Delta: +16,640 bytes

## Validation

- `nix develop --command pnpm run format`
- `nix develop --command pnpm typecheck`
- `nix develop --command pnpm run test`
- `cargo build --manifest-path rust/Cargo.toml --release --bin ccusage`
- Byte-for-byte JSON parity checked with `cmp` for:
  - `claude daily --offline --json`
  - `session --offline --json`
  - `codex daily --offline --json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up the Rust CLI’s usage loading and reporting by optimizing hashing, memory use, and line parsing, with no output changes. Typical runs are ~2.1x faster; others see 1.1–1.3x gains.

- **Performance**
  - Added fast-path utils: `byte_lines` (memchr-based), `suffix_string`, `FxHashMap`/`FxHashSet`, `SmallIndexVec`.
  - Replaced std hashing with `rustc-hash` in hot paths; sharded dedupe sets for Codex using `FxHasher`.
  - Reduced allocations with `CompactString` keys and `SmallVec`; avoided `format!` in hot paths.
  - Faster parsing by scanning bytes with `memchr`/`memmem`, reading Codex logs as bytes, and early line filtering.
  - Compile-time lookup via `phf` for nullable field checks; minor model-suffix micro-opts.
  - Output parity preserved (byte-for-byte). Benchmarks: `daily --offline --json` 2.18x, `codex daily --offline --json` 2.16x; others 1.11–1.28x. Binary +16.6 KB.

- **Dependencies**
  - Added `compact_str`, `phf`, `rustc-hash`, `smallvec`.

<sup>Written for commit c557d3e60f0252bcc121b1eff8da54c563e872c4. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1096?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal data structures for faster lookups and reduced memory usage across usage tracking and pricing modules.
  * Improved JSONL parsing efficiency with byte-oriented operations.
  * Streamlined model deduplication and aggregation logic.

* **Chores**
  * Updated dependencies to enhance performance characteristics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1096?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->