### PR TITLE
fix(ccusage): normalize dashed dates in --since/--until filters

### DIFF
--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -712,8 +712,16 @@ fn parse_shared_arg_for_command(
 
 fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(), String> {
     match parser.next_flag()?.as_str() {
-        "-s" | "--since" => shared.since = Some(parser.value_for("--since")?),
-        "-u" | "--until" => shared.until = Some(parser.value_for("--until")?),
+        "-s" | "--since" => {
+            shared.since = Some(crate::date_utils::normalize_date_filter(
+                &parser.value_for("--since")?,
+            ))
+        }
+        "-u" | "--until" => {
+            shared.until = Some(crate::date_utils::normalize_date_filter(
+                &parser.value_for("--until")?,
+            ))
+        }
         "-j" | "--json" => shared.json = true,
         "-m" | "--mode" => shared.mode = parse_cost_mode(&parser.value_for("--mode")?)?,
         "-d" | "--debug" => shared.debug = true,
@@ -1805,6 +1813,23 @@ mod tests {
         assert_eq!(args.kind, AgentReportKind::Daily);
         assert!(args.shared.json);
         assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+    }
+
+    #[test]
+    fn normalizes_dashed_since_and_until_to_dashless_form() {
+        let cli = parse(&[
+            "ccusage",
+            "daily",
+            "--since",
+            "2026-01-02",
+            "--until",
+            "2026-03-15",
+        ]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+        assert_eq!(args.shared.until.as_deref(), Some("20260315"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -373,10 +373,10 @@ pub(crate) fn apply_config_to_agent_args(
 
 fn apply_shared_options(shared: &mut SharedArgs, options: SharedOptions) {
     if let Some(since) = options.since {
-        shared.since = Some(since);
+        shared.since = Some(crate::date_utils::normalize_date_filter(&since));
     }
     if let Some(until) = options.until {
-        shared.until = Some(until);
+        shared.until = Some(crate::date_utils::normalize_date_filter(&until));
     }
     if let Some(json) = options.json {
         shared.json = json;
@@ -531,8 +531,8 @@ mod tests {
 
         apply_config_to_shared(&mut shared, &config);
 
-        assert_eq!(shared.since.as_deref(), Some("2026-01-01"));
-        assert_eq!(shared.until.as_deref(), Some("2026-01-31"));
+        assert_eq!(shared.since.as_deref(), Some("20260101"));
+        assert_eq!(shared.until.as_deref(), Some("20260131"));
         assert!(shared.json);
         assert_eq!(shared.mode, CostMode::Calculate);
         assert!(shared.debug);

--- a/rust/crates/ccusage/src/date_utils.rs
+++ b/rust/crates/ccusage/src/date_utils.rs
@@ -318,3 +318,26 @@ pub(crate) fn am_pm(hour: u32) -> &'static str {
         "PM"
     }
 }
+
+/// Normalizes a `--since` / `--until` date filter to the dashless `YYYYMMDD`
+/// form used for entry-date comparisons.
+///
+/// Date filters are compared against entry dates that have their dashes
+/// stripped, so the documented `YYYY-MM-DD` input must be normalized the same
+/// way. Without this, a value like `2026-03-15` is compared verbatim and the
+/// filter silently misbehaves (`--since` matches everything, `--until` matches
+/// nothing) because `-` sorts before the digits it sits next to.
+pub(crate) fn normalize_date_filter(value: &str) -> String {
+    value.replace('-', "")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_date_filter;
+
+    #[test]
+    fn normalizes_dashed_and_dashless_dates_identically() {
+        assert_eq!(normalize_date_filter("2026-03-15"), "20260315");
+        assert_eq!(normalize_date_filter("20260315"), "20260315");
+    }
+}


### PR DESCRIPTION
## Summary

`--since` / `--until` silently produce wrong results when given a dashed `YYYY-MM-DD` date, even though the docs advertise that format alongside `YYYYMMDD`.

Date filtering compares entry dates with their dashes stripped (`20260315`) against the raw flag value. A dashed input like `2026-03-15` is compared verbatim, and since `-` (0x2D) sorts before the digits next to it, `--since` matches every row and `--until` matches none — with no error reported.

Reproduced with the release binary against real data (range 2026-01-23 – 2026-05-20):

| command | rows returned |
|---|---|
| `--since 20260315` | 29 |
| `--since 2026-03-15` | 39 (all rows — filter is a silent no-op) |
| `--until 20260315` | 10 |
| `--until 2026-03-15` | 0 (empty report) |

## Changes

Normalize `--since` / `--until` to the dashless form at parse time — for both CLI flags and config-file values — via a small `normalize_date_filter` helper. After the fix the dashed and dashless forms return identical results.

Adds unit tests for the helper and for dashed CLI-flag parsing, and updates one config test that asserted the previously-unnormalized value.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes date filters so dashed `YYYY-MM-DD` values in `--since`/`--until` are normalized and behave the same as `YYYYMMDD`. Prevents the prior bug where dashed input made `--since` match all rows and `--until` match none.

- **Bug Fixes**
  - Normalize `--since`/`--until` to `YYYYMMDD` at parse time for both CLI flags and config values.
  - Added `normalize_date_filter` helper with tests; updated config test expectations.
  - Both date formats now produce identical, correct results.

<sup>Written for commit 7ba845dfbeb52c6adfb3e9fd061855447e8a7a72. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1107?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Date filter arguments (`--since` and `--until`) now properly normalize dates provided in dashed format (YYYY-MM-DD) for consistent date filtering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->