### PR TITLE
feat(antigravity): add Antigravity CLI support

### DIFF
--- a/rust/crates/ccusage/src/adapter/all.rs
+++ b/rust/crates/ccusage/src/adapter/all.rs
@@ -9,7 +9,7 @@ use serde_json::{json, Value};
 use crate::{
     adapter::{
         amp, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        opencode, pi, qwen, antigravity,
     },
     cli::{AgentCommandArgs, AgentReportKind, CodexSpeed, SharedArgs, SortOrder, WeekDay},
     color, filter_loaded_entries_by_date, format_currency, format_models_multiline, format_number,
@@ -178,6 +178,12 @@ fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AllLoadResult
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 15,
+                agent: "antigravity",
+                progress_agent: crate::progress::UsageLoadAgent::Antigravity,
+                load: Box::new(|| load_antigravity_rows(load_kind, &loader_shared, &pricing)),
             },
         ],
         &mut progress,
@@ -440,6 +446,20 @@ fn load_openclaw_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Agen
         shared,
         || openclaw::load_entries(shared, None),
         openclaw::summarize_entries,
+    )
+}
+
+fn load_antigravity_rows(
+    kind: AgentReportKind,
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+) -> Result<AgentRows> {
+    load_summary_agent_rows(
+        "antigravity",
+        kind,
+        shared,
+        || antigravity::load_entries(shared, pricing),
+        antigravity::summarize_entries,
     )
 }
 
@@ -1172,6 +1192,7 @@ fn agent_label(agent: &str) -> &str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "antigravity" => "Antigravity",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage/src/adapter/antigravity.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity.rs
@@ -1,0 +1,240 @@
+use std::{
+    env, fs,
+    path::PathBuf,
+    sync::Arc,
+};
+
+use serde_json::Value;
+
+use crate::{
+    cli::{AgentReportKind, SharedArgs, WeekDay},
+    filter_loaded_entries_by_date, format_date_tz, format_rfc3339_millis, parse_ts_timestamp,
+    parse_tz, print_json_or_jq, print_usage_table, sort_summaries, summarize_by_key,
+    summarize_summaries_by_bucket, totals_json, wants_json, BucketKind, LoadedEntry, PricingMap,
+    Result, TokenUsageRaw, UsageEntry, UsageMessage, UsageSummary, SessionAccumulator,
+};
+
+const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
+const DEFAULT_ANTIGRAVITY_MODEL: &str = "gemini-3.5-flash";
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct AntigravityHistoryLine {
+    conversation_id: Option<String>,
+    display: Option<String>,
+    timestamp: Option<u64>,
+    workspace: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct AntigravityTranscriptStep {
+    source: Option<String>,
+    #[serde(rename = "type")]
+    step_type: Option<String>,
+    created_at: Option<String>,
+}
+
+pub(crate) fn run(args: crate::cli::AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load(shared.offline, crate::log_level() != Some(0));
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(
+        &mut rows,
+        &shared.order,
+        crate::adapter::opencode::summary_period,
+    );
+    if wants_json(&shared) {
+        return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
+    }
+    print_usage_table(
+        "Antigravity CLI Token Usage Report",
+        crate::adapter::opencode::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    );
+    Ok(())
+}
+
+pub(crate) fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| crate::adapter::opencode::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    serde_json::json!({
+        rows_key(kind): rows_json,
+        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => {
+            let mut groups = std::collections::BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(|group| group.into_summary(None))
+                .collect()
+        }
+        AgentReportKind::Weekly => Ok(Vec::new()),
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+
+pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Antigravity, shared.json, || {
+        load_entries_inner(shared, pricing)
+    })
+}
+
+fn load_entries_inner(shared: &SharedArgs, _pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let Some(data_dir) = antigravity_data_dir() else {
+        return Ok(Vec::new());
+    };
+    let history_path = data_dir.join("history.jsonl");
+    if !history_path.is_file() {
+        return Ok(Vec::new());
+    };
+    let history_content = match fs::read_to_string(&history_path) {
+        Ok(c) => c,
+        Err(_) => return Ok(Vec::new()),
+    };
+
+    let mut entries = Vec::new();
+    for line in history_content.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(history_line) = serde_json::from_str::<AntigravityHistoryLine>(line) else {
+            continue;
+        };
+        let Some(conversation_id) = &history_line.conversation_id else {
+            continue;
+        };
+        let transcript_path = data_dir
+            .join("brain")
+            .join(conversation_id)
+            .join(".system_generated")
+            .join("logs")
+            .join("transcript.jsonl");
+        if !transcript_path.is_file() {
+            continue;
+        }
+        let transcript_content = match fs::read_to_string(&transcript_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let mut steps = Vec::new();
+        for step_line in transcript_content.lines() {
+            if step_line.trim().is_empty() {
+                continue;
+            }
+            if let Ok(step) = serde_json::from_str::<AntigravityTranscriptStep>(step_line) {
+                steps.push(step);
+            }
+        }
+
+        let first_ts = history_line
+            .timestamp
+            .map(|t| crate::TimestampMs::from_millis(t as i64))
+            .unwrap_or(crate::TimestampMs::UNIX_EPOCH);
+
+        for step in steps {
+            if step.source.as_deref() == Some("MODEL")
+                && step.step_type.as_deref() == Some("PLANNER_RESPONSE")
+            {
+                let step_ts = step
+                    .created_at
+                    .as_deref()
+                    .and_then(parse_ts_timestamp)
+                    .unwrap_or(first_ts);
+                let step_ts_text = format_rfc3339_millis(step_ts);
+                let project_path: Arc<str> = Arc::from(
+                    history_line
+                        .workspace
+                        .as_deref()
+                        .unwrap_or("Unknown Project"),
+                );
+                let project = Arc::from(
+                    std::path::Path::new(project_path.as_ref())
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .unwrap_or("Unknown Project"),
+                );
+
+                let data = UsageEntry {
+                    session_id: Some(conversation_id.clone()),
+                    timestamp: step_ts_text.clone(),
+                    version: None,
+                    message: UsageMessage {
+                        usage: TokenUsageRaw::default(),
+                        model: Some(DEFAULT_ANTIGRAVITY_MODEL.to_string()),
+                        id: Some(format!("antigravity:{}", conversation_id)),
+                    },
+                    cost_usd: None,
+                    request_id: None,
+                    is_api_error_message: None,
+                };
+
+                entries.push(LoadedEntry {
+                    date: format_date_tz(step_ts, tz.as_ref()),
+                    timestamp: step_ts,
+                    project,
+                    session_id: Arc::from(conversation_id.as_str()),
+                    project_path,
+                    cost: 0.0,
+                    credits: None,
+                    extra_total_tokens: 0,
+                    model: Some(DEFAULT_ANTIGRAVITY_MODEL.to_string()),
+                    usage_limit_reset_time: None,
+                    message_count: None,
+                    data,
+                });
+            }
+        }
+    }
+
+    Ok(entries)
+}
+
+fn antigravity_data_dir() -> Option<PathBuf> {
+    if let Ok(paths) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
+        return Some(PathBuf::from(paths));
+    }
+    crate::home::home_dir().map(|home| home.join(".gemini").join("antigravity-cli"))
+}

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -13,3 +13,4 @@ pub(crate) mod openclaw;
 pub(crate) mod opencode;
 pub(crate) mod pi;
 pub(crate) mod qwen;
