### PR TITLE
feat(session): add firstActivity to session JSON output

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -586,6 +586,9 @@ fn summary_metadata(agent: &'static str, summary: &UsageSummary) -> Option<Value
         metadata.insert("credits".to_string(), json_float(credits));
     }
     if summary.session_id.is_some() {
+        if let Some(first_activity) = summary.first_activity.as_ref() {
+            metadata.insert("firstActivity".to_string(), json!(first_activity));
+        }
         if let Some(last_activity) = summary.last_activity.as_ref() {
             metadata.insert("lastActivity".to_string(), json!(last_activity));
         }
@@ -637,6 +640,7 @@ pub(super) fn codex_group_row(
         total_tokens: group.total_tokens,
         total_cost: codex::calculate_group_cost(group, pricing, speed),
         metadata: Some(json!({
+            "firstActivity": group.first_activity,
             "lastActivity": group.last_activity,
             "reasoningOutputTokens": group.reasoning_output_tokens,
         })),
@@ -679,6 +683,7 @@ mod tests {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens,
             output_tokens: 0,

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -474,6 +474,7 @@ impl DailyAccumulator {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens: self.counts.input_tokens,
             output_tokens: self.counts.output_tokens,

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -306,6 +306,13 @@ fn accumulate_codex_event_into_group(
     group.reasoning_output_tokens += event.reasoning_output_tokens;
     group.total_tokens += event.total_tokens;
     if group
+        .first_activity
+        .as_deref()
+        .is_none_or(|current| event.timestamp.as_str() < current)
+    {
+        group.first_activity = Some(event.timestamp.clone());
+    }
+    if group
         .last_activity
         .as_deref()
         .is_none_or(|current| event.timestamp.as_str() > current)
@@ -377,6 +384,14 @@ fn merge_groups(target: &mut BTreeMap<String, CodexGroup>, source: BTreeMap<Stri
         target_group.output_tokens += group.output_tokens;
         target_group.reasoning_output_tokens += group.reasoning_output_tokens;
         target_group.total_tokens += group.total_tokens;
+        if target_group.first_activity.as_deref().is_none_or(|current| {
+            group
+                .first_activity
+                .as_deref()
+                .is_some_and(|next| next < current)
+        }) {
+            target_group.first_activity = group.first_activity;
+        }
         if target_group.last_activity.as_deref().is_none_or(|current| {
             group
                 .last_activity

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -68,6 +68,7 @@ fn group_json(
         "models": models,
     });
     if kind == AgentReportKind::Session {
+        row["firstActivity"] = json!(group.first_activity);
         row["lastActivity"] = json!(group.last_activity);
         let separator = period.rfind('/');
         row["sessionFile"] = json!(separator.map_or(period, |index| &period[index + 1..]));

--- a/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
+++ b/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
@@ -98,6 +98,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "cachedInputTokens": 110,
         "costUSD": 0.0008085,
         "directory": "/workspace/api",
+        "firstActivity": "2026-01-02T00:00:00.000Z",
         "inputTokens": 100,
         "lastActivity": "2026-01-02T00:05:00.000Z",
         "models": {
@@ -120,6 +121,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "cachedInputTokens": 0,
         "costUSD": 0.000013,
         "directory": "/workspace/web",
+        "firstActivity": "2026-01-05T23:59:59.000Z",
         "inputTokens": 10,
         "lastActivity": "2026-01-05T23:59:59.000Z",
         "models": {

--- a/rust/crates/ccusage/src/adapter/opencode/report.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/report.rs
@@ -51,6 +51,12 @@ pub(crate) fn agent_summary_json(
     if include_session_metadata {
         if let Some(obj) = value.as_object_mut() {
             obj.insert(
+                "firstActivity".to_string(),
+                row.first_activity
+                    .as_ref()
+                    .map_or(Value::Null, |value| json!(value)),
+            );
+            obj.insert(
                 "lastActivity".to_string(),
                 row.last_activity
                     .as_ref()
@@ -187,6 +193,7 @@ mod tests {
             week: Some("2025-12-29".to_string()),
             session_id: Some("session-a".to_string()),
             project_path: Some("/workspace/api".to_string()),
+            first_activity: None,
             last_activity: Some("2026-01-02".to_string()),
             input_tokens: 100,
             output_tokens: 50,

--- a/rust/crates/ccusage/src/adapter/opencode/snapshots/ccusage__adapter__opencode__report__tests__snapshots_agent_summary_json_period_keys_and_session_metadata.snap
+++ b/rust/crates/ccusage/src/adapter/opencode/snapshots/ccusage__adapter__opencode__report__tests__snapshots_agent_summary_json_period_keys_and_session_metadata.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ccusage/src/adapter/opencode/report.rs
-assertion_line: 173
 expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, AgentReportKind::Daily, false),\n    \"weekly\": agent_summary_json(&weekly, AgentReportKind::Weekly, false),\n    \"monthly\": agent_summary_json(&monthly, AgentReportKind::Monthly, false),\n    \"session\": agent_summary_json(&session, AgentReportKind::Session, true),\n    \"dailyReport\":\n    report_from_rows(std::slice::from_ref(&daily), AgentReportKind::Daily),\n    \"sessionReport\": report_from_rows(&[session], AgentReportKind::Session),\n})"
 ---
 {
@@ -66,6 +65,7 @@ expression: "serde_json::json!({\n    \"daily\": agent_summary_json(&daily, Agen
     "cacheCreationTokens": 10,
     "cacheReadTokens": 5,
     "credits": 1.5,
+    "firstActivity": null,
     "inputTokens": 100,
     "lastActivity": "2026-01-02",
     "messageCount": 3,

--- a/rust/crates/ccusage/src/adapter/qwen/mod.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/mod.rs
@@ -52,6 +52,9 @@ fn filter_session_summaries(rows: &mut Vec<crate::UsageSummary>, shared: &Shared
                 .last_activity
                 .as_deref()
                 .unwrap_or_default()
+                .split('T')
+                .next()
+                .unwrap_or("")
                 .replace('-', "");
             since.as_ref().is_none_or(|bound| &date >= bound)
                 && until.as_ref().is_none_or(|bound| &date <= bound)
@@ -181,6 +184,7 @@ mod tests {
             week: None,
             session_id: Some(session_id.to_string()),
             project_path: None,
+            first_activity: None,
             last_activity: Some(last_activity.to_string()),
             input_tokens: 0,
             output_tokens: 0,

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -174,6 +174,9 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
                 .last_activity
                 .as_deref()
                 .unwrap_or_default()
+                .split('T')
+                .next()
+                .unwrap_or("")
                 .replace('-', "");
             session_shared
                 .since

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -60,6 +60,9 @@ pub(crate) fn session_summary_json(row: &UsageSummary) -> Value {
         "modelBreakdowns": row.model_breakdowns,
         "projectPath": row.project_path,
     });
+    if let (Some(obj), Some(first_activity)) = (value.as_object_mut(), &row.first_activity) {
+        obj.insert("firstActivity".to_string(), json!(first_activity));
+    }
     if let (Some(obj), Some(credits)) = (value.as_object_mut(), row.credits) {
         obj.insert("credits".to_string(), json!(credits));
     }
@@ -427,6 +430,7 @@ mod tests {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens: 100,
             output_tokens: 50,
@@ -458,7 +462,8 @@ mod tests {
         row.date = None;
         row.session_id = Some("session-a".to_string());
         row.project_path = Some("/Users/example/workspace/api".to_string());
-        row.last_activity = Some("2026-01-02 12:34:56".to_string());
+        row.first_activity = Some("2026-01-01T10:00:00.000Z".to_string());
+        row.last_activity = Some("2026-01-02T12:34:56.000Z".to_string());
 
         insta::assert_json_snapshot!(session_summary_json(&row));
     }
@@ -506,6 +511,7 @@ mod tests {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens: 1_234,
             output_tokens: 567,

--- a/rust/crates/ccusage/src/snapshots/ccusage__output__tests__snapshots_session_summary_json_with_present_and_missing_options.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__output__tests__snapshots_session_summary_json_with_present_and_missing_options.snap
@@ -5,8 +5,9 @@ expression: session_summary_json(&row)
 {
   "cacheCreationTokens": 89,
   "cacheReadTokens": 10,
+  "firstActivity": "2026-01-01T10:00:00.000Z",
   "inputTokens": 1234,
-  "lastActivity": "2026-01-02 12:34:56",
+  "lastActivity": "2026-01-02T12:34:56.000Z",
   "modelBreakdowns": [
     {
       "cacheCreationTokens": 50,

--- a/rust/crates/ccusage/src/snapshots/ccusage__summary__tests__snapshots_session_accumulator_latest_metadata_versions_and_timezone.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__summary__tests__snapshots_session_accumulator_latest_metadata_versions_and_timezone.snap
@@ -5,7 +5,8 @@ expression: row
 {
   "sessionId": "latest-session",
   "projectPath": "/workspace/new",
-  "lastActivity": "2026-01-03",
+  "firstActivity": "2026-01-02T01:20:00.000Z",
+  "lastActivity": "2026-01-03T01:00:00.000Z",
   "inputTokens": 120,
   "outputTokens": 60,
   "cacheCreationTokens": 10,

--- a/rust/crates/ccusage/src/summary.rs
+++ b/rust/crates/ccusage/src/summary.rs
@@ -7,8 +7,8 @@ use crate::{
     cli::{SharedArgs, SortOrder, WeekDay},
     cli_error,
     fast::{FxHashMap, FxHashSet},
-    format_date, format_naive_date, parse_iso_date, LoadedEntry, ModelBreakdown, Result,
-    TimestampMs, TokenCounts, UsageSummary,
+    format_naive_date, format_rfc3339_millis, parse_iso_date, LoadedEntry,
+    ModelBreakdown, Result, TimestampMs, TokenCounts, UsageSummary,
 };
 
 pub(crate) fn summarize_by_key<F, M>(
@@ -90,6 +90,7 @@ impl UsageAccumulator {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens: self.counts.input_tokens,
             output_tokens: self.counts.output_tokens,
@@ -110,6 +111,7 @@ impl UsageAccumulator {
 #[derive(Default)]
 pub(crate) struct SessionAccumulator {
     usage: UsageAccumulator,
+    earliest: Option<TimestampMs>,
     latest: Option<(TimestampMs, Arc<str>, Arc<str>)>,
     versions: BTreeSet<String>,
 }
@@ -117,6 +119,9 @@ pub(crate) struct SessionAccumulator {
 impl SessionAccumulator {
     pub(crate) fn add_entry(&mut self, entry: &LoadedEntry) {
         self.usage.add_entry(entry);
+        if self.earliest.is_none_or(|ts| entry.timestamp < ts) {
+            self.earliest = Some(entry.timestamp);
+        }
         if self
             .latest
             .as_ref()
@@ -133,14 +138,15 @@ impl SessionAccumulator {
         }
     }
 
-    pub(crate) fn into_summary(self, timezone: Option<&str>) -> Result<UsageSummary> {
+    pub(crate) fn into_summary(self, _timezone: Option<&str>) -> Result<UsageSummary> {
         let Some((timestamp, session_id, project_path)) = self.latest else {
             return Err(cli_error("empty session group"));
         };
         let mut summary = self.usage.into_summary();
         summary.session_id = Some(session_id.to_string());
         summary.project_path = Some(project_path.to_string());
-        summary.last_activity = Some(format_date(timestamp, timezone));
+        summary.first_activity = self.earliest.map(format_rfc3339_millis);
+        summary.last_activity = Some(format_rfc3339_millis(timestamp));
         summary.versions = Some(self.versions.into_iter().collect());
         Ok(summary)
     }
@@ -189,6 +195,7 @@ fn aggregate_summaries(rows: &[&UsageSummary]) -> UsageSummary {
         week: None,
         session_id: None,
         project_path: None,
+        first_activity: None,
         last_activity: None,
         input_tokens: 0,
         output_tokens: 0,
@@ -607,6 +614,7 @@ mod tests {
             week: None,
             session_id: None,
             project_path: None,
+            first_activity: None,
             last_activity: None,
             input_tokens: fixture.input_tokens,
             output_tokens: 10,

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -145,6 +145,7 @@ pub(crate) struct CodexGroup {
     pub(crate) reasoning_output_tokens: u64,
     pub(crate) total_tokens: u64,
     pub(crate) models: BTreeMap<String, CodexModelUsage>,
+    pub(crate) first_activity: Option<String>,
     pub(crate) last_activity: Option<String>,
 }
 
@@ -161,6 +162,8 @@ pub(crate) struct UsageSummary {
     pub(crate) session_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) project_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) first_activity: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) last_activity: Option<String>,
     pub(crate) input_tokens: u64,


### PR DESCRIPTION
## Summary

Add a `firstActivity` field to session JSON output alongside the existing `lastActivity`, enabling consumers to calculate session duration.

Both `firstActivity` and `lastActivity` now use ISO 8601 format (RFC 3339 with millis) for precision, matching the `blocks` command precedent with `startTime`/`actualEndTime`.

Closes #827

## Changes

- Add `first_activity` field to `UsageSummary` and `CodexGroup` types
- Track earliest timestamp in `SessionAccumulator` (opposite of existing `latest`)
- Track `first_activity` in `CodexGroup` aggregation and merge
- Output `firstActivity` in all session JSON paths (claude, codex, opencode, all)
- Change `lastActivity` format from date-only to RFC 3339 millis in session output
- Fix date filtering (`--since`/`--until`) to handle ISO timestamps (split on `T`)

## Example output

```json
{
  "sessionId": "0f3df204-64ed-4932-9e46-fa67d43a0675",
  "firstActivity": "2026-05-26T02:57:47.169Z",
  "lastActivity": "2026-05-26T02:59:16.218Z",
  "inputTokens": 17,
  "outputTokens": 3443,
  ...
}
```

This enables calculating:
- Session duration: `lastActivity - firstActivity`
- Session age: time since session started
- Activity patterns and productivity metrics

## Testing

- All 189 tests pass
- Clippy zero warnings
- Verified with `ccusage session --json --offline`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add firstActivity to session JSON and standardize lastActivity to ISO 8601 (RFC 3339 with millis) so clients can compute session duration and rely on consistent timestamps across `claude`, `codex`, `opencode`, and `all`. Also fixes date filtering to handle ISO timestamps.

- **New Features**
  - Track earliest activity and emit firstActivity in session JSON; update `UsageSummary` and `CodexGroup`.
  - Use RFC 3339 with milliseconds for lastActivity (matches blocks command).

- **Migration**
  - Update consumers to parse RFC 3339 with milliseconds for lastActivity (was date-only) and for firstActivity.

<sup>Written for commit e6158ea91ac99593e23567ee6aa44ec7ae60d481. Summary will update on new commits. <a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1165?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `firstActivity` field to usage summaries and session reports in JSON output, tracking the earliest activity timestamp.
  * Field automatically included in all session reports and activity summaries.

* **Bug Fixes**
  * Fixed date range filtering logic to correctly extract calendar dates from ISO-formatted timestamps when applying date-based filters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->