### PR TITLE
docs: add CCWarriors to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -24,6 +24,7 @@ These projects are maintained independently and are not affiliated with the ccus
 
 - [Straude](https://straude.com) - Strava-style Claude Code telemetry for logging usage, tracking spend, and comparing pace
 - [viberank](https://viberank.app) - A community-driven leaderboard for Claude Code usage. ([GitHub](https://github.com/sculptdotfun/viberank))
+- [CCWarriors](https://ccwarriors.xyz) - Live leaderboard of AI coding spend across Claude Code, Codex, Gemini, and other ccusage-readable agents, with per-tool filters and real-time updates. ([GitHub](https://github.com/distroinfinity/ccwarriors))
 
 ## Contributing
 


### PR DESCRIPTION
## What

Adds [CCWarriors](https://ccwarriors.xyz) to the Web Applications section of the community projects list.

CCWarriors is a live leaderboard of AI coding spend built on the ccusage family — it shells out to `ccusage <agent> daily --json` for every agent ccusage detects (Claude Code, Codex, Gemini, Copilot, OpenCode, Amp, …), ships the raw per-day token counts, and ranks everyone by 30-day spend with per-tool filters and real-time WebSocket updates. Open source: https://github.com/distroinfinity/ccwarriors

Thanks for ccusage — it's the foundation the whole thing stands on. 🙏

Placed alphabetically-adjacent to the other leaderboard entry (viberank) and matched the existing line format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CCWarriors to the Community Projects (Web Applications) page with links to the site and GitHub. Describes it as a live leaderboard of coding spend across agents supported by `ccusage`, with per‑tool filters and real-time updates.

<sup>Written for commit cbe63e76582f47ff16d91ea2c2aa40bb12ae419f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ryoppippi/ccusage/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community project entry to the Web Applications section, including website and GitHub repository links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->