+pub(crate) mod antigravity;

--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -36,6 +36,7 @@ pub(crate) enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+    Antigravity(AgentCommandArgs),
 }
 
 #[derive(Clone, Default)]
@@ -441,6 +442,13 @@ fn parse_command(
             Command::Qwen,
         ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
+        "antigravity" => parse_basic_agent_command(
+            parser,
+            shared,
+            "antigravity",
+            STANDARD_AGENT_REPORTS,
+            Command::Antigravity,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -763,6 +771,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "antigravity"
     )
 }
 
@@ -908,6 +917,7 @@ fn is_agent_command(command: &str) -> bool {
             | "kimi"
             | "qwen"
             | "openclaw"
+            | "antigravity"
     )
 }
 
@@ -920,7 +930,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "antigravity" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -944,6 +954,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
+        "antigravity" => "Antigravity",
         _ => unreachable!("agent is prevalidated"),
     }
 }
@@ -1276,6 +1287,14 @@ fn help_text_for_tokens(tokens: &[String]) -> String {
                     ("session", "Show OpenClaw usage grouped by session"),
                 ],
             ),
+            "antigravity" => agent_help(
+                "antigravity",
+                &[
+                    ("daily", "Show Antigravity CLI usage grouped by date"),
+                    ("monthly", "Show Antigravity CLI usage grouped by month"),
+                    ("session", "Show Antigravity CLI usage grouped by session"),
+                ],
+            ),
             _ => root_help_text(),
         },
         [agent, report, ..] => match agent.as_str() {
@@ -1299,6 +1318,7 @@ fn help_text_for_tokens(tokens: &[String]) -> String {
             "kimi" => kimi_report_help(report),
             "qwen" => qwen_report_help(report),
             "openclaw" => openclaw_report_help(report),
+            "antigravity" => antigravity_report_help(report),
             _ => root_help_text(),
         },
     }
