### PR TITLE
feat(pricing): add Z.AI GLM model pricing

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -510,6 +510,98 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        // Z.AI GLM models (pricing from https://docs.z.ai/guides/overview/pricing)
+        self.entries.insert(
+            "glm-5.1".to_string(),
+            Pricing {
+                input: 1.4e-6,
+                output: 4.4e-6,
+                cache_create: 1.4e-6,
+                cache_read: 0.26e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "glm-5".to_string(),
+            Pricing {
+                input: 1.0e-6,
+                output: 3.2e-6,
+                cache_create: 1.0e-6,
+                cache_read: 0.2e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "glm-5-turbo".to_string(),
+            Pricing {
+                input: 1.2e-6,
+                output: 4.0e-6,
+                cache_create: 1.2e-6,
+                cache_read: 0.24e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "glm-4.7".to_string(),
+            Pricing {
+                input: 0.6e-6,
+                output: 2.2e-6,
+                cache_create: 0.6e-6,
+                cache_read: 0.11e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "glm-4.6".to_string(),
+            Pricing {
+                input: 0.6e-6,
+                output: 2.2e-6,
+                cache_create: 0.6e-6,
+                cache_read: 0.11e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+        self.entries.insert(
+            "glm-4.5".to_string(),
+            Pricing {
+                input: 0.6e-6,
+                output: 2.2e-6,
+                cache_create: 0.6e-6,
+                cache_read: 0.11e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                fast_multiplier: 1.0,
+            },
+        );
+
         self.context_limits.insert("gpt-5.5".to_string(), 1_050_000);
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
@@ -597,6 +689,27 @@ mod tests {
         assert!(pricing.find("gpt-5.5").is_some());
         assert!(pricing.find("grok-4.3").is_some());
         assert_eq!(pricing.context_limit("grok-4.3"), Some(1_000_000));
+    }
+
+    #[test]
+    fn embedded_pricing_includes_glm_models() {
+        let pricing = PricingMap::load_embedded();
+
+        let glm_51 = pricing.find("glm-5.1").unwrap();
+        assert_eq!(glm_51.input, 1.4e-6);
+        assert_eq!(glm_51.output, 4.4e-6);
+        assert_eq!(glm_51.cache_read, 0.26e-6);
+        assert!(glm_51.cache_read_explicit);
+
+        let glm_5 = pricing.find("glm-5").unwrap();
+        assert_eq!(glm_5.input, 1.0e-6);
+        assert_eq!(glm_5.output, 3.2e-6);
+        assert_eq!(glm_5.cache_read, 0.2e-6);
+
+        assert!(pricing.find("glm-5-turbo").is_some());
+        assert!(pricing.find("glm-4.7").is_some());
+        assert!(pricing.find("glm-4.6").is_some());
+        assert!(pricing.find("glm-4.5").is_some());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add fallback pricing for Z.AI GLM series models so that cost calculation works when using custom URLs with GLM models in Claude Code.

## Problem

When using Claude Code with a custom URL pointing to Z.AI's `glm-5.1` model, ccusage shows $0.00 cost because:

1. **Build-time LiteLLM filter** (`build.rs` `is_embedded_model()`) only accepts `claude-`, `gpt-`, `openai/`, etc. prefixes — GLM models are excluded
2. **LiteLLM data** has GLM-5.1 only as `fireworks_ai/glm-5p1` — the name doesn't match `glm-5.1`
3. **Hardcoded fallback** in `put_fallback_pricing()` had no GLM entries

Result: `pricing.find("glm-5.1")` → `None` → cost returns `0.0`

## Changes

Added GLM model pricing to the hardcoded fallback in `pricing.rs`, sourced from [z.ai official pricing](https://docs.z.ai/guides/overview/pricing):

| Model | Input ($/1M) | Cached Input ($/1M) | Output ($/1M) |
|-------|-------------|--------------------|--------------|
| glm-5.1 | $1.4 | $0.26 | $4.4 |
| glm-5 | $1.0 | $0.20 | $3.2 |
| glm-5-turbo | $1.2 | $0.24 | $4.0 |
| glm-4.7 | $0.6 | $0.11 | $2.2 |
| glm-4.6 | $0.6 | $0.11 | $2.2 |
| glm-4.5 | $0.6 | $0.11 | $2.2 |

Also added a test `embedded_pricing_includes_glm_models` to verify pricing lookup.

## Testing

- `cargo test --package ccusage embedded_pricing_includes_glm_models` — validates all GLM entries
- Manual test: `ccusage --mode calculate` now correctly shows costs for `glm-5.1` sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds fallback pricing for Z.AI GLM models so `ccusage` correctly calculates costs when using custom GLM URLs. Fixes the $0.00 cost issue in Claude Code sessions.

- **Bug Fixes**
  - Added pricing entries for `glm-5.1`, `glm-5`, `glm-5-turbo`, `glm-4.7`, `glm-4.6`, `glm-4.5` based on Z.AI docs.
  - Added test `embedded_pricing_includes_glm_models` to validate lookups and cache-read rates.

<sup>Written for commit 586757574d6c2c165f1daeef8033426f72d8e0d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Z.AI GLM models (glm-5.1, glm-5, glm-5-turbo, glm-4.7, glm-4.6, glm-4.5) with complete pricing information including input/output token costs and cache operation pricing.

* **Tests**
  * Added unit tests to validate all GLM model pricing data and ensure accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->