### PR TITLE
fix(opencode): fix opencode kimi k2p6 cost bug.

### DIFF
--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -297,16 +297,7 @@ mod tests {
 
     #[test]
     fn calculates_cost_for_k2p6_when_opencode_stores_zero_cost() {
-        let mut pricing = PricingMap::default();
-        pricing.load_json(
-            r#"{
-                "kimi-k2.6": {
-                    "input_cost_per_token": 0.00000095,
-                    "output_cost_per_token": 0.000004,
-                    "cache_read_input_token_cost": 0.00000016
-                }
-            }"#,
-        );
+        let pricing = PricingMap::load_embedded();
         let entry = message_value_to_entry(
             &json!({
                 "id": "message-a",

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -130,6 +130,7 @@ fn open_code_model_candidates(model: &str, provider: &str) -> Vec<String> {
 fn resolve_open_code_model_name(model: &str) -> String {
     match model {
         "gemini-3-pro-high" => "gemini-3-pro-preview".to_string(),
+        "k2p6" => "kimi-k2.6".to_string(),
         _ => model.to_string(),
     }
 }
@@ -292,6 +293,43 @@ mod tests {
                 "github_copilot/claude-sonnet-4-5",
             ]
         );
+    }
+
+    #[test]
+    fn calculates_cost_for_k2p6_when_opencode_stores_zero_cost() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "kimi-k2.6": {
+                    "input_cost_per_token": 0.00000095,
+                    "output_cost_per_token": 0.000004,
+                    "cache_read_input_token_cost": 0.00000016
+                }
+            }"#,
+        );
+        let entry = message_value_to_entry(
+            &json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "kimi-for-coding",
+                "modelID": "k2p6",
+                "time": { "created": 0 },
+                "tokens": {
+                    "input": 100,
+                    "output": 10,
+                    "cache": { "read": 50 }
+                },
+                "cost": 0
+            }),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            Some(&pricing),
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 0.000143);
     }
 
     #[test]


### PR DESCRIPTION
The fix adds a single model alias mapping in `rust/crates/ccusage/src/adapter/opencode/parser.rs:`

This resolves OpenCode's k2p6 model ID to kimi-k2.6, which then matches the existing moonshot/kimi-k2.6 pricing through fuzzy substring matching. 

fix #1172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed model-name mapping so the k2p6 variant is recognized correctly, ensuring accurate cost lookup when external pricing reports zero or invalid values.

* **Tests**
  * Added a unit test that verifies correct cost computation for k2p6, including fallback to embedded pricing when external cost is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ryoppippi/ccusage/pull/1179?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->