### PR TITLE
fix(codex): respect terminal width when rendering tables

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -18,8 +18,8 @@ use crate::{
     fast::FxHashSet,
     format_currency, format_date_tz, format_models_multiline, format_number, json_float,
     json_value_u64, log_level, parse_ts_timestamp, parse_tz, print_box_title, print_json_or_jq,
-    wants_json, week_start, Align, CodexGroup, CodexModelUsage, CodexTokenUsageEvent, Color,
-    PricingMap, Result, SimpleTable,
+    terminal_width, wants_json, week_start, Align, CodexGroup, CodexModelUsage,
+    CodexTokenUsageEvent, Color, PricingMap, Result, SimpleTable,
 };
 
 type CodexEventKey = (
@@ -597,6 +597,7 @@ fn print_table(output: &Value, kind: AgentReportKind, shared: &SharedArgs) {
         ],
         shared,
     )
+    .with_terminal_width(terminal_width())
     .with_date_compaction(true);
     for row in &rows {
         let label = row


### PR DESCRIPTION
## Summary

Codex table output was always rendered with the default `SimpleTable` width of 120 columns because the Codex renderer did not pass the detected terminal width into the table.

This caused large values, especially in the `Total` row, to be truncated even when the terminal was wide enough to display them.

This change passes `terminal_width()` into the Codex `SimpleTable`, matching the behavior used by the other table renderers.

## Verification

- `cargo fmt --check`
- `cargo test -p ccusage-terminal`
- `cargo test -p ccusage adapter::codex`
- Manually verified `COLUMNS=400 ccusage codex daily --offline --since 2026-05-22` now shows full total values instead of ellipsized values.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Codex tables now respect the current terminal width, so wide terminals show full values instead of truncating large numbers (like the Total row).

- **Bug Fixes**
  - Pass `terminal_width()` to the Codex `SimpleTable`, aligning behavior with other table renderers.

<sup>Written for commit b061db48af7ffc90b886d88e4214e5ac6b0050a0. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1116?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code structure for improved maintainability.

* **Bug Fixes**
  * Fixed table rendering to properly respect terminal width constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->