### PR TITLE
fix(codex): respect terminal width in reports

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex.rs
+++ b/rust/crates/ccusage/src/adapter/codex.rs
@@ -597,6 +597,7 @@ fn print_table(output: &Value, kind: AgentReportKind, shared: &SharedArgs) {
         ],
         shared,
     )
+    .with_terminal_width(crate::terminal_width())
     .with_date_compaction(true);
     for row in &rows {
         let label = row


### PR DESCRIPTION
Pass the detected terminal width into the Codex report table so wide terminals and COLUMNS overrides can prevent unnecessary truncation. This matches the shared usage table behavior while preserving existing date compaction.

Testing:
- cargo fmt --manifest-path .\rust\Cargo.toml --all --check
- cargo test --manifest-path .\rust\Cargo.toml -p ccusage adapter::codex
- cargo test --manifest-path .\rust\Cargo.toml -p ccusage-terminal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pass the detected terminal width into the Codex report table to prevent unnecessary truncation on wide terminals and when `COLUMNS` is set. This aligns with shared usage tables and preserves date compaction.

<sup>Written for commit 65eedcfccd7a4853909fb951ba0b0448b5765fd8. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1119?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced table display to correctly respect terminal width constraints.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->