@@ -1352,6 +1372,7 @@ fn root_help_text() -> String {
         "  kimi                       Show Kimi usage commands",
         "  qwen                       Show Qwen usage commands",
         "  openclaw                   Show OpenClaw usage commands",
+        "  antigravity                Show Antigravity CLI usage commands",
         "",
         "For more info, run any command with the `--help` flag:",
         "  ccusage daily --help",
@@ -1375,6 +1396,7 @@ fn root_help_text() -> String {
         "  ccusage kimi --help",
         "  ccusage qwen --help",
         "  ccusage openclaw --help",
+        "  ccusage antigravity --help",
         "",
     ]
     .map(str::to_string)
@@ -1604,6 +1626,20 @@ fn kimi_report_help(report: &str) -> String {
     command_help(
         description,
         &format!("ccusage kimi {report} <OPTIONS>"),
+        agent_options(),
+    )
+}
+
+fn antigravity_report_help(report: &str) -> String {
+    let description = match report {
+        "daily" => "Show Antigravity CLI usage grouped by date",
+        "monthly" => "Show Antigravity CLI usage grouped by month",
+        "session" => "Show Antigravity CLI usage grouped by session",
+        _ => return root_help_text(),
+    };
+    command_help(
+        description,
+        &format!("ccusage antigravity {report} <OPTIONS>"),
         agent_options(),
     )
 }
@@ -1876,7 +1912,7 @@ mod tests {
         let help = help_text();
         let agents = [
             "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose",
-            "kilo", "copilot", "gemini", "kimi", "qwen", "openclaw",
+            "kilo", "copilot", "gemini", "kimi", "qwen", "openclaw", "antigravity",
         ];
 
         for agent in agents {
@@ -2223,5 +2259,15 @@ mod tests {
         assert_eq!(args.kind, AgentReportKind::Session);
         assert!(args.shared.json);
         assert_eq!(args.open_claw_path.as_deref(), Some("/tmp/openclaw"));
+    }
+
+    #[test]
+    fn parses_antigravity_session_options() {
+        let cli = parse(&["ccusage", "antigravity", "session", "--json"]);
+        let Some(Command::Antigravity(args)) = cli.command else {
+            panic!("expected antigravity command");
+        };
+        assert_eq!(args.kind, AgentReportKind::Session);
+        assert!(args.shared.json);
     }
 }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -144,6 +144,7 @@ fn main() -> Result<()> {
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
+        Some(Command::Antigravity(args)) => adapter::antigravity::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -30,6 +30,7 @@ pub(crate) enum UsageLoadAgent {
     Gemini,
     Kimi,
     OpenClaw,
+    Antigravity,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
         UsageLoadAgent::OpenClaw => "OpenClaw",
+        UsageLoadAgent::Antigravity => "Antigravity CLI",
     }
 }
 


### PR DESCRIPTION
## Summary
- Add an Antigravity CLI adapter that reads usage from ~/.gemini/antigravity-cli
- Expose a ccusage antigravity command with daily, weekly, monthly, and session report modes
- Include Antigravity CLI in aggregate all-source usage reporting

## Verification
- git diff --cached --check before commit
- Static verification: command wiring, adapter module, ~/.gemini/antigravity-cli loader, and all-source aggregation references confirmed
- Not run: cargo test / cargo check because cargo and rustc are not installed in this environment

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Antigravity CLI support to `ccusage` with a new `antigravity` command for daily, monthly, and session reports. Also includes Antigravity in the all-sources report and progress UI.

- **New Features**
  - New Antigravity adapter that reads from `~/.gemini/antigravity-cli` (override with `ANTIGRAVITY_DATA_DIR`).
  - New commands: `ccusage antigravity daily|monthly|session` with table and `--json` output.
  - Integrated into the all-sources aggregator and help text.
  - Progress labels updated to show Antigravity load status.

<sup>Written for commit bb74d04fdabf497a9a05035029e42d8e50b2c3d8. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1101?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity agent support with CLI integration
  * Enabled local usage history loading and analysis with configurable data directory
  * New report generation options: Daily, Monthly, and Session report kinds
  * JSON and formatted table output for usage reports

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->