### PR TITLE
fix(hermes): price subscription-included sessions

### DIFF
--- a/rust/crates/ccusage/src/adapter/hermes.rs
+++ b/rust/crates/ccusage/src/adapter/hermes.rs
@@ -373,7 +373,13 @@ fn to_loaded_entry(
 }
 
 fn calculate_hermes_cost(entry: &HermesEntry, pricing: &PricingMap) -> f64 {
-    if let Some(cost) = entry.cost_usd {
+    // Only trust a recorded cost when it is strictly positive. Hermes writes
+    // estimated_cost_usd = 0.0 for subscription-included billing modes (for
+    // example, ChatGPT Plus/Pro via https://chatgpt.com/backend-api/codex),
+    // even when the session burned non-trivial tokens. Treat that recorded
+    // zero as "no cost recorded" and fall through to pricing-based
+    // calculation, mirroring how the codex adapter handles the same models.
+    if let Some(cost) = entry.cost_usd.filter(|cost| *cost > 0.0) {
         return cost;
     }
     let usage = TokenUsageRaw {
@@ -388,7 +394,7 @@ fn calculate_hermes_cost(entry: &HermesEntry, pricing: &PricingMap) -> f64 {
             CostMode::Calculate,
             Some(pricing),
         );
-        if cost >= 0.0 && cost.is_finite() && cost > 0.0 {
+        if cost.is_finite() && cost > 0.0 {
             return cost;
         }
     }
@@ -579,6 +585,62 @@ mod tests {
                 "{model} should resolve to embedded pricing"
             );
         }
+    }
+
+    #[test]
+    fn recorded_zero_cost_falls_back_to_pricing_calculation() {
+        // Hermes writes estimated_cost_usd = 0.0 for subscription-included
+        // billing (e.g. ChatGPT Plus/Pro via the codex backend), even when the
+        // session consumed real tokens. The adapter should not short-circuit
+        // on that recorded zero; it should price the tokens from the embedded
+        // table so users still see a meaningful cost number.
+        let pricing = PricingMap::load_embedded();
+        let entry = HermesEntry {
+            timestamp: crate::parse_ts_timestamp("2026-05-19T00:00:00.000Z").unwrap(),
+            timestamp_text: "2026-05-19T00:00:00.000Z".to_string(),
+            session_id: "subscription-included".to_string(),
+            model: "gpt-5.5".to_string(),
+            provider: "openai".to_string(),
+            usage: TokenUsageRaw {
+                input_tokens: 244_075,
+                output_tokens: 10_019,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 3_339_776,
+                speed: None,
+            },
+            reasoning_tokens: 3_216,
+            message_count: 72,
+            cost_usd: Some(0.0),
+        };
+
+        assert!(
+            calculate_hermes_cost(&entry, &pricing) > 0.0,
+            "subscription-included sessions with token usage should still be priced"
+        );
+    }
+
+    #[test]
+    fn recorded_positive_cost_is_trusted() {
+        let pricing = PricingMap::load_embedded();
+        let entry = HermesEntry {
+            timestamp: crate::parse_ts_timestamp("2026-05-19T00:00:00.000Z").unwrap(),
+            timestamp_text: "2026-05-19T00:00:00.000Z".to_string(),
+            session_id: "metered".to_string(),
+            model: "gpt-5.5".to_string(),
+            provider: "openai".to_string(),
+            usage: TokenUsageRaw {
+                input_tokens: 1_000,
+                output_tokens: 100,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+                speed: None,
+            },
+            reasoning_tokens: 0,
+            message_count: 1,
+            cost_usd: Some(0.42),
+        };
+
+        assert_eq!(calculate_hermes_cost(&entry, &pricing), 0.42);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`calculate_hermes_cost` in `rust/crates/ccusage/src/adapter/hermes.rs` short-circuits on any `Some(cost)` read from Hermes' `state.db`, so sessions where Hermes wrote `estimated_cost_usd = 0.0` (subscription-included billing, e.g. ChatGPT Plus/Pro via the codex backend) report `$0` even when token usage is non-zero. The codex adapter doesn't have this short-circuit and prices the same `gpt-5.5` model correctly, so on the same machine `ccusage codex daily` shows a real cost while `ccusage hermes daily` shows `$0.00`.

This change only short-circuits on a strictly positive recorded cost and falls through to pricing-based calculation otherwise, matching how the codex adapter handles the same models. A recorded positive cost is still trusted as-is.

Closes #1112.

## Changes

- `rust/crates/ccusage/src/adapter/hermes.rs`
  - `calculate_hermes_cost`: only return early when `entry.cost_usd > 0.0`; otherwise fall through to the existing pricing-based candidate loop.
  - Drop the redundant `cost >= 0.0` check inside the candidate loop (the subsequent `cost > 0.0` already implies it).
  - Add two regression tests:
    - `recorded_zero_cost_falls_back_to_pricing_calculation` — reproduces the bug with real-world numbers (`gpt-5.5`, `Some(0.0)`, non-zero tokens) and asserts cost > 0.
    - `recorded_positive_cost_is_trusted` — guards against accidentally pricing sessions where Hermes already recorded a real cost.

## Test plan

- [x] `cargo test` — 219/219 pass, including the two new tests
- [x] `rustfmt --check` clean

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Hermes cost calculation so subscription-included sessions with a recorded `0.0` cost are priced from token usage. Only trust a recorded cost when it’s strictly positive, matching the `codex` adapter.

- **Bug Fixes**
  - In `calculate_hermes_cost`, early-return only when `cost_usd > 0.0`; otherwise compute via pricing.
  - Remove redundant `cost >= 0.0` check.
  - Add regression tests to ensure fallback pricing for `0.0` costs and trusting positive recorded costs.

<sup>Written for commit 2432620a30a4495025b2c8c4950540c3a2307830. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1113?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of cost reporting by adding stricter validation for recorded costs, with automatic fallback to alternative pricing calculations when recorded values are invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->