### PR TITLE
fix: skip compact auto-detect when stdout is not a TTY

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -76,7 +76,8 @@ pub(super) fn print_table(
     }
     let terminal_width = crate::terminal_width();
     let is_tty = std::io::stdout().is_terminal();
-    let compact = shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
+    let compact =
+        shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
     let (headers, aligns) = all_table_columns(kind, compact);
     let mut table = SimpleTable::new(headers, aligns, crate::terminal_style(shared))
         .with_terminal_width(terminal_width)

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{collections::BTreeSet, io::IsTerminal};
 
 use serde_json::{json, Value};
 
@@ -75,7 +75,8 @@ pub(super) fn print_table(
         return Ok(());
     }
     let terminal_width = crate::terminal_width();
-    let compact = shared.compact || terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD;
+    let is_tty = std::io::stdout().is_terminal();
+    let compact = shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
     let (headers, aligns) = all_table_columns(kind, compact);
     let mut table = SimpleTable::new(headers, aligns, crate::terminal_style(shared))
         .with_terminal_width(terminal_width)

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -5,7 +5,7 @@ use serde_json::{json, Value};
 use crate::{
     cli::{AgentReportKind, SharedArgs, SortOrder},
     color, format_currency, format_models_multiline, format_number, json_float, print_box_title,
-    short_model_name, Align, Color, ModelBreakdown, Result, SimpleTable,
+    short_model_name, should_use_compact_layout, Align, Color, ModelBreakdown, Result, SimpleTable,
 };
 
 use super::types::AllRow;
@@ -76,8 +76,12 @@ pub(super) fn print_table(
     }
     let terminal_width = crate::terminal_width();
     let is_tty = std::io::stdout().is_terminal();
-    let compact =
-        shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
+    let compact = should_use_compact_layout(
+        shared,
+        is_tty,
+        terminal_width,
+        crate::USAGE_COMPACT_WIDTH_THRESHOLD,
+    );
     let (headers, aligns) = all_table_columns(kind, compact);
     let mut table = SimpleTable::new(headers, aligns, crate::terminal_style(shared))
         .with_terminal_width(terminal_width)

--- a/rust/crates/ccusage/src/adapter/amp/report.rs
+++ b/rust/crates/ccusage/src/adapter/amp/report.rs
@@ -92,7 +92,8 @@ pub(crate) fn print_table_for_agent(
     }
     let terminal_width = crate::terminal_width();
     let is_tty = std::io::stdout().is_terminal();
