### PR TITLE
fix(codex): dedupe archived session files

### DIFF
--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -23,7 +23,7 @@ Most users can start with unified reports such as `ccusage daily`. Add the `code
 
 ## Data Source
 
-The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. For each entry, ccusage discovers `sessions/` and `archived_sessions/` independently, so an entry with only `archived_sessions/` still contributes archived Codex logs. When neither directory exists, the entry is read directly as a JSONL directory, which lets saved `codex exec --json` output live beside normal Codex homes.
+The CLI reads Codex session JSONL files located under `CODEX_HOME` (defaults to `~/.codex`). `CODEX_HOME` can be one directory or a comma-separated list of directories. For each entry, ccusage discovers `sessions/` and `archived_sessions/` independently, so an entry with only `archived_sessions/` still contributes archived Codex logs. When neither directory exists, the entry is read directly as a JSONL directory, which lets saved `codex exec --json` output live beside normal Codex homes. If the same relative JSONL path exists in both `sessions/` and `archived_sessions/` for one Codex home, the active `sessions/` copy wins so archived copies are not double counted.
 
 ```bash
 CODEX_HOME="$HOME/.codex,$HOME/.codex-work,$HOME/codex-exec-logs" ccusage codex daily

--- a/rust/crates/ccusage/src/adapter/codex/README.md
+++ b/rust/crates/ccusage/src/adapter/codex/README.md
@@ -7,6 +7,9 @@ ${CODEX_HOME:-~/.codex}/sessions/
 ${CODEX_HOME:-~/.codex}/archived_sessions/
 ```
 
+When both directories contain the same relative JSONL path for one Codex home,
+the active `sessions/` copy wins.
+
 Relevant JSONL event:
 
 - `type === "event_msg"`

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -41,16 +41,24 @@ pub(crate) fn load_groups(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let paths = paths::codex_usage_paths()?;
-    if paths.len() == 1 && !wants_json(shared) {
-        return load_groups_from_directory(&paths[0], shared, kind);
+    let sources = paths::codex_usage_sources()?;
+    if sources.len() == 1 && !wants_json(shared) {
+        return load_groups_from_directory(&sources[0].dir, shared, kind);
     }
+    load_groups_from_sources(&sources, shared, kind)
+}
+
+fn load_groups_from_sources(
+    sources: &[paths::CodexUsageSource],
+    shared: &SharedArgs,
+    kind: AgentReportKind,
+) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
-    for path in paths {
+    for group in paths::collect_deduped_codex_usage_files(sources) {
         merge_groups(
             &mut groups,
-            load_groups_from_directory_with_dedupe(&path, shared, kind, &seen)?,
+            aggregate_files_with_dedupe(&group.dir, &group.files, shared, kind, &seen)?,
         );
     }
     Ok(groups)
@@ -61,8 +69,7 @@ pub(super) fn load_groups_from_directory(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let mut files = Vec::new();
-    crate::collect_usage_files(sessions_dir, &mut files);
+    let files = paths::collect_codex_usage_files(sessions_dir);
     if shared.single_thread {
         return aggregate_files_local(sessions_dir, &files, shared, kind);
     }
@@ -70,18 +77,17 @@ pub(super) fn load_groups_from_directory(
     aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen)
 }
 
-pub(super) fn load_groups_from_directory_with_dedupe(
+fn aggregate_files_with_dedupe(
     sessions_dir: &Path,
+    files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
     seen: &CodexDedupeShards,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let mut files = Vec::new();
-    crate::collect_usage_files(sessions_dir, &mut files);
     if shared.single_thread {
-        return aggregate_files(sessions_dir, &files, shared, kind, seen);
+        return aggregate_files(sessions_dir, files, shared, kind, seen);
     }
-    aggregate_files_parallel(sessions_dir, &files, shared, kind, seen)
+    aggregate_files_parallel(sessions_dir, files, shared, kind, seen)
 }
 
 fn aggregate_files(
@@ -446,4 +452,129 @@ pub(crate) fn filter_events_by_date(
     }
     *events = kept;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ccusage_test_support::fs_fixture;
+    use serde_json::json;
+
+    use crate::adapter::codex::paths::CodexUsageSource;
+
+    #[test]
+    fn aggregates_active_copy_when_archived_file_has_same_relative_path() {
+        let active_usage = [
+            json!({
+                "timestamp": "2026-05-12T08:00:00.000Z",
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.2",
+                },
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-05-12T08:01:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 111,
+                            "cached_input_tokens": 10,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 1,
+                            "total_tokens": 131,
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let archived_usage = [
+            json!({
+                "timestamp": "2026-05-12T09:00:00.000Z",
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.2",
+                },
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-05-12T09:01:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 999,
+                            "cached_input_tokens": 90,
+                            "output_tokens": 80,
+                            "reasoning_output_tokens": 7,
+                            "total_tokens": 1_079,
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "codex/sessions/duplicate.jsonl": active_usage,
+            "codex/archived_sessions/duplicate.jsonl": archived_usage,
+            "codex/archived_sessions/archived-only.jsonl": [
+                json!({
+                    "timestamp": "2026-05-13T08:00:00.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "model": "gpt-5.2",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-13T08:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "total_token_usage": {
+                                "input_tokens": 222,
+                                "cached_input_tokens": 20,
+                                "output_tokens": 30,
+                                "reasoning_output_tokens": 2,
+                                "total_tokens": 252,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let sources = vec![
+                CodexUsageSource::new_for_test(
+                    fixture.path("codex/sessions"),
+                    fixture.path("codex"),
+                ),
+                CodexUsageSource::new_for_test(
+                    fixture.path("codex/archived_sessions"),
+                    fixture.path("codex"),
+                ),
+            ];
+            let groups =
+                load_groups_from_sources(&sources, &shared, AgentReportKind::Daily).unwrap();
+
+            assert_eq!(groups.len(), 2);
+            assert_eq!(groups["2026-05-12"].input_tokens, 111);
+            assert_eq!(groups["2026-05-13"].input_tokens, 222);
+        }
+    }
 }

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -6,19 +6,23 @@ use std::{
 use compact_str::CompactString;
 
 use crate::{
-    chunk_file_indexes_by_size, cli::SharedArgs, collect_usage_files, fast::FxHashSet, progress,
-    CodexTokenUsageEvent, Result,
+    chunk_file_indexes_by_size, cli::SharedArgs, fast::FxHashSet, progress, CodexTokenUsageEvent,
+    Result,
 };
 
-use super::{parser::visit_codex_session_file, paths::codex_usage_paths};
+use super::{
+    parser::visit_codex_session_file,
+    paths::{
+        codex_usage_sources, collect_codex_usage_files, collect_deduped_codex_usage_files,
+        CodexUsageSource,
+    },
+};
 
 pub(crate) fn load_codex_events_from_directory(
     sessions_dir: &Path,
     single_thread: bool,
 ) -> Result<Vec<CodexTokenUsageEvent>> {
-    let mut files = Vec::new();
-    collect_usage_files(sessions_dir, &mut files);
-    files.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
+    let files = collect_codex_usage_files(sessions_dir);
     let mut events = if single_thread {
         files
             .iter()
@@ -38,12 +42,29 @@ pub(crate) fn load_codex_events(shared: &SharedArgs) -> Result<Vec<CodexTokenUsa
 }
 
 fn load_codex_events_inner(shared: &SharedArgs) -> Result<Vec<CodexTokenUsageEvent>> {
+    load_codex_events_from_sources(&codex_usage_sources()?, shared.single_thread)
+}
+
+fn load_codex_events_from_sources(
+    sources: &[CodexUsageSource],
+    single_thread: bool,
+) -> Result<Vec<CodexTokenUsageEvent>> {
+    if let [source] = sources {
+        return load_codex_events_from_directory(&source.dir, single_thread);
+    }
+
     let mut events = Vec::new();
-    for path in codex_usage_paths()? {
-        events.extend(load_codex_events_from_directory(
-            &path,
-            shared.single_thread,
-        )?);
+    for group in collect_deduped_codex_usage_files(sources) {
+        let mut source_events = if single_thread {
+            group
+                .files
+                .iter()
+                .flat_map(|file| read_codex_session_file(&group.dir, file))
+                .collect::<Vec<_>>()
+        } else {
+            read_codex_session_files_parallel(&group.dir, &group.files)
+        };
+        events.append(&mut source_events);
     }
     dedupe_codex_events(&mut events);
     Ok(events)
@@ -122,6 +143,8 @@ mod tests {
 
     use ccusage_test_support::fs_fixture;
     use serde_json::json;
+
+    use crate::adapter::codex::paths::CodexUsageSource;
 
     fn codex_event(session_id: &str) -> CodexTokenUsageEvent {
         CodexTokenUsageEvent {
@@ -288,6 +311,118 @@ mod tests {
         assert_eq!(events[2].output_tokens, 4);
         assert_eq!(events[2].reasoning_output_tokens, 1);
         assert_eq!(events[2].total_tokens, 14);
+    }
+
+    #[test]
+    fn loads_active_copy_when_archived_file_has_same_relative_path() {
+        let active_usage = [
+            json!({
+                "timestamp": "2026-05-12T08:00:00.000Z",
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.2",
+                },
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-05-12T08:01:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 111,
+                            "cached_input_tokens": 10,
+                            "output_tokens": 20,
+                            "reasoning_output_tokens": 1,
+                            "total_tokens": 131,
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let archived_usage = [
+            json!({
+                "timestamp": "2026-05-12T09:00:00.000Z",
+                "type": "turn_context",
+                "payload": {
+                    "model": "gpt-5.2",
+                },
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-05-12T09:01:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 999,
+                            "cached_input_tokens": 90,
+                            "output_tokens": 80,
+                            "reasoning_output_tokens": 7,
+                            "total_tokens": 1_079,
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "codex/sessions/duplicate.jsonl": active_usage,
+            "codex/archived_sessions/duplicate.jsonl": archived_usage,
+            "codex/archived_sessions/archived-only.jsonl": [
+                json!({
+                    "timestamp": "2026-05-13T08:00:00.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "model": "gpt-5.2",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-13T08:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "total_token_usage": {
+                                "input_tokens": 222,
+                                "cached_input_tokens": 20,
+                                "output_tokens": 30,
+                                "reasoning_output_tokens": 2,
+                                "total_tokens": 252,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        for single_thread in [true, false] {
+            let sources = vec![
+                CodexUsageSource::new_for_test(
+                    fixture.path("codex/sessions"),
+                    fixture.path("codex"),
+                ),
+                CodexUsageSource::new_for_test(
+                    fixture.path("codex/archived_sessions"),
+                    fixture.path("codex"),
+                ),
+            ];
+            let events = load_codex_events_from_sources(&sources, single_thread).unwrap();
+
+            assert_eq!(events.len(), 2);
+            assert_eq!(events[0].session_id, "duplicate");
+            assert_eq!(events[0].input_tokens, 111);
+            assert_eq!(events[1].session_id, "archived-only");
+            assert_eq!(events[1].input_tokens, 222);
+        }
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/paths.rs
+++ b/rust/crates/ccusage/src/adapter/codex/paths.rs
@@ -1,12 +1,23 @@
-use std::{env, path::PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 use crate::{cli_error, fast::FxHashSet, home, Result};
 
-pub(super) fn codex_usage_paths() -> Result<Vec<PathBuf>> {
-    Ok(codex_usage_paths_from_homes(codex_home_paths()?))
+pub(super) fn codex_usage_sources() -> Result<Vec<CodexUsageSource>> {
+    Ok(codex_usage_sources_from_homes(codex_home_paths()?))
 }
 
+#[cfg(test)]
 fn codex_usage_paths_from_homes(homes: Vec<PathBuf>) -> Vec<PathBuf> {
+    codex_usage_sources_from_homes(homes)
+        .into_iter()
+        .map(|source| source.dir)
+        .collect()
+}
+
+fn codex_usage_sources_from_homes(homes: Vec<PathBuf>) -> Vec<CodexUsageSource> {
     let mut paths = Vec::new();
     let mut seen = FxHashSet::default();
     for path in homes {
@@ -15,21 +26,79 @@ fn codex_usage_paths_from_homes(homes: Vec<PathBuf>) -> Vec<PathBuf> {
         let mut found_usage_dir = false;
         if sessions.is_dir() {
             if seen.insert(sessions.clone()) {
-                paths.push(sessions);
+                paths.push(CodexUsageSource {
+                    dir: sessions,
+                    dedupe_scope: path.clone(),
+                });
             }
             found_usage_dir = true;
         }
         if archived_sessions.is_dir() {
             if seen.insert(archived_sessions.clone()) {
-                paths.push(archived_sessions);
+                paths.push(CodexUsageSource {
+                    dir: archived_sessions,
+                    dedupe_scope: path.clone(),
+                });
             }
             found_usage_dir = true;
         }
         if !found_usage_dir && seen.insert(path.clone()) {
-            paths.push(path);
+            paths.push(CodexUsageSource {
+                dir: path.clone(),
+                dedupe_scope: path,
+            });
         }
     }
     paths
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct CodexUsageSource {
+    pub(super) dir: PathBuf,
+    dedupe_scope: PathBuf,
+}
+
+#[cfg(test)]
+impl CodexUsageSource {
+    pub(super) fn new_for_test(dir: PathBuf, dedupe_scope: PathBuf) -> Self {
+        Self { dir, dedupe_scope }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub(super) struct CodexUsageFileGroup {
+    pub(super) dir: PathBuf,
+    pub(super) files: Vec<PathBuf>,
+}
+
+pub(super) fn collect_codex_usage_files(dir: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    crate::collect_usage_files(dir, &mut files);
+    files.sort();
+    files
+}
+
+pub(super) fn collect_deduped_codex_usage_files(
+    sources: &[CodexUsageSource],
+) -> Vec<CodexUsageFileGroup> {
+    let mut seen = FxHashSet::default();
+    let mut groups = Vec::new();
+    for source in sources {
+        let files = collect_codex_usage_files(&source.dir)
+            .into_iter()
+            .filter(|file| seen.insert(codex_usage_file_key(source, file)))
+            .collect::<Vec<_>>();
+        groups.push(CodexUsageFileGroup {
+            dir: source.dir.clone(),
+            files,
+        });
+    }
+    groups
+}
+
+fn codex_usage_file_key(source: &CodexUsageSource, file: &Path) -> (PathBuf, PathBuf) {
+    let relative = file.strip_prefix(&source.dir).unwrap_or(file).to_path_buf();
+    (source.dedupe_scope.clone(), relative)
 }
 
 pub(super) fn codex_home_paths() -> Result<Vec<PathBuf>> {
@@ -108,5 +177,76 @@ mod tests {
         let paths = codex_usage_paths_from_homes(vec![home.clone(), home]);
 
         assert_eq!(paths, vec![fixture.path("codex/sessions")]);
+    }
+
+    #[test]
+    fn keeps_active_session_file_when_archived_file_has_same_relative_path() {
+        let fixture = Fixture::new();
+        let _ = fixture.create_dir_all("codex/sessions");
+        let _ = fixture.create_dir_all("codex/archived_sessions");
+        let _ = fixture.write_file("codex/sessions/session.jsonl", "");
+        let _ = fixture.write_file("codex/archived_sessions/session.jsonl", "");
+        let _ = fixture.write_file("codex/archived_sessions/archive-only.jsonl", "");
+
+        let sources = codex_usage_sources_from_homes(vec![fixture.path("codex")]);
+        let groups = collect_deduped_codex_usage_files(&sources);
+
+        assert_eq!(
+            groups,
+            vec![
+                CodexUsageFileGroup {
+                    dir: fixture.path("codex/sessions"),
+                    files: vec![fixture.path("codex/sessions/session.jsonl")],
+                },
+                CodexUsageFileGroup {
+                    dir: fixture.path("codex/archived_sessions"),
+                    files: vec![fixture.path("codex/archived_sessions/archive-only.jsonl")],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_same_relative_session_file_across_different_homes() {
+        let fixture = Fixture::new();
+        let _ = fixture.create_dir_all("work/sessions");
+        let _ = fixture.create_dir_all("personal/sessions");
+        let _ = fixture.write_file("work/sessions/session.jsonl", "");
+        let _ = fixture.write_file("personal/sessions/session.jsonl", "");
+
+        let sources =
+            codex_usage_sources_from_homes(vec![fixture.path("work"), fixture.path("personal")]);
+        let groups = collect_deduped_codex_usage_files(&sources);
+
+        assert_eq!(
+            groups,
+            vec![
+                CodexUsageFileGroup {
+                    dir: fixture.path("work/sessions"),
+                    files: vec![fixture.path("work/sessions/session.jsonl")],
+                },
+                CodexUsageFileGroup {
+                    dir: fixture.path("personal/sessions"),
+                    files: vec![fixture.path("personal/sessions/session.jsonl")],
+                },
+            ]
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn deduplicates_non_utf8_relative_session_paths_without_lossy_strings() {
+        use std::{ffi::OsString, os::unix::ffi::OsStringExt};
+
+        let file_name = PathBuf::from(OsString::from_vec(b"session-\xFF.jsonl".to_vec()));
+        let source = CodexUsageSource::new_for_test(
+            PathBuf::from("/codex/sessions"),
+            PathBuf::from("/codex"),
+        );
+
+        assert_eq!(
+            codex_usage_file_key(&source, &source.dir.join(&file_name)),
+            (PathBuf::from("/codex"), file_name)
+        );
     }
 }


### PR DESCRIPTION
## Summary\n\n- Rebased #1176 on top of #1230\n- Keep active sessions/ JSONL files when archived_sessions/ has the same relative path in the same CODEX_HOME\n- Keep separate CODEX_HOME roots independent and use PathBuf keys for file dedupe\n- Document active-session precedence\n\n## Testing\n\n- direnv exec . cargo fmt --manifest-path rust/Cargo.toml -p ccusage\n- direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::codex\n- direnv exec . cargo clippy --manifest-path rust/Cargo.toml -p ccusage --all-targets -- -D warnings\n- direnv exec . cargo test --manifest-path rust/Cargo.toml -p ccusage\n- direnv exec . pnpm run format\n- direnv exec . cargo run --manifest-path rust/Cargo.toml -q -p ccusage --bin ccusage -- codex daily --json --offline