### PR TITLE
Add Grok Build usage source

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -41,6 +41,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | OpenClaw           | `ccusage openclaw daily` |
 | Kilo               | `ccusage kilo daily`     |
 | Kimi               | `ccusage kimi daily`     |
+| Grok Build         | `ccusage grok daily`     |
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
@@ -95,6 +96,7 @@ bunx ccusage goose daily
 bunx ccusage openclaw daily
 bunx ccusage kilo daily
 bunx ccusage kimi daily
+bunx ccusage grok daily
 bunx ccusage qwen daily
 bunx ccusage copilot daily
 bunx ccusage gemini daily
@@ -124,7 +126,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -4694,6 +4694,452 @@
 					},
 					"type": "object"
 				},
+				"grok": {
+					"additionalProperties": false,
+					"description": "Grok Build configuration.",
+					"markdownDescription": "Grok Build configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"hermes": {
 					"additionalProperties": false,
 					"description": "Hermes Agent configuration.",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -78,6 +78,7 @@ export default defineConfig({
 						{ text: 'pi-agent', link: '/guide/pi/' },
 						{ text: 'Goose', link: '/guide/goose/' },
 						{ text: 'Kilo', link: '/guide/kilo/' },
+						{ text: 'Grok Build', link: '/guide/grok/' },
 						{ text: 'Qwen', link: '/guide/qwen/' },
 						{ text: 'GitHub Copilot CLI', link: '/guide/copilot/' },
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -25,7 +25,7 @@ ccusage daily --all
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |
@@ -51,6 +51,7 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | OpenClaw     | `openclaw` | `ccusage openclaw daily`  |
 | Kilo         | `kilo`     | `ccusage kilo daily`      |
 | Kimi         | `kimi`     | `ccusage kimi daily`      |
+| Grok Build   | `grok`     | `ccusage grok daily`      |
 | Qwen         | `qwen`     | `ccusage qwen daily`      |
 | Copilot CLI  | `copilot`  | `ccusage copilot daily`   |
 | Gemini CLI   | `gemini`   | `ccusage gemini daily`    |
@@ -69,6 +70,7 @@ ccusage codebuff daily
 ccusage pi session --pi-path /path/to/sessions
 ccusage openclaw daily --open-claw-path /path/to/openclaw
 ccusage kilo session
+ccusage grok daily
 ccusage qwen daily
 ccusage copilot daily --json
 ccusage gemini session --json

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -1,6 +1,6 @@
 # Claude Code Data Source
 
-ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 
@@ -75,7 +75,7 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
-For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
+For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -4,7 +4,7 @@
 
 > ⚠️ Codex log support is experimental while the Codex CLI log format continues to evolve.
 
-ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -176,7 +176,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `grok`, `qwen`, `copilot`, and `gemini`.
 
 ```json
 {
@@ -236,6 +236,11 @@ Use data source namespaces to set defaults and report overrides. Supported names
 			"offline": true
 		}
 	},
+	"grok": {
+		"defaults": {
+			"offline": true
+		}
+	},
 	"qwen": {
 		"defaults": {
 			"offline": true
@@ -265,6 +270,7 @@ ccusage pi daily
 ccusage openclaw daily
 ccusage kilo daily
 ccusage kimi daily
+ccusage grok daily
 ccusage qwen daily
 ccusage copilot monthly
 ccusage gemini daily

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -55,6 +55,7 @@ export OPENCODE_DATA_DIR="$HOME/.local/share/opencode"
 export AMP_DATA_DIR="$HOME/.local/share/amp"
 export PI_AGENT_DIR="$HOME/.pi/agent/sessions"
 export KILO_DATA_DIR="$HOME/.local/share/kilo"
+export GROK_HOME="$HOME/.grok"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="$HOME/.copilot/otel/copilot-otel.jsonl"
 ```
 
@@ -65,6 +66,7 @@ export CODEX_HOME="$HOME/.codex,$HOME/.codex-work"
 export GEMINI_DATA_DIR="$HOME/.gemini/tmp,/backup/gemini/tmp"
 export OPENCODE_DATA_DIR="$HOME/.local/share/opencode,/archive/opencode"
 export KILO_DATA_DIR="$HOME/.local/share/kilo,/backup/kilo"
+export GROK_HOME="$HOME/.grok,/archive/grok"
 ```
 
 2. **Create a configuration file** for your preferences:
@@ -109,7 +111,7 @@ For individual developers working on multiple projects:
 
 ### Multiple Sources
 
-Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
+Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
 
 ```json
 // ~/.config/claude/ccusage.json

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -18,6 +18,7 @@ ccusage codex daily
 ccusage opencode daily
 ccusage amp daily
 ccusage pi daily
+ccusage grok daily
 ccusage qwen daily
 ```
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -20,6 +20,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `OPENCLAW_DIR`                    | OpenClaw     | `~/.openclaw`                      |
 | `KILO_DATA_DIR`                   | Kilo         | `~/.local/share/kilo`              |
 | `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`                          |
+| `GROK_HOME`                       | Grok Build   | `~/.grok`                          |
 | `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                          |
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI  | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI   | `~/.gemini/tmp`                    |
@@ -38,6 +39,7 @@ export GOOSE_PATH_ROOT="/path/to/goose,/archive/goose"
 export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
+export GROK_HOME="/path/to/grok,/archive/grok"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GEMINI_DATA_DIR="/path/to/gemini/tmp,/archive/gemini/tmp"

--- a/docs/guide/gemini/index.md
+++ b/docs/guide/gemini/index.md
@@ -2,7 +2,7 @@
 
 > Gemini CLI support is experimental while the Gemini CLI log format continues to evolve.
 
-ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, and GitHub Copilot CLI.
+ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, Grok Build, Qwen, pi-agent, and GitHub Copilot CLI.
 
 ## Focused Views
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,6 +51,7 @@ ccusage amp session
 ccusage pi monthly
 ccusage kilo daily
 ccusage kimi daily
+ccusage grok daily
 ccusage qwen daily
 ```
 
@@ -173,6 +174,7 @@ If ccusage shows no data, check:
    - Goose: standard Goose data roots or `GOOSE_PATH_ROOT`
    - Kilo: `${KILO_DATA_DIR:-~/.local/share/kilo}`
    - Kimi: `${KIMI_DATA_DIR:-~/.kimi}`
+   - Grok Build: `${GROK_HOME:-~/.grok}`
    - OpenClaw: `${OPENCLAW_DIR:-~/.openclaw}` (also scans `~/.clawdbot`, `~/.moltbot`, `~/.moldbot`)
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
@@ -194,6 +196,7 @@ export GOOSE_PATH_ROOT="/path/to/goose"
 export OPENCLAW_DIR="/path/to/openclaw"
 export KILO_DATA_DIR="/path/to/kilo"
 export KIMI_DATA_DIR="/path/to/kimi"
+export GROK_HOME="/path/to/grok"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 ```
@@ -212,6 +215,7 @@ export GOOSE_PATH_ROOT="/path/to/goose,/archive/goose"
 export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
+export GROK_HOME="/path/to/grok,/archive/grok"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 ```
 

--- a/docs/guide/grok/index.md
+++ b/docs/guide/grok/index.md
@@ -1,0 +1,74 @@
+# Grok Build Data Source (Experimental)
+
+> Grok Build support is experimental. Expect breaking changes while both ccusage and Grok Build continue to evolve.
+
+ccusage can read Grok Build session state as one of its supported local data sources, using the same focused and all-source report views as the rest of ccusage.
+
+## Focused Views
+
+::: code-group
+
+```bash [bunx (Recommended)]
+bunx ccusage grok --help
+```
+
+```bash [npx]
+npx ccusage@latest grok --help
+```
+
+```bash [pnpm]
+pnpm dlx ccusage grok --help
+```
+
+:::
+
+## Data Source
+
+The CLI reads Grok Build session files from `GROK_HOME` (defaults to `~/.grok`). `GROK_HOME` can be one directory or a comma-separated list of directories.
+
+```bash
+GROK_HOME="$HOME/.grok,/backup/grok" ccusage grok daily
+```
+
+```text
+~/.grok/
+└── sessions/
+    └── <encoded-cwd>/
+        └── <session-id>/
+            ├── signals.json
+            └── summary.json
+```
+
+## Report Views
+
+| Focused view           | Description                       | See also                                |
+| ---------------------- | --------------------------------- | --------------------------------------- |
+| `ccusage grok daily`   | Aggregate usage by date           | [Daily Usage](/guide/daily-reports)     |
+| `ccusage grok monthly` | Aggregate usage by month          | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage grok session` | Group usage by Grok Build session | [Session Usage](/guide/session-reports) |
+
+These views support `--json`, `--compact`, `--breakdown`, and standard date filters.
+
+## What Gets Calculated
+
+- **Total tokens** - `contextTokensUsed` plus `totalTokensBeforeCompaction` from `signals.json` is reported as `totalTokens`.
+- **Model attribution** - `primaryModelId`, `current_model_id`, or the first `modelsUsed` value is shown as the model name.
+- **Session metadata** - `summary.json` supplies timestamps, session IDs, and project paths when available.
+- **Cost** - Grok Build session state does not currently expose per-request input/output/cache token counts or recorded USD cost, so cost is reported as `$0.00`.
+
+## Environment Variables
+
+| Variable    | Description                                                                                  |
+| ----------- | -------------------------------------------------------------------------------------------- |
+| `GROK_HOME` | Override the root directory, or comma-separated root directories, containing Grok Build data |
+| `LOG_LEVEL` | Adjust verbosity (0 silent ... 5 trace)                                                      |
+
+## Troubleshooting
+
+::: details No Grok Build usage data found
+Ensure the data directory exists at `~/.grok/sessions/` and contains session directories with `signals.json` files. Set `GROK_HOME` if your Grok Build data lives elsewhere or in multiple archive roots.
+:::
+
+::: details Costs showing as $0.00
+This is expected for Grok Build rows today. ccusage reports the persisted context token totals, but Grok Build does not yet persist a stable per-request token breakdown or recorded USD cost that ccusage can price.
+:::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Grok Build, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -86,6 +86,7 @@ ccusage reads from local coding CLI data directories:
 | OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
 | Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
 | Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
+| Grok Build   | `grok`     | `${GROK_HOME:-~/.grok}`                         |
 | Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
 | Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                       |
 | Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`             |
@@ -93,7 +94,7 @@ ccusage reads from local coding CLI data directories:
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI and Devin CLI.
 
 ## Report Shape
 
@@ -121,6 +122,7 @@ ccusage goose daily
 ccusage openclaw daily
 ccusage kilo daily
 ccusage kimi daily
+ccusage grok daily
 ccusage qwen daily
 ccusage copilot daily
 ccusage gemini daily

--- a/docs/guide/kimi/index.md
+++ b/docs/guide/kimi/index.md
@@ -2,7 +2,7 @@
 
 > Kimi support is experimental. Expect breaking changes while both ccusage and [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) continue to evolve.
 
-ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, Grok Build, Qwen, pi-agent, GitHub Copilot CLI, and Gemini CLI.
 
 ## Usage
 

--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -9,6 +9,7 @@ ccusage monthly
 ccusage codex monthly
 ccusage amp monthly
 ccusage pi monthly
+ccusage grok monthly
 ccusage qwen monthly
 ```
 

--- a/docs/guide/session-reports.md
+++ b/docs/guide/session-reports.md
@@ -10,6 +10,7 @@ ccusage codex session
 ccusage opencode session
 ccusage amp session
 ccusage pi session
+ccusage grok session
 ccusage qwen session
 ```
 

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -17,7 +17,7 @@ A source is a good fit when its local files include most of the following:
 
 Local transcript text alone is not enough. A transcript can be useful for debugging, but it does not reveal tokenizer behavior, hidden system context, cached input, tool-call overhead, or provider-side accounting.
 
-## Unsupported Sources Investigated
+## Investigated Sources and Format Notes
 
 ::: details Why is Antigravity CLI not supported?
 Antigravity CLI is separate from Gemini CLI. The Antigravity CLI binary is exposed as `agy`, and it stores state under `~/.gemini/antigravity-cli/`.
@@ -29,10 +29,10 @@ The CLI log files include operational events such as conversation creation, stre
 Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
 :::
 
-::: details Why is Grok CLI not supported?
-Grok CLI was investigated, but its local SQLite data did not contain usable token accounting. Without token counts, model usage, or recorded costs in the local database, ccusage has nothing reliable to aggregate.
+::: details What changed for Grok support?
+Earlier Grok CLI local SQLite data did not contain usable token accounting, so ccusage could not support that format reliably.
 
-Estimating tokens from message text would ignore provider-side context, hidden prompts, tool-call payloads, cached input, and tokenizer differences, so ccusage does not do that.
+Grok Build now writes structured session state under `${GROK_HOME:-~/.grok}/sessions/` with `signals.json` files that include context token totals and model/session metadata. ccusage supports that Grok Build format through the `grok` namespace.
 :::
 
 ::: details Why is Devin CLI not supported?

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -88,6 +88,10 @@
 				"description": "Show Kimi usage commands"
 			},
 			{
+				"name": "grok",
+				"description": "Show Grok Build usage commands"
+			},
+			{
 				"name": "qwen",
 				"description": "Show Qwen usage commands"
 			},
@@ -653,6 +657,43 @@
 			"path": ["kimi", "session"],
 			"description": "Show Kimi usage grouped by session",
 			"usage": "ccusage kimi session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["grok"],
+			"description": "Usage reports for Grok Build.",
+			"usage": "ccusage grok <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Grok Build usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Grok Build usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Grok Build usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["grok", "daily"],
+			"description": "Show Grok Build usage grouped by date",
+			"usage": "ccusage grok daily <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["grok", "monthly"],
+			"description": "Show Grok Build usage grouped by month",
+			"usage": "ccusage grok monthly <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["grok", "session"],
+			"description": "Show Grok Build usage grouped by session",
+			"usage": "ccusage grok session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -256,6 +256,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Kimi,
         ),
+        "grok" => parse_basic_agent_command(
+            parser,
+            shared,
+            "grok",
+            STANDARD_AGENT_REPORTS,
+            Command::Grok,
+        ),
         "qwen" => parse_basic_agent_command(
             parser,
             shared,
@@ -629,6 +636,7 @@ fn is_command(arg: &str) -> bool {
             | "copilot"
             | "gemini"
             | "kimi"
+            | "grok"
             | "qwen"
     )
 }
@@ -785,6 +793,7 @@ fn is_agent_command(command: &str) -> bool {
             | "copilot"
             | "gemini"
             | "kimi"
+            | "grok"
             | "qwen"
             | "openclaw"
     )
@@ -799,7 +808,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "grok" | "qwen" | "openclaw" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -821,6 +830,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "copilot" => "GitHub Copilot CLI",
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
+        "grok" => "Grok Build",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         _ => unreachable!("agent is prevalidated"),

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -26,6 +26,7 @@ COMMANDS:
   copilot                    Show GitHub Copilot CLI usage commands
   gemini                     Show Gemini CLI usage commands
   kimi                       Show Kimi usage commands
+  grok                       Show Grok Build usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
 
@@ -49,6 +50,7 @@ For more info, run any command with the `--help` flag:
   ccusage copilot --help
   ccusage gemini --help
   ccusage kimi --help
+  ccusage grok --help
   ccusage qwen --help
   ccusage openclaw --help
 

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -200,6 +200,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Copilot(args)) => agent_command_snapshot("copilot", args),
         Some(Command::Gemini(args)) => agent_command_snapshot("gemini", args),
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
+        Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
     }
@@ -925,6 +926,16 @@ fn parses_kimi_session_options() {
     let cli = parse(&["ccusage", "kimi", "session", "--json"]);
     let Some(Command::Kimi(args)) = cli.command else {
         panic!("expected kimi command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn parses_grok_session_options() {
+    let cli = parse(&["ccusage", "grok", "session", "--json"]);
+    let Some(Command::Grok(args)) = cli.command else {
+        panic!("expected grok command");
     };
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -25,6 +25,7 @@ pub enum Command {
     Copilot(AgentCommandArgs),
     Gemini(AgentCommandArgs),
     Kimi(AgentCommandArgs),
+    Grok(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
 }

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -4,8 +4,8 @@ use serde_json::{json, Value};
 
 use crate::{
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
+        openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float, summarize_by_key, summarize_summaries_by_bucket,
@@ -230,6 +230,20 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
             },
             AgentLoadSpec {
                 index: 14,
+                agent: "grok",
+                progress_agent: crate::progress::UsageLoadAgent::Grok,
+                load: Box::new(|| {
+                    load_summary_agent_rows(
+                        "grok",
+                        load_kind,
+                        &loader_shared,
+                        || grok::load_entries(&loader_shared),
+                        grok::summarize_entries,
+                    )
+                }),
+            },
+            AgentLoadSpec {
+                index: 15,
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -426,6 +426,7 @@ fn agent_label(agent: &str) -> &str {
         "copilot" => "GitHub Copilot CLI",
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
+        "grok" => "Grok Build",
         "qwen" => "Qwen",
         _ => agent,
     }

--- a/rust/crates/ccusage/src/adapter/grok/README.md
+++ b/rust/crates/ccusage/src/adapter/grok/README.md
@@ -1,0 +1,18 @@
+# Grok Build Adapter
+
+The Grok Build adapter reads local session state from:
+
+```text
+${GROK_HOME:-~/.grok}/sessions/<encoded-cwd>/<session-id>/
+```
+
+For each session, `signals.json` is the usage source and `summary.json` supplies
+metadata such as the session id, model, project path, and last activity time.
+
+Grok Build currently records context token totals rather than a stable
+input/output/cache usage breakdown in these session files. ccusage therefore
+reports the recorded context total as `totalTokens` and leaves
+`inputTokens`, `outputTokens`, cache tokens, and `totalCost` at zero for this
+adapter. When Grok exposes per-request token usage in persisted session files,
+the parser should move that data into the standard token fields and enable cost
+calculation.

--- a/rust/crates/ccusage/src/adapter/grok/loader.rs
+++ b/rust/crates/ccusage/src/adapter/grok/loader.rs
@@ -1,0 +1,79 @@
+use crate::{cli::SharedArgs, parse_tz, LoadedEntry, Result};
+
+use super::{parser::read_session, paths::discover_signal_files};
+
+pub(crate) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Grok, shared.json, || {
+        load_entries_inner(shared)
+    })
+}
+
+fn load_entries_inner(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mut entries = Vec::new();
+    for file in discover_signal_files()? {
+        if let Some(entry) = read_session(&file, tz.as_ref())? {
+            entries.push(entry);
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsString, path::Path};
+
+    use ccusage_test_support::fs_fixture;
+
+    use super::super::paths::GROK_HOME_ENV;
+    use super::*;
+
+    struct EnvDirGuard {
+        previous: Option<OsString>,
+    }
+
+    impl EnvDirGuard {
+        fn set(dir: &Path) -> Self {
+            let previous = env::var_os(GROK_HOME_ENV);
+            env::set_var(GROK_HOME_ENV, dir);
+            Self { previous }
+        }
+    }
+
+    impl Drop for EnvDirGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                env::set_var(GROK_HOME_ENV, previous);
+            } else {
+                env::remove_var(GROK_HOME_ENV);
+            }
+        }
+    }
+
+    #[test]
+    fn loads_entries_from_grok_home_sessions() {
+        let _guard = super::super::GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "sessions/%2Fworkspace%2Fapi/session-a/signals.json": r#"{
+                "contextTokensUsed": 100,
+                "primaryModelId": "grok-build"
+            }"#,
+            "sessions/%2Fworkspace%2Fapi/session-a/summary.json": r#"{
+                "last_active_at": "2026-05-22T00:00:00.000Z",
+                "info": { "id": "session-a", "cwd": "/workspace/api" }
+            }"#,
+        });
+        let _cleanup = EnvDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries(&shared).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2026-05-22");
+        assert_eq!(entries[0].extra_total_tokens, 100);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/mod.rs
+++ b/rust/crates/ccusage/src/adapter/grok/mod.rs
@@ -1,0 +1,37 @@
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json, Result,
+};
+
+pub(crate) use loader::load_entries;
+pub(crate) use report::{report_from_rows, summarize_entries};
+
+#[cfg(test)]
+static GROK_HOME_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let mut entries = load_entries(&shared)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        opencode::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
+    }
+    print_usage_table(
+        "Grok Build Token Usage Report",
+        opencode::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/crates/ccusage/src/adapter/grok/parser.rs
+++ b/rust/crates/ccusage/src/adapter/grok/parser.rs
@@ -1,0 +1,331 @@
+use std::{fs, path::Path, sync::Arc, time::UNIX_EPOCH};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
+
+use crate::{
+    format_date_tz, format_rfc3339_millis, parse_ts_timestamp, LoadedEntry, Result, TimestampMs,
+    TokenUsageRaw, UsageEntry, UsageMessage,
+};
+
+const DEFAULT_MODEL: &str = "grok-build";
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GrokSignals {
+    #[serde(default)]
+    context_tokens_used: u64,
+    #[serde(default)]
+    total_tokens_before_compaction: u64,
+    primary_model_id: Option<String>,
+    #[serde(default)]
+    models_used: Vec<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummary {
+    current_model_id: Option<String>,
+    created_at: Option<String>,
+    updated_at: Option<String>,
+    last_active_at: Option<String>,
+    git_root_dir: Option<String>,
+    info: Option<GrokSummaryInfo>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummaryInfo {
+    id: Option<String>,
+    cwd: Option<String>,
+}
+
+struct GrokSessionRecord {
+    timestamp: TimestampMs,
+    timestamp_text: String,
+    session_id: String,
+    project_path: String,
+    model: String,
+    total_tokens: u64,
+}
+
+pub(super) fn read_session(
+    signals_path: &Path,
+    tz: Option<&JiffTimeZone>,
+) -> Result<Option<LoadedEntry>> {
+    let content = fs::read_to_string(signals_path)?;
+    let Ok(signals) = serde_json::from_str::<GrokSignals>(&content) else {
+        return Ok(None);
+    };
+    let total_tokens = signals
+        .context_tokens_used
+        .saturating_add(signals.total_tokens_before_compaction);
+    if total_tokens == 0 {
+        return Ok(None);
+    }
+    let summary = read_summary(signals_path);
+    let record = session_record(signals_path, signals, summary, total_tokens);
+    Ok(Some(record_to_loaded(record, tz)))
+}
+
+fn read_summary(signals_path: &Path) -> GrokSummary {
+    let summary_path = signals_path.with_file_name("summary.json");
+    let Ok(content) = fs::read_to_string(summary_path) else {
+        return GrokSummary::default();
+    };
+    serde_json::from_str::<GrokSummary>(&content).unwrap_or_default()
+}
+
+fn session_record(
+    signals_path: &Path,
+    signals: GrokSignals,
+    summary: GrokSummary,
+    total_tokens: u64,
+) -> GrokSessionRecord {
+    let fallback_timestamp = file_modified_timestamp(signals_path);
+    let timestamp_text = summary
+        .last_active_at
+        .as_deref()
+        .or(summary.updated_at.as_deref())
+        .or(summary.created_at.as_deref())
+        .and_then(normalize_grok_timestamp)
+        .unwrap_or_else(|| format_rfc3339_millis(fallback_timestamp));
+    let timestamp = parse_ts_timestamp(&timestamp_text).unwrap_or(fallback_timestamp);
+    let session_id = summary
+        .info
+        .as_ref()
+        .and_then(|info| info.id.clone())
+        .or_else(|| session_id_from_path(signals_path))
+        .unwrap_or_else(|| "unknown".to_string());
+    let project_path = summary
+        .info
+        .as_ref()
+        .and_then(|info| info.cwd.clone())
+        .or(summary.git_root_dir)
+        .or_else(|| project_path_from_session_file(signals_path))
+        .unwrap_or_else(|| "Grok Build".to_string());
+    let model = signals
+        .primary_model_id
+        .or(summary.current_model_id)
+        .or_else(|| signals.models_used.first().cloned())
+        .filter(|model| !model.trim().is_empty())
+        .unwrap_or_else(|| DEFAULT_MODEL.to_string());
+    GrokSessionRecord {
+        timestamp,
+        timestamp_text,
+        session_id,
+        project_path: project_path.trim_end_matches('/').to_string(),
+        model,
+        total_tokens,
+    }
+}
+
+fn record_to_loaded(record: GrokSessionRecord, tz: Option<&JiffTimeZone>) -> LoadedEntry {
+    let usage = TokenUsageRaw {
+        input_tokens: 0,
+        output_tokens: 0,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        speed: None,
+    };
+    let data = UsageEntry {
+        session_id: Some(record.session_id.clone()),
+        timestamp: record.timestamp_text,
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: Some(record.model.clone()),
+            id: None,
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        data,
+        timestamp: record.timestamp,
+        date: format_date_tz(record.timestamp, tz),
+        project: Arc::from("grok"),
+        session_id: Arc::from(record.session_id),
+        project_path: Arc::from(record.project_path),
+        cost: 0.0,
+        extra_total_tokens: record.total_tokens,
+        credits: None,
+        message_count: None,
+        model: Some(record.model),
+        usage_limit_reset_time: None,
+        missing_pricing_model: None,
+    }
+}
+
+fn normalize_grok_timestamp(value: &str) -> Option<String> {
+    if parse_ts_timestamp(value).is_some() {
+        return Some(value.to_string());
+    }
+    let dot = value.find('.')?;
+    let timezone_offset = value[dot + 1..]
+        .find(['Z', '+', '-'])
+        .map(|offset| dot + 1 + offset)?;
+    let fraction = &value[dot + 1..timezone_offset];
+    if fraction.len() < 3 {
+        return None;
+    }
+    let normalized = format!(
+        "{}.{}{}",
+        &value[..dot],
+        &fraction[..3],
+        &value[timezone_offset..]
+    );
+    parse_ts_timestamp(&normalized).map(|_| normalized)
+}
+
+fn file_modified_timestamp(path: &Path) -> TimestampMs {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .map(TimestampMs::from_millis)
+        .unwrap_or(TimestampMs::UNIX_EPOCH)
+}
+
+fn session_id_from_path(path: &Path) -> Option<String> {
+    path.parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+}
+
+fn project_path_from_session_file(path: &Path) -> Option<String> {
+    let encoded = path
+        .parent()?
+        .parent()?
+        .file_name()
+        .and_then(|name| name.to_str())?;
+    let decoded = percent_decode(encoded);
+    (!decoded.is_empty()).then_some(decoded)
+}
+
+fn percent_decode(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut output = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            if let Some(value) = hex_byte(bytes[index + 1], bytes[index + 2]) {
+                output.push(value);
+                index += 3;
+                continue;
+            }
+        }
+        output.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&output).into_owned()
+}
+
+fn hex_byte(high: u8, low: u8) -> Option<u8> {
+    Some(hex_value(high)? * 16 + hex_value(low)?)
+}
+
+fn hex_value(value: u8) -> Option<u8> {
+    match value {
+        b'0'..=b'9' => Some(value - b'0'),
+        b'a'..=b'f' => Some(value - b'a' + 10),
+        b'A'..=b'F' => Some(value - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ccusage_test_support::fs_fixture;
+    use jiff::tz::TimeZone;
+
+    use super::*;
+
+    #[test]
+    fn loads_grok_session_from_signals_and_summary() {
+        let fixture = fs_fixture!({
+            "sessions/%2Fworkspace%2Fapi/session-a/signals.json": r#"{
+                "contextTokensUsed": 12000,
+                "totalTokensBeforeCompaction": 3000,
+                "primaryModelId": "grok-build",
+                "modelsUsed": ["grok-build"],
+                "turnCount": 2
+            }"#,
+            "sessions/%2Fworkspace%2Fapi/session-a/summary.json": r#"{
+                "current_model_id": "grok-build",
+                "last_active_at": "2026-05-21T18:07:58.312121Z",
+                "info": {
+                    "id": "session-a",
+                    "cwd": "/workspace/api"
+                }
+            }"#,
+        });
+
+        let entry = read_session(
+            &fixture.path("sessions/%2Fworkspace%2Fapi/session-a/signals.json"),
+            Some(&TimeZone::UTC),
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(entry.date, "2026-05-21");
+        assert_eq!(entry.session_id.as_ref(), "session-a");
+        assert_eq!(entry.project_path.as_ref(), "/workspace/api");
+        assert_eq!(entry.model.as_deref(), Some("grok-build"));
+        assert_eq!(entry.extra_total_tokens, 15_000);
+        assert_eq!(entry.message_count, None);
+        assert_eq!(entry.data.message.usage.input_tokens, 0);
+        assert_eq!(entry.cost, 0.0);
+    }
+
+    #[test]
+    fn falls_back_to_path_metadata_when_summary_is_missing() {
+        let fixture = fs_fixture!({
+            "sessions/%2Fworkspace%2Fapi/session-b/signals.json": r#"{
+                "contextTokensUsed": 42,
+                "modelsUsed": ["grok-composer-2.5-fast"]
+            }"#,
+        });
+
+        let entry = read_session(
+            &fixture.path("sessions/%2Fworkspace%2Fapi/session-b/signals.json"),
+            None,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(entry.session_id.as_ref(), "session-b");
+        assert_eq!(entry.project_path.as_ref(), "/workspace/api");
+        assert_eq!(entry.model.as_deref(), Some("grok-composer-2.5-fast"));
+        assert_eq!(entry.extra_total_tokens, 42);
+    }
+
+    #[test]
+    fn skips_zero_token_sessions() {
+        let fixture = fs_fixture!({
+            "sessions/%2Fworkspace%2Fapi/session-c/signals.json": r#"{
+                "contextTokensUsed": 0,
+                "totalTokensBeforeCompaction": 0
+            }"#,
+        });
+
+        let entry = read_session(
+            &fixture.path("sessions/%2Fworkspace%2Fapi/session-c/signals.json"),
+            None,
+        )
+        .unwrap();
+
+        assert!(entry.is_none());
+    }
+
+    #[test]
+    fn normalizes_microsecond_grok_timestamps_to_milliseconds() {
+        assert_eq!(
+            normalize_grok_timestamp("2026-05-21T18:07:58.312121Z").as_deref(),
+            Some("2026-05-21T18:07:58.312Z")
+        );
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/paths.rs
+++ b/rust/crates/ccusage/src/adapter/grok/paths.rs
@@ -1,0 +1,102 @@
+use std::{
+    collections::HashSet,
+    env,
+    path::{Path, PathBuf},
+};
+
+use crate::{collect_files_with_extension, Result};
+
+pub(super) const GROK_HOME_ENV: &str = "GROK_HOME";
+const SESSIONS_DIR: &str = "sessions";
+const SIGNALS_FILE: &str = "signals.json";
+
+pub(super) fn paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    if let Ok(env_paths) = env::var(GROK_HOME_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+        return Ok(paths);
+    }
+
+    if let Some(home) = crate::home::home_dir() {
+        let path = home.join(".grok");
+        if path.is_dir() && seen.insert(path.clone()) {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+pub(super) fn discover_signal_files() -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for grok_home in paths()? {
+        let sessions_path = grok_home.join(SESSIONS_DIR);
+        let mut candidates = Vec::new();
+        collect_files_with_extension(&sessions_path, "json", &mut candidates);
+        files.extend(candidates.into_iter().filter(|file| is_signals_file(file)));
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn is_signals_file(file_path: &Path) -> bool {
+    file_path.file_name().and_then(|name| name.to_str()) == Some(SIGNALS_FILE)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsString, path::Path};
+
+    use ccusage_test_support::fs_fixture;
+
+    use super::*;
+
+    struct EnvDirGuard {
+        previous: Option<OsString>,
+    }
+
+    impl EnvDirGuard {
+        fn set(dir: &Path) -> Self {
+            let previous = env::var_os(GROK_HOME_ENV);
+            env::set_var(GROK_HOME_ENV, dir);
+            Self { previous }
+        }
+    }
+
+    impl Drop for EnvDirGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                env::set_var(GROK_HOME_ENV, previous);
+            } else {
+                env::remove_var(GROK_HOME_ENV);
+            }
+        }
+    }
+
+    #[test]
+    fn discovers_signal_files_under_grok_sessions() {
+        let _guard = super::super::GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "sessions/%2Fworkspace/project/session-a/signals.json": "{}",
+            "sessions/%2Fworkspace/project/session-a/summary.json": "{}",
+            "sessions/%2Fworkspace/project/session-b/events.jsonl": "{}\n",
+        });
+        let _cleanup = EnvDirGuard::set(fixture.root());
+        let files = discover_signal_files().unwrap();
+
+        assert_eq!(
+            files,
+            vec![fixture.path("sessions/%2Fworkspace/project/session-a/signals.json")]
+        );
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/report.rs
+++ b/rust/crates/ccusage/src/adapter/grok/report.rs
@@ -1,0 +1,67 @@
+use serde_json::{json, Value};
+
+use crate::{
+    adapter::opencode,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json, BucketKind, LoadedEntry, Result,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| opencode::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod copilot;
 pub(crate) mod droid;
 pub(crate) mod gemini;
 pub(crate) mod goose;
+pub(crate) mod grok;
 pub(crate) mod hermes;
 pub(crate) mod kilo;
 pub(crate) mod kimi;

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -243,6 +243,7 @@ fn is_agent_command(command: &str) -> bool {
             | "pi"
             | "goose"
             | "kilo"
+            | "grok"
             | "qwen"
             | "copilot"
             | "gemini"

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -44,6 +44,8 @@ pub(crate) struct CcusageConfig {
     pub(crate) gemini: Option<GeminiConfig>,
     /// Kimi configuration.
     pub(crate) kimi: Option<KimiConfig>,
+    /// Grok Build configuration.
+    pub(crate) grok: Option<GrokConfig>,
     /// Qwen configuration.
     pub(crate) qwen: Option<QwenConfig>,
 }
@@ -268,6 +270,21 @@ pub(crate) struct KimiConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct KimiCommandsConfig {
+    pub(crate) daily: Option<SharedOptions>,
+    pub(crate) monthly: Option<SharedOptions>,
+    pub(crate) session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GrokConfig {
+    pub(crate) defaults: Option<SharedOptions>,
+    pub(crate) commands: Option<GrokCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GrokCommandsConfig {
     pub(crate) daily: Option<SharedOptions>,
     pub(crate) monthly: Option<SharedOptions>,
     pub(crate) session: Option<SharedOptions>,
@@ -1009,6 +1026,7 @@ mod tests {
         assert!(schema_property(&schema, &["kilo", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["gemini", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["kimi", "defaults", "openClawPath"]).is_none());
+        assert!(schema_property(&schema, &["grok", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["qwen", "defaults", "openClawPath"]).is_none());
     }
 
@@ -1043,8 +1061,8 @@ mod tests {
             "ccusage-config",
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi",
+                "qwen", "droid",
             ],
         );
         assert!(
@@ -1174,6 +1192,13 @@ mod tests {
                 }
             },
             "kimi": {
+                "commands": {
+                    "session": {
+                        "json": true
+                    }
+                }
+            },
+            "grok": {
                 "commands": {
                     "session": {
                         "json": true

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -143,6 +143,7 @@ fn main() -> Result<()> {
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
+        Some(Command::Grok(args)) => adapter::grok::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         None => {
             let args = AgentCommandArgs {

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -395,10 +395,7 @@ fn push_breakdown_rows(
     shared: &SharedArgs,
 ) {
     for breakdown in &row.model_breakdowns {
-        let total = breakdown.input_tokens
-            + breakdown.output_tokens
-            + breakdown.cache_creation_tokens
-            + breakdown.cache_read_tokens;
+        let total = model_breakdown_total_tokens(breakdown);
         let mut values = if compact {
             vec![
                 color(
@@ -440,6 +437,14 @@ fn push_breakdown_rows(
         }
         table.push(values);
     }
+}
+
+fn model_breakdown_total_tokens(breakdown: &crate::ModelBreakdown) -> u64 {
+    breakdown.input_tokens
+        + breakdown.output_tokens
+        + breakdown.cache_creation_tokens
+        + breakdown.cache_read_tokens
+        + breakdown.extra_total_tokens
 }
 
 pub(crate) fn format_models_multiline(models: &[String]) -> String {
@@ -530,6 +535,21 @@ mod tests {
         }]);
 
         assert_eq!(totals["totalTokens"], 172);
+    }
+
+    #[test]
+    fn model_breakdown_total_includes_extra_tokens() {
+        assert_eq!(
+            model_breakdown_total_tokens(&ModelBreakdown {
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_creation_tokens: 10,
+                cache_read_tokens: 5,
+                extra_total_tokens: 7,
+                ..ModelBreakdown::default()
+            }),
+            172
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -29,6 +29,7 @@ pub(crate) enum UsageLoadAgent {
     Copilot,
     Gemini,
     Kimi,
+    Grok,
     OpenClaw,
 }
 
@@ -59,6 +60,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Copilot => "GitHub Copilot CLI",
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
+        UsageLoadAgent::Grok => "Grok Build",
         UsageLoadAgent::OpenClaw => "OpenClaw",
     }
 }

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ccusage/src/config_schema.rs
-assertion_line: 1257
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -782,6 +781,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "droid",
     "gemini",
     "goose",
+    "grok",
     "hermes",
     "kilo",
     "kimi",


### PR DESCRIPTION
Summary:
- Add Grok Build as an experimental ccusage data source backed by GROK_HOME session signals.
- Wire the grok namespace into focused reports, all-source loading, progress labels, config schema, generated help, and docs.
- Report persisted Grok context token totals as totalTokens while leaving cost/input/output/cache at zero until Grok stores a stable per-request breakdown.

Testing:
- pnpm run test
- npx --yes oxfmt --check .


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Grok Build as an experimental usage source, with focused commands and unified reports, using session signals from `GROK_HOME`.

- **New Features**
  - New Rust adapter reads `signals.json`/`summary.json` under `${GROK_HOME:-~/.grok}/sessions`.
  - New CLI commands: `ccusage grok daily|monthly|session`; included in all-source views and progress labels.
  - Reports `totalTokens` from `contextTokensUsed + totalTokensBeforeCompaction`; model inferred from session; cost set to $0.00.
  - Added `grok` namespace to config schema (`defaults` and per-command options) and generated CLI help; docs added.

- **Migration**
  - Set `GROK_HOME` if Grok data isn’t under `~/.grok` (supports comma-separated roots).
  - Expect $0.00 costs for Grok rows until per-request token breakdown is available.

<sup>Written for commit 29e92c28eec5d6ae333f3c93ab8969d73744a5b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Grok Build as a supported data source with `ccusage grok daily`, `ccusage grok monthly`, and `ccusage grok session` commands
  * Added `GROK_HOME` environment variable support for configuring Grok data directory
  * Added Grok Build configuration options in config files

* **Documentation**
  * Added new Grok Build guide with usage examples and troubleshooting
  * Updated all relevant guides to include Grok Build examples and environment variables

* **Improvements**
  * Model breakdown total tokens now includes extra token metrics

<!-- end of auto-generated comment: release notes by coderabbit.ai -->