-    let compact = shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
+    let compact =
+        shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
     print_box_title(
         &format!(
             "{agent_name} Token Usage Report - {}",

--- a/rust/crates/ccusage/src/adapter/amp/report.rs
+++ b/rust/crates/ccusage/src/adapter/amp/report.rs
@@ -3,9 +3,9 @@ use std::io::IsTerminal;
 
 use crate::{
     adapter::opencode, cli::AgentReportKind, cli::SharedArgs, cli::WeekDay, format_currency,
-    format_models_multiline, format_number, json_value_u64, print_box_title, summarize_by_key,
-    summarize_summaries_by_bucket, totals_json, Align, BucketKind, Color, LoadedEntry, Result,
-    SimpleTable,
+    format_models_multiline, format_number, json_value_u64, print_box_title,
+    should_use_compact_layout, summarize_by_key, summarize_summaries_by_bucket, totals_json, Align,
+    BucketKind, Color, LoadedEntry, Result, SimpleTable,
 };
 
 pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
@@ -92,8 +92,12 @@ pub(crate) fn print_table_for_agent(
     }
     let terminal_width = crate::terminal_width();
     let is_tty = std::io::stdout().is_terminal();
-    let compact =
-        shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
+    let compact = should_use_compact_layout(
+        shared,
+        is_tty,
+        terminal_width,
+        crate::USAGE_COMPACT_WIDTH_THRESHOLD,
+    );
     print_box_title(
         &format!(
             "{agent_name} Token Usage Report - {}",

--- a/rust/crates/ccusage/src/adapter/amp/report.rs
+++ b/rust/crates/ccusage/src/adapter/amp/report.rs
@@ -1,4 +1,5 @@
 use serde_json::{json, Value};
+use std::io::IsTerminal;
 
 use crate::{
     adapter::opencode, cli::AgentReportKind, cli::SharedArgs, cli::WeekDay, format_currency,
@@ -90,7 +91,8 @@ pub(crate) fn print_table_for_agent(
         return Ok(());
     }
     let terminal_width = crate::terminal_width();
-    let compact = shared.compact || terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD;
+    let is_tty = std::io::stdout().is_terminal();
+    let compact = shared.compact || (is_tty && terminal_width < crate::USAGE_COMPACT_WIDTH_THRESHOLD);
     print_box_title(
         &format!(
             "{agent_name} Token Usage Report - {}",

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -1,3 +1,5 @@
+use std::io::IsTerminal;
+
 use serde_json::{json, Value};
 
 use crate::{
@@ -302,7 +304,8 @@ pub(crate) fn print_blocks_table(
         return Ok(());
     }
     let terminal_width = terminal_width();
-    let compact = shared.compact || terminal_width < BLOCKS_COMPACT_WIDTH_THRESHOLD;
+    let is_tty = std::io::stdout().is_terminal();
+    let compact = shared.compact || (is_tty && terminal_width < BLOCKS_COMPACT_WIDTH_THRESHOLD);
     let actual_limit = parse_token_limit(token_limit, max_tokens);
     print_box_title("Claude Code Token Usage Report - Session Blocks", shared);
     let mut headers = vec!["Block Start", "Duration/Status", "Models", "Tokens"];

--- a/rust/crates/ccusage/src/blocks.rs
+++ b/rust/crates/ccusage/src/blocks.rs
@@ -8,10 +8,10 @@ use crate::{
     color,
     fast::FxHashSet,
     format_currency, format_date, format_models_multiline, format_number, format_rfc3339_millis,
-    format_utc_second, hour_12, json_float, local_parts, print_box_title, terminal_width, utc_now,
-    Align, BurnRate, Color, LoadedEntry, Projection, Result, SessionBlock, SimpleTable,
-    TimestampMs, TokenCounts, BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD,
-    MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
+    format_utc_second, hour_12, json_float, local_parts, print_box_title,
+    should_use_compact_layout, terminal_width, utc_now, Align, BurnRate, Color, LoadedEntry,
+    Projection, Result, SessionBlock, SimpleTable, TimestampMs, TokenCounts,
+    BLOCKS_COMPACT_WIDTH_THRESHOLD, BLOCKS_WARNING_THRESHOLD, MILLIS_PER_HOUR, MILLIS_PER_MINUTE,
 };
 
 pub(crate) fn identify_session_blocks(
@@ -305,7 +305,12 @@ pub(crate) fn print_blocks_table(
     }
     let terminal_width = terminal_width();
     let is_tty = std::io::stdout().is_terminal();
-    let compact = shared.compact || (is_tty && terminal_width < BLOCKS_COMPACT_WIDTH_THRESHOLD);
+    let compact = should_use_compact_layout(
+        shared,
+        is_tty,
+        terminal_width,
+        BLOCKS_COMPACT_WIDTH_THRESHOLD,
+    );
     let actual_limit = parse_token_limit(token_limit, max_tokens);
     print_box_title("Claude Code Token Usage Report - Session Blocks", shared);
     let mut headers = vec!["Block Start", "Duration/Status", "Models", "Tokens"];

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -32,8 +32,8 @@ pub(crate) use date_utils::*;
 pub(crate) use logger::{debug_log, log_level};
 pub(crate) use output::{
     format_currency, format_models_multiline, format_number, group_project_output, json_float,
-    print_json_or_jq, print_usage_table, session_summary_json, summary_json, totals_json,
-    wants_json,
+    print_json_or_jq, print_usage_table, session_summary_json, should_use_compact_layout,
+    summary_json, totals_json, wants_json,
 };
 pub(crate) use project_names::{format_project_name, parse_project_aliases, short_model_name};
 pub(crate) use summary::{

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -15,6 +15,15 @@ pub(crate) fn wants_json(shared: &SharedArgs) -> bool {
     shared.json || shared.jq.is_some()
 }
 
+pub(crate) fn should_use_compact_layout(
+    shared: &SharedArgs,
+    is_stdout_tty: bool,
+    terminal_width: usize,
+    compact_width_threshold: usize,
+) -> bool {
+    shared.compact || (is_stdout_tty && terminal_width < compact_width_threshold)
+}
+
 pub(crate) fn summary_json(row: &UsageSummary) -> Value {
     let mut value = json!({
         "inputTokens": row.input_tokens,
@@ -143,7 +152,12 @@ pub(crate) fn print_usage_table(
     }
     let terminal_width = terminal_width();
     let is_tty = io::stdout().is_terminal();
-    let compact = shared.compact || (is_tty && terminal_width < USAGE_COMPACT_WIDTH_THRESHOLD);
+    let compact = should_use_compact_layout(
+        shared,
+        is_tty,
+        terminal_width,
+        USAGE_COMPACT_WIDTH_THRESHOLD,
+    );
     let include_last_activity = rows.iter().any(|row| row.last_activity.is_some());
     print_box_title(title, shared);
     let mut headers = if compact {
@@ -414,6 +428,30 @@ pub(crate) fn format_currency(value: f64) -> String {
 mod tests {
     use super::*;
     use crate::ModelBreakdown;
+
+    #[test]
+    fn narrow_non_tty_output_does_not_auto_compact() {
+        let shared = SharedArgs::default();
+
+        assert!(!should_use_compact_layout(&shared, false, 80, 100));
+    }
+
+    #[test]
+    fn narrow_tty_output_auto_compacts() {
+        let shared = SharedArgs::default();
+
+        assert!(should_use_compact_layout(&shared, true, 80, 100));
+    }
+
+    #[test]
+    fn compact_flag_forces_compact_for_non_tty_output() {
+        let shared = SharedArgs {
+            compact: true,
+            ..SharedArgs::default()
+        };
+
+        assert!(should_use_compact_layout(&shared, false, 120, 100));
+    }
 
     #[test]
     fn empty_usage_table_message_is_provider_agnostic() {

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    io::{BufWriter, Write},
+    io::{self, BufWriter, IsTerminal, Write},
 };
 
 use serde_json::{json, Value};
@@ -142,7 +142,8 @@ pub(crate) fn print_usage_table(
         return Ok(());
     }
     let terminal_width = terminal_width();
-    let compact = shared.compact || terminal_width < USAGE_COMPACT_WIDTH_THRESHOLD;
+    let is_tty = io::stdout().is_terminal();
+    let compact = shared.compact || (is_tty && terminal_width < USAGE_COMPACT_WIDTH_THRESHOLD);
     let include_last_activity = rows.iter().any(|row| row.last_activity.is_some());
     print_box_title(title, shared);
     let mut headers = if compact {


### PR DESCRIPTION
Addesses #1110

- Add std::io::stdout().is_terminal() check before compact threshold
- Show full columns when output is piped or redirected
- --compact flag still works as explicit override

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip compact auto-detection when stdout is not a TTY so piped/redirected output shows full columns. `--compact` still forces compact mode. Fixes #1110.

- **Bug Fixes**
  - Gate compact mode on `stdout().is_terminal()`; auto-compact only on TTYs.
  - Use a shared `should_use_compact_layout` across all table renderers and add tests covering TTY vs non-TTY and the `--compact` override.

<sup>Written for commit 3d2919ac0466e693cae459cebd9dc8cd41ed8d34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1111?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Compact display now activates only for interactive terminals or when explicitly requested, avoiding cramped output when results are redirected or piped.
  * Preserves readable JSON and table formatting for non-interactive workflows (files, pipelines, or redirected output).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1111?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->