### PR TITLE
Normalize dashed date bounds for since/until filtering

### DIFF
--- a/rust/crates/ccusage/src/cli.rs
+++ b/rust/crates/ccusage/src/cli.rs
@@ -256,6 +256,7 @@ impl Cli {
         let mut shared = SharedArgs::with_defaults();
         let config = ConfigContext::from_args(&parser.args);
         apply_config_to_shared(&mut shared, &config);
+        normalize_date_bounds(&mut shared);
         while let Some(arg) = parser.peek() {
             if is_command(arg) {
                 break;
@@ -748,8 +749,8 @@ fn parse_shared_arg_for_command(
 
 fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(), String> {
     match parser.next_flag()?.as_str() {
-        "-s" | "--since" => shared.since = Some(parser.value_for("--since")?),
-        "-u" | "--until" => shared.until = Some(parser.value_for("--until")?),
+        "-s" | "--since" => shared.since = Some(normalize_date_bound(parser.value_for("--since")?)),
+        "-u" | "--until" => shared.until = Some(normalize_date_bound(parser.value_for("--until")?)),
         "-j" | "--json" => shared.json = true,
         "-m" | "--mode" => shared.mode = parse_cost_mode(&parser.value_for("--mode")?)?,
         "-d" | "--debug" => shared.debug = true,
@@ -773,6 +774,19 @@ fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(
         flag => return Err(format!("Unknown option '{flag}'")),
     }
     Ok(())
+}
+
+fn normalize_date_bounds(shared: &mut SharedArgs) {
+    if let Some(since) = shared.since.clone() {
+        shared.since = Some(normalize_date_bound(since));
+    }
+    if let Some(until) = shared.until.clone() {
+        shared.until = Some(normalize_date_bound(until));
+    }
+}
+
+fn normalize_date_bound(raw: String) -> String {
+    raw.replace('-', "")
 }
 
 fn is_command(arg: &str) -> bool {
@@ -1846,6 +1860,43 @@ mod tests {
         assert_eq!(args.kind, AgentReportKind::Daily);
         assert!(args.shared.json);
         assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+    }
+
+    #[test]
+    fn normalizes_dashed_since_and_until_in_root_daily() {
+        let cli = parse(&[
+            "ccusage",
+            "daily",
+            "--since",
+            "2026-04-22",
+            "--until",
+            "2026-04-30",
+        ]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert_eq!(args.shared.since.as_deref(), Some("20260422"));
+        assert_eq!(args.shared.until.as_deref(), Some("20260430"));
+    }
+
+    #[test]
+    fn normalizes_dashed_since_and_until_from_config_defaults() {
+        let path = temp_config_path("date-bounds-config");
+        fs::write(
+            &path,
+            r#"{
+                "defaults": { "since": "2026-04-22", "until": "2026-04-30" }
+            }"#,
+        )
+        .unwrap();
+        let path = path.to_string_lossy().to_string();
+
+        let cli = parse(&["ccusage", "--config", path.as_str(), "daily"]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert_eq!(args.shared.since.as_deref(), Some("20260422"));
+        assert_eq!(args.shared.until.as_deref(), Some("20260430"));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #1126.\n\n## Summary\n- Normalize shared --since/--until date bounds by removing dashes at the parse boundary.\n- Keep existing YYYYMMDD inputs unchanged.\n- Add parser regression tests for dashed CLI and config date bounds.\n\n## Tests\n- cargo test --manifest-path rust/Cargo.toml --package ccusage snapshots_filter_and_sort_summaries_since_until_inclusive\n- cargo test --manifest-path rust/Cargo.toml --package ccusage cli::tests::parses_root_daily_as_all_agent_report -- --exact\n- cargo test --manifest-path rust/Cargo.toml --package ccusage normalizes_dashed_since_and_until\n- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize date bounds for --since and --until by stripping dashes so inputs like 2026-04-22 work from both CLI flags and config defaults. Keeps existing YYYYMMDD inputs unchanged and fixes filtering failures with dashed dates (Fixes #1126).

<sup>Written for commit f48b7b4ed661c15aa7ba7cf90537d6f63f1da299. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1143?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * CLI `--since` and `--until` date flags now accept dashed date format (e.g., `2026-04-22`) in addition to YYYYMMDD format, with consistent handling across CLI arguments and configuration defaults.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->