### PR TITLE
feat: support Antigravity CLI agent log tracking

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -458,6 +458,452 @@
 					},
 					"type": "object"
 				},
+				"antigravity": {
+					"additionalProperties": false,
+					"description": "Antigravity configuration.",
+					"markdownDescription": "Antigravity configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"claude": {
 					"additionalProperties": false,
 					"description": "Claude Code configuration.",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -81,6 +81,7 @@ export default defineConfig({
 						{ text: 'Qwen', link: '/guide/qwen/' },
 						{ text: 'GitHub Copilot CLI', link: '/guide/copilot/' },
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
+						{ text: 'Antigravity CLI', link: '/guide/antigravity/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },

--- a/docs/guide/antigravity/index.md
+++ b/docs/guide/antigravity/index.md
@@ -1,0 +1,70 @@
+# Antigravity CLI Data Source (Beta)
+
+> Antigravity CLI support is experimental and relies on estimating token usage from transcript character counts.
+
+ccusage can read Antigravity CLI chat logs as one of its supported local data sources. Antigravity uses the same unified and focused report model as Claude Code, Gemini CLI, and other supported coding CLIs.
+
+## Focused Views
+
+```bash
+# Daily Antigravity CLI usage
+ccusage antigravity daily
+
+# Monthly Antigravity CLI usage
+ccusage antigravity monthly
+
+# Antigravity CLI sessions
+ccusage antigravity session
+```
+
+Most users can start with unified reports such as `ccusage daily`. Add the `antigravity` namespace only when you want to focus the same report shape on Antigravity CLI usage.
+
+## Data Source
+
+The CLI reads Antigravity CLI transcript files located under `ANTIGRAVITY_DATA_DIR` (defaults to `~/.gemini/antigravity-cli`). `ANTIGRAVITY_DATA_DIR` can be one directory or a comma-separated list of directories.
+
+```bash
+ANTIGRAVITY_DATA_DIR="$HOME/.gemini/antigravity-cli,/backup/antigravity" ccusage antigravity daily
+```
+
+```text
+~/.gemini/antigravity-cli/
+└── brain/
+    └── <conversation-id>/
+        └── .system_generated/
+            └── logs/
+                └── transcript.jsonl
+```
+
+## Report Views
+
+| Focused view                  | Description                            | See also                                |
+| ----------------------------- | -------------------------------------- | --------------------------------------- |
+| `ccusage antigravity daily`   | Aggregate usage by date                | [Daily Usage](/guide/daily-reports)     |
+| `ccusage antigravity monthly` | Aggregate usage by month               | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage antigravity session` | Group usage by Antigravity CLI session | [Session Usage](/guide/session-reports) |
+
+These views support `--json`, `--compact`, and `--offline`.
+
+## What Gets Calculated
+
+- **Token usage** - Because Antigravity CLI does not record raw token counts locally, ccusage estimates input and output tokens based on character counts in `transcript.jsonl` (using an estimation of 1.5 tokens per character).
+- **Reasoning tokens** - Antigravity CLI `thinking` blocks are included in total tokens and exposed as `reasoningTokens` in JSON output.
+- **Pricing** - Costs are calculated from LiteLLM pricing data based on the selected Gemini model or a standard fallback (`google/gemini-1.5-flash`).
+
+## Environment Variables
+
+| Variable               | Description                                                                                   |
+| ---------------------- | --------------------------------------------------------------------------------------------- |
+| `ANTIGRAVITY_DATA_DIR` | Override the root directory, or comma-separated root directories, containing Antigravity data |
+| `LOG_LEVEL`            | Adjust verbosity (0 silent ... 5 trace)                                                       |
+
+## Troubleshooting
+
+::: details No Antigravity CLI usage data found
+Ensure Antigravity CLI has written transcripts under `~/.gemini/antigravity-cli/brain/`. Set `ANTIGRAVITY_DATA_DIR` if your data lives elsewhere.
+:::
+
+::: details Costs showing as $0.00
+If the model cannot be mapped to the pricing database, the cost will fall back to `google/gemini-1.5-flash`. If it still shows $0.00, check your offline/online settings.
+:::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,28 +72,29 @@ Each data source page covers the details that only apply to that source, includi
 
 ccusage reads from local coding CLI data directories:
 
-| Agent        | ID         | Default data location                           |
-| ------------ | ---------- | ----------------------------------------------- |
-| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`      |
-| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                       |
-| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}` |
-| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`           |
-| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`    |
-| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`      |
-| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`            |
-| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`         |
-| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`  |
-| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
-| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
-| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
-| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
-| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                       |
-| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`             |
+| Agent           | ID            | Default data location                                |
+| --------------- | ------------- | ---------------------------------------------------- |
+| Claude Code     | `claude`      | `~/.config/claude/projects/`, `~/.claude/`           |
+| Codex           | `codex`       | `${CODEX_HOME:-~/.codex}`                            |
+| OpenCode        | `opencode`    | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`      |
+| Amp             | `amp`         | `${AMP_DATA_DIR:-~/.local/share/amp}`                |
+| Droid           | `droid`       | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`         |
+| Codebuff        | `codebuff`    | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`           |
+| Hermes Agent    | `hermes`      | `${HERMES_HOME:-~/.hermes}/state.db`                 |
+| pi-agent        | `pi`          | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`              |
+| Goose           | `goose`       | Standard Goose data roots or `GOOSE_PATH_ROOT`       |
+| OpenClaw        | `openclaw`    | `${OPENCLAW_DIR:-~/.openclaw}`                       |
+| Kilo            | `kilo`        | `${KILO_DATA_DIR:-~/.local/share/kilo}`              |
+| Kimi            | `kimi`        | `${KIMI_DATA_DIR:-~/.kimi}`                          |
+| Qwen            | `qwen`        | `${QWEN_DATA_DIR:-~/.qwen}`                          |
+| Copilot CLI     | `copilot`     | `~/.copilot/otel/*.jsonl`                            |
+| Gemini CLI      | `gemini`      | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`                  |
+| Antigravity CLI | `antigravity` | `${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity-cli}` |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Grok CLI and Devin CLI.
 
 ## Report Shape
 

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -19,16 +19,6 @@ Local transcript text alone is not enough. A transcript can be useful for debugg
 
 ## Unsupported Sources Investigated
 
-::: details Why is Antigravity CLI not supported?
-Antigravity CLI is separate from Gemini CLI. The Antigravity CLI binary is exposed as `agy`, and it stores state under `~/.gemini/antigravity-cli/`.
-
-The current local data has conversation files such as `conversations/<conversation-id>.pb`, plus lightweight history and cache JSON files. The `.pb` files are opaque binary payloads and do not expose readable token usage, model usage, or per-turn accounting without Antigravity's private schema and storage semantics.
-
-The CLI log files include operational events such as conversation creation, streaming, prompt length, auth, and model configuration messages. They do not include input, output, cache, or reasoning token counts. Quota-oriented tools can inspect remaining Antigravity quota, but quota snapshots are not the same as historical per-session token usage.
-
-Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
-:::
-
 ::: details Why is Grok CLI not supported?
 Grok CLI was investigated, but its local SQLite data did not contain usable token accounting. Without token counts, model usage, or recorded costs in the local database, ccusage has nothing reliable to aggregate.
 

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -84,6 +84,10 @@
 				"description": "Show Gemini CLI usage commands"
 			},
 			{
+				"name": "antigravity",
+				"description": "Show Antigravity CLI usage commands"
+			},
+			{
 				"name": "kimi",
 				"description": "Show Kimi usage commands"
 			},
@@ -616,6 +620,43 @@
 			"path": ["gemini", "session"],
 			"description": "Show Gemini CLI usage grouped by session",
 			"usage": "ccusage gemini session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity"],
+			"description": "Usage reports for antigravity.",
+			"usage": "ccusage antigravity <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Antigravity CLI usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Antigravity CLI usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Antigravity CLI usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["antigravity", "daily"],
+			"description": "Show Antigravity CLI usage grouped by date",
+			"usage": "ccusage antigravity daily <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity", "monthly"],
+			"description": "Show Antigravity CLI usage grouped by month",
+			"usage": "ccusage antigravity monthly <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity", "session"],
+			"description": "Show Antigravity CLI usage grouped by session",
+			"usage": "ccusage antigravity session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -249,6 +249,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Gemini,
         ),
+        "antigravity" => parse_basic_agent_command(
+            parser,
+            shared,
+            "antigravity",
+            STANDARD_AGENT_REPORTS,
+            Command::Antigravity,
+        ),
         "kimi" => parse_basic_agent_command(
             parser,
             shared,
@@ -630,6 +637,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "antigravity"
     )
 }
 
@@ -787,6 +795,7 @@ fn is_agent_command(command: &str) -> bool {
             | "kimi"
             | "qwen"
             | "openclaw"
+            | "antigravity"
     )
 }
 
@@ -799,7 +808,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "antigravity" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -823,6 +832,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
+        "antigravity" => "Antigravity CLI",
         _ => unreachable!("agent is prevalidated"),
     }
 }

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -25,6 +25,7 @@ COMMANDS:
   kilo                       Show Kilo usage commands
   copilot                    Show GitHub Copilot CLI usage commands
   gemini                     Show Gemini CLI usage commands
+  antigravity                Show Antigravity CLI usage commands
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
@@ -48,6 +49,7 @@ For more info, run any command with the `--help` flag:
   ccusage kilo --help
   ccusage copilot --help
   ccusage gemini --help
+  ccusage antigravity --help
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -199,6 +199,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kilo(args)) => agent_command_snapshot("kilo", args),
         Some(Command::Copilot(args)) => agent_command_snapshot("copilot", args),
         Some(Command::Gemini(args)) => agent_command_snapshot("gemini", args),
+        Some(Command::Antigravity(args)) => agent_command_snapshot("antigravity", args),
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
@@ -358,7 +359,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw",
+        "copilot", "gemini", "antigravity", "kimi", "qwen", "openclaw",
     ];
 
     for agent in agents {
@@ -915,6 +916,16 @@ fn parses_gemini_session_options() {
     let cli = parse(&["ccusage", "gemini", "session", "--json"]);
     let Some(Command::Gemini(args)) = cli.command else {
         panic!("expected gemini command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn parses_antigravity_session_options() {
+    let cli = parse(&["ccusage", "antigravity", "session", "--json"]);
+    let Some(Command::Antigravity(args)) = cli.command else {
+        panic!("expected antigravity command");
     };
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -358,8 +358,22 @@ fn applies_schema_documented_config_file_options() {
 fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
-        "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "antigravity", "kimi", "qwen", "openclaw",
+        "claude",
+        "codex",
+        "opencode",
+        "amp",
+        "droid",
+        "codebuff",
+        "hermes",
+        "pi",
+        "goose",
+        "kilo",
+        "copilot",
+        "gemini",
+        "antigravity",
+        "kimi",
+        "qwen",
+        "openclaw",
     ];
 
     for agent in agents {

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -24,6 +24,7 @@ pub enum Command {
     Kilo(AgentCommandArgs),
     Copilot(AgentCommandArgs),
     Gemini(AgentCommandArgs),
+    Antigravity(AgentCommandArgs),
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -4,8 +4,8 @@ use serde_json::{json, Value};
 
 use crate::{
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, antigravity, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo,
+        kimi, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float, summarize_by_key, summarize_summaries_by_bucket,
@@ -233,6 +233,21 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 15,
+                agent: "antigravity",
+                progress_agent: crate::progress::UsageLoadAgent::Antigravity,
+                load: Box::new(|| {
+                    load_priced_summary_agent_rows(
+                        "antigravity",
+                        load_kind,
+                        &loader_shared,
+                        &pricing,
+                        antigravity::load_entries,
+                        antigravity::summarize_entries,
+                    )
+                }),
             },
         ],
         &mut progress,

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -394,6 +394,7 @@ fn agent_label(agent: &str) -> &str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "antigravity" => "Antigravity CLI",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage/src/adapter/antigravity/README.md
+++ b/rust/crates/ccusage/src/adapter/antigravity/README.md
@@ -1,0 +1,3 @@
+# Antigravity CLI Adapter
+
+Supports reading conversation logs for Antigravity CLI, located under `~/.gemini/antigravity-cli/brain/`.

--- a/rust/crates/ccusage/src/adapter/antigravity/loader.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/loader.rs
@@ -6,9 +6,11 @@ use super::{
 };
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
-    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Antigravity, shared.json, || {
-        load_entries_inner(shared, pricing)
-    })
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent::Antigravity,
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
 }
 
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {

--- a/rust/crates/ccusage/src/adapter/antigravity/loader.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/loader.rs
@@ -1,0 +1,59 @@
+use crate::{cli::SharedArgs, parse_tz, LoadedEntry, PricingMap, Result};
+
+use super::{
+    parser::{event_to_loaded, parse_transcript_file},
+    paths::discover_log_files,
+};
+
+pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Antigravity, shared.json, || {
+        load_entries_inner(shared, pricing)
+    })
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mut events = Vec::new();
+    for file in discover_log_files()? {
+        events.extend(parse_transcript_file(&file)?);
+    }
+    events.sort_by_key(|event| event.timestamp);
+    Ok(events
+        .into_iter()
+        .map(|event| event_to_loaded(event, tz.as_ref(), shared.mode, pricing))
+        .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn loads_antigravity_transcript_events_with_estimated_tokens() {
+        let _guard = super::super::ANTIGRAVITY_DATA_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "brain/session-abc/.system_generated/logs/transcript.jsonl": [
+                r#"{"created_at":"2026-05-28T13:42:00Z","type":"USER_INPUT","content":"test message"}"#,
+                r#"{"created_at":"2026-05-28T13:42:05Z","type":"PLANNER_RESPONSE","content":"response message","thinking":"thinking hard"}"#,
+            ]
+            .join("\n"),
+        });
+        let _env_guard = super::super::AntigravityDataDirEnvGuard::set(fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].date, "2026-05-28");
+        assert_eq!(entries[0].session_id.as_ref(), "session-abc");
+        assert_eq!(entries[0].model.as_deref(), Some("google/gemini-3.5-flash"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 18);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 0);
+
+        assert_eq!(entries[1].data.message.usage.output_tokens, 24);
+        assert_eq!(entries[1].extra_total_tokens, 20);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/antigravity/mod.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/mod.rs
@@ -1,0 +1,62 @@
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json, PricingMap, Result,
+};
+
+pub(crate) use loader::load_entries;
+pub(crate) use report::{report_from_rows, summarize_entries};
+
+#[cfg(test)]
+static ANTIGRAVITY_DATA_DIR_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+struct AntigravityDataDirEnvGuard {
+    previous: Option<std::ffi::OsString>,
+}
+
+#[cfg(test)]
+impl AntigravityDataDirEnvGuard {
+    fn set(path: &std::path::Path) -> Self {
+        let previous = std::env::var_os(paths::ANTIGRAVITY_DATA_DIR_ENV);
+        std::env::set_var(paths::ANTIGRAVITY_DATA_DIR_ENV, path);
+        Self { previous }
+    }
+}
+
+#[cfg(test)]
+impl Drop for AntigravityDataDirEnvGuard {
+    fn drop(&mut self) {
+        match &self.previous {
+            Some(value) => std::env::set_var(paths::ANTIGRAVITY_DATA_DIR_ENV, value),
+            None => std::env::remove_var(paths::ANTIGRAVITY_DATA_DIR_ENV),
+        }
+    }
+}
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load(shared.offline, crate::log_level() != Some(0));
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        opencode::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
+    }
+    print_usage_table(
+        "Antigravity CLI Usage Report",
+        opencode::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/crates/ccusage/src/adapter/antigravity/parser.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/parser.rs
@@ -1,0 +1,241 @@
+use std::{fs, path::Path, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde_json::Value;
+
+use crate::{
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, LoadedEntry, PricingMap, Result,
+    TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+};
+
+const DEFAULT_MODEL: &str = "google/gemini-3.5-flash";
+const FALLBACK_PRICING_MODEL: &str = "google/gemini-1.5-flash";
+
+#[derive(Debug, Clone)]
+pub(super) struct AntigravityUsageEvent {
+    pub(super) timestamp: TimestampMs,
+    timestamp_text: String,
+    session_id: String,
+    model: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    reasoning_tokens: u64,
+}
+
+pub(super) fn parse_transcript_file(path: &Path) -> Result<Vec<AntigravityUsageEvent>> {
+    let session_id = path
+        .parent()
+        .and_then(|p| p.parent())
+        .and_then(|p| p.parent())
+        .and_then(|p| p.file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let content = fs::read_to_string(path)?;
+    let mut events = Vec::new();
+    let mut current_model = DEFAULT_MODEL.to_string();
+
+    for line in content.lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(record) = value.as_object() else {
+            continue;
+        };
+
+        let created_at_str = record.get("created_at").and_then(Value::as_str);
+        let timestamp = created_at_str
+            .and_then(crate::parse_ts_timestamp)
+            .unwrap_or_else(|| {
+                fs::metadata(path)
+                    .and_then(|m| m.modified())
+                    .ok()
+                    .and_then(|d| d.duration_since(std::time::UNIX_EPOCH).ok())
+                    .and_then(|d| i64::try_from(d.as_millis()).ok())
+                    .map(TimestampMs::from_millis)
+                    .unwrap_or(TimestampMs::UNIX_EPOCH)
+            });
+
+        let r_type = record.get("type").and_then(Value::as_str).unwrap_or("");
+        let content_str = record.get("content").and_then(Value::as_str).unwrap_or("");
+
+        if r_type == "USER_INPUT" {
+            if let Some(model_name) = extract_model_from_settings_change(content_str) {
+                current_model = format!("google/{}", model_name.to_lowercase().replace(' ', "-"));
+            }
+            let char_count = content_str.chars().count();
+            if char_count > 0 {
+                let input_tokens = (char_count as f64 * 1.5).round() as u64;
+                events.push(AntigravityUsageEvent {
+                    timestamp,
+                    timestamp_text: crate::format_rfc3339_millis(timestamp),
+                    session_id: session_id.clone(),
+                    model: current_model.clone(),
+                    input_tokens,
+                    output_tokens: 0,
+                    reasoning_tokens: 0,
+                });
+            }
+        } else if r_type == "PLANNER_RESPONSE" {
+            let char_count = content_str.chars().count();
+            let thinking_str = record.get("thinking").and_then(Value::as_str).unwrap_or("");
+            let thinking_count = thinking_str.chars().count();
+
+            if char_count > 0 || thinking_count > 0 {
+                let output_tokens = (char_count as f64 * 1.5).round() as u64;
+                let reasoning_tokens = (thinking_count as f64 * 1.5).round() as u64;
+                events.push(AntigravityUsageEvent {
+                    timestamp,
+                    timestamp_text: crate::format_rfc3339_millis(timestamp),
+                    session_id: session_id.clone(),
+                    model: current_model.clone(),
+                    input_tokens: 0,
+                    output_tokens,
+                    reasoning_tokens,
+                });
+            }
+        }
+    }
+
+    Ok(events)
+}
+
+fn extract_model_from_settings_change(content: &str) -> Option<String> {
+    if let Some(idx) = content.find("Model Selection` from ") {
+        let sub = &content[idx..];
+        if let Some(to_idx) = sub.find(" to ") {
+            let model_part = &sub[to_idx + 4..];
+            let raw_model = if let Some(end_idx) = model_part.find('\n') {
+                &model_part[..end_idx]
+            } else {
+                model_part
+            };
+            let mut end_pos = raw_model.len();
+            for (char_idx, c) in raw_model.char_indices() {
+                if c == '.' {
+                    let next_char = raw_model[char_idx + c.len_utf8()..].chars().next();
+                    if let Some(nc) = next_char {
+                        if nc.is_ascii_digit() {
+                            continue;
+                        }
+                    }
+                    end_pos = char_idx;
+                    break;
+                }
+            }
+            let raw_model = &raw_model[..end_pos];
+            return Some(raw_model.trim().to_string());
+        }
+    }
+    None
+}
+
+pub(super) fn event_to_loaded(
+    event: AntigravityUsageEvent,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> LoadedEntry {
+    let usage = TokenUsageRaw {
+        input_tokens: event.input_tokens,
+        output_tokens: event.output_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        speed: None,
+    };
+    let cost =
+        calculate_antigravity_cost(&event.model, usage, event.reasoning_tokens, mode, pricing);
+    let data = UsageEntry {
+        session_id: Some(event.session_id.clone()),
+        timestamp: event.timestamp_text,
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: Some(event.model.clone()),
+            id: None,
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        date: format_date_tz(event.timestamp, tz),
+        timestamp: event.timestamp,
+        project: Arc::from("antigravity"),
+        session_id: Arc::from(event.session_id),
+        project_path: Arc::from("Antigravity"),
+        cost,
+        extra_total_tokens: event.reasoning_tokens,
+        credits: None,
+        message_count: None,
+        model: Some(event.model),
+        usage_limit_reset_time: None,
+        data,
+    }
+}
+
+fn calculate_antigravity_cost(
+    model: &str,
+    usage: TokenUsageRaw,
+    reasoning_tokens: u64,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> f64 {
+    let cost_usage = TokenUsageRaw {
+        output_tokens: usage.output_tokens.saturating_add(reasoning_tokens),
+        ..usage
+    };
+    let raw = calculate_cost_for_usage(Some(model), cost_usage, None, mode, Some(pricing));
+    if raw > 0.0 {
+        return raw;
+    }
+    calculate_cost_for_usage(
+        Some(FALLBACK_PRICING_MODEL),
+        cost_usage,
+        None,
+        mode,
+        Some(pricing),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn parses_transcript_events_and_estimates_tokens() {
+        let fixture = fs_fixture!({
+            "brain/session-xyz/.system_generated/logs/transcript.jsonl": [
+                r#"{"created_at":"2026-05-28T13:42:08Z","type":"USER_INPUT","content":"<USER_REQUEST>\nhello world\n</USER_REQUEST>"}"#,
+                r#"{"created_at":"2026-05-28T13:42:10Z","type":"PLANNER_RESPONSE","content":"hi user","thinking":"thinking hard"}"#,
+                r#"{"created_at":"2026-05-28T13:42:15Z","type":"USER_INPUT","content":"Model Selection` from None to Gemini 3.5 Flash (Medium)."}"#,
+            ]
+            .join("\n"),
+        });
+
+        let file = fixture.path("brain/session-xyz/.system_generated/logs/transcript.jsonl");
+        let events = parse_transcript_file(&file).unwrap();
+
+        assert_eq!(events.len(), 3);
+
+        // 1st event: USER_INPUT
+        assert_eq!(events[0].session_id, "session-xyz");
+        assert_eq!(events[0].model, DEFAULT_MODEL);
+        // "<USER_REQUEST>\nhello world\n</USER_REQUEST>" = 42 chars. 42 * 1.5 = 63 tokens.
+        assert_eq!(events[0].input_tokens, 63);
+        assert_eq!(events[0].output_tokens, 0);
+
+        // 2nd event: PLANNER_RESPONSE
+        assert_eq!(events[1].model, DEFAULT_MODEL);
+        // "hi user" = 7 chars. 7 * 1.5 = 10.5 -> 11 tokens.
+        assert_eq!(events[1].output_tokens, 11);
+        // "thinking hard" = 13 chars. 13 * 1.5 = 19.5 -> 20 tokens.
+        assert_eq!(events[1].reasoning_tokens, 20);
+
+        // 3rd event: USER_INPUT with model change
+        assert_eq!(events[2].model, "google/gemini-3.5-flash-(medium)");
+    }
+}

--- a/rust/crates/ccusage/src/adapter/antigravity/paths.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/paths.rs
@@ -1,0 +1,81 @@
+use std::{collections::HashSet, env, path::PathBuf};
+
+use crate::Result;
+
+pub(super) const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
+
+pub(super) fn paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    if let Ok(env_paths) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+        return Ok(paths);
+    }
+
+    if let Some(home) = crate::home::home_dir() {
+        let path = home.join(".gemini").join("antigravity-cli");
+        if path.is_dir() && seen.insert(path.clone()) {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+pub(super) fn discover_log_files() -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for base_path in paths()? {
+        let brain_path = base_path.join("brain");
+        if brain_path.is_dir() {
+            if let Ok(entries) = std::fs::read_dir(brain_path) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.is_dir() {
+                        let transcript = path.join(".system_generated").join("logs").join("transcript.jsonl");
+                        if transcript.is_file() {
+                            files.push(transcript);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn discovers_transcript_logs() {
+        let _guard = super::super::ANTIGRAVITY_DATA_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "brain/session-a/.system_generated/logs/transcript.jsonl": "{}\n",
+            "brain/session-a/.system_generated/logs/transcript_full.jsonl": "{}\n",
+            "brain/session-b/.system_generated/logs/transcript.jsonl": "{}\n",
+            "brain/session-c/ignore.txt": "no",
+        });
+        let _env_guard = super::super::AntigravityDataDirEnvGuard::set(fixture.root());
+        let files = discover_log_files().unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                fixture.path("brain/session-a/.system_generated/logs/transcript.jsonl"),
+                fixture.path("brain/session-b/.system_generated/logs/transcript.jsonl")
+            ]
+        );
+    }
+}

--- a/rust/crates/ccusage/src/adapter/antigravity/paths.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/paths.rs
@@ -39,7 +39,10 @@ pub(super) fn discover_log_files() -> Result<Vec<PathBuf>> {
                 for entry in entries.flatten() {
                     let path = entry.path();
                     if path.is_dir() {
-                        let transcript = path.join(".system_generated").join("logs").join("transcript.jsonl");
+                        let transcript = path
+                            .join(".system_generated")
+                            .join("logs")
+                            .join("transcript.jsonl");
                         if transcript.is_file() {
                             files.push(transcript);
                         }

--- a/rust/crates/ccusage/src/adapter/antigravity/report.rs
+++ b/rust/crates/ccusage/src/adapter/antigravity/report.rs
@@ -1,0 +1,66 @@
+use serde_json::{json, Value};
+
+use crate::{
+    adapter::opencode, cli::AgentReportKind, summarize_by_key, summarize_summaries_by_bucket,
+    totals_json, BucketKind, LoadedEntry, Result,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| opencode::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                crate::cli::WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                crate::cli::WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) mod all;
 pub(crate) mod amp;
+pub(crate) mod antigravity;
 pub(crate) mod claude;
 pub(crate) mod codebuff;
 pub(crate) mod codex;

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -248,6 +248,7 @@ fn is_agent_command(command: &str) -> bool {
             | "gemini"
             | "kimi"
             | "openclaw"
+            | "antigravity"
     )
 }
 

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -46,6 +46,8 @@ pub(crate) struct CcusageConfig {
     pub(crate) kimi: Option<KimiConfig>,
     /// Qwen configuration.
     pub(crate) qwen: Option<QwenConfig>,
+    /// Antigravity configuration.
+    pub(crate) antigravity: Option<AntigravityConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -253,6 +255,21 @@ pub(crate) struct GeminiConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct GeminiCommandsConfig {
+    pub(crate) daily: Option<SharedOptions>,
+    pub(crate) monthly: Option<SharedOptions>,
+    pub(crate) session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AntigravityConfig {
+    pub(crate) defaults: Option<SharedOptions>,
+    pub(crate) commands: Option<AntigravityCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AntigravityCommandsConfig {
     pub(crate) daily: Option<SharedOptions>,
     pub(crate) monthly: Option<SharedOptions>,
     pub(crate) session: Option<SharedOptions>,
@@ -1042,8 +1059,24 @@ mod tests {
             &schema,
             "ccusage-config",
             &[
-                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
+                "$schema",
+                "amp",
+                "antigravity",
+                "claude",
+                "codebuff",
+                "codex",
+                "commands",
+                "copilot",
+                "defaults",
+                "gemini",
+                "goose",
+                "hermes",
+                "kilo",
+                "kimi",
+                "opencode",
+                "openclaw",
+                "pi",
+                "qwen",
                 "droid",
             ],
         );

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -138,6 +138,7 @@ fn main() -> Result<()> {
         Some(Command::Qwen(args)) => adapter::qwen::run(args),
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
+        Some(Command::Antigravity(args)) => adapter::antigravity::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         None => {

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -30,6 +30,7 @@ pub(crate) enum UsageLoadAgent {
     Gemini,
     Kimi,
     OpenClaw,
+    Antigravity,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
         UsageLoadAgent::OpenClaw => "OpenClaw",
+        UsageLoadAgent::Antigravity => "Antigravity CLI",
     }
 }
 

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ccusage/src/config_schema.rs
-assertion_line: 1257
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -773,6 +772,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
   "rootProperties": [
     "$schema",
     "amp",
+    "antigravity",
     "claude",
     "codebuff",
     "codex",


### PR DESCRIPTION
## Summary

Adds support for tracking usage from the Antigravity CLI as a new agent source in `ccusage`. Antigravity stores per-conversation transcripts under `~/.gemini/antigravity-cli/brain/<id>/.system_generated/logs/transcript.jsonl`, which ccusage now discovers, parses, and surfaces through the unified report model plus a focused `ccusage antigravity` namespace (`daily`, `monthly`, `session`).

## What Changed

- `rust/crates/ccusage/src/adapter/antigravity/` — new adapter with `paths`, `parser`, `loader`, and `report` modules that read the transcript jsonl format, estimate token usage from character counts (Antigravity does not record raw token counts), and feed the unified loader.
- `rust/crates/ccusage-cli/` — registers the `antigravity` subcommand, root-help listing, and snapshots.
- `rust/crates/ccusage/src/adapter/all/` — wires Antigravity into the unified `all` loader/report.
- `rust/crates/ccusage/src/config*.rs` and `apps/ccusage/config-schema.json` — adds `antigravity`-scoped configuration and updates the generated JSON schema.
- `docs/guide/antigravity/index.md` and `docs/.vitepress/config.ts` — new docs guide and nav entry; `docs/guide/index.md` and `source-support-qa.md` updated to mention Antigravity.

## Why

Antigravity CLI is a new Gemini-based coding agent and users have local transcripts but no built-in way to estimate cost or token usage. Adding it as a first-class source keeps parity with the other supported agents (Claude Code, Gemini CLI, Codex, etc.).

## Notes

- Token counts are character-count estimates (1.5 tokens/char). This is documented as beta in the guide.
- Pricing falls back to `google/gemini-1.5-flash` when the recorded model cannot be mapped via LiteLLM.
- `ANTIGRAVITY_DATA_DIR` (single dir or comma-separated list) overrides the default location.

## Testing

- `cargo test` (via pre-push hook in the Nix dev shell)
- `cargo fmt --check`
- CLI help snapshot updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Antigravity CLI as a tracked agent in `ccusage`, reading `transcript.jsonl` logs to estimate token and cost data. Antigravity usage now appears in unified reports and via `ccusage antigravity daily|monthly|session`.

- **New Features**
  - New Antigravity adapter discovers `~/.gemini/antigravity-cli/brain/*/.system_generated/logs/transcript.jsonl`, parses events, and estimates tokens from character counts (1.5 tokens/char), including reasoning tokens from `thinking`.
  - Pricing maps to Gemini models via LiteLLM with a fallback to `google/gemini-1.5-flash`.
  - CLI namespace `antigravity` with `daily`, `monthly`, and `session` commands; included in the unified `all` loader/report by default.
  - Config: added `antigravity` defaults and per-command options; updated JSON schema.
  - Docs: new Antigravity guide and nav entry.

<sup>Written for commit ae6b230d6772f32f2c3774efac72494bde65cc61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1178?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Antigravity CLI as a supported data source.
  * Added configuration options supporting daily, monthly, and session reporting views.
  * Added support for discovering and reading transcript log files.

* **Documentation**
  * Updated documentation to list Antigravity CLI as a supported data source.
  * Added Antigravity CLI configuration and troubleshooting guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1178?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->