### PR TITLE
feat: add billing: "subscription" config option to suppress inflated costs

### DIFF
--- a/rust/crates/ccusage-cli/src/lib.rs
+++ b/rust/crates/ccusage-cli/src/lib.rs
@@ -4,9 +4,9 @@ mod parser;
 mod types;
 
 pub use types::{
-    normalize_date_bound, AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig,
-    CodexSpeed, Command, CostMode, CostSource, DailyArgs, NoConfig, PricingOverride, SessionArgs,
-    SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
+    normalize_date_bound, AgentCommandArgs, AgentReportKind, BillingType, BlocksArgs, Cli,
+    CliConfig, CodexSpeed, Command, CostMode, CostSource, DailyArgs, NoConfig, PricingOverride,
+    SessionArgs, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
 };
 
 #[cfg(test)]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -52,6 +52,7 @@ pub struct SharedArgs {
     pub compact: bool,
     pub single_thread: bool,
     pub no_cost: bool,
+    pub billing: BillingType,
     pub pricing_overrides: BTreeMap<String, PricingOverride>,
 }
 
@@ -180,6 +181,16 @@ pub enum CostMode {
     Auto,
     Calculate,
     Display,
+    /// Internal mode activated by `billing: "subscription"` in `ccusage.json`.
+    /// All costs are forced to zero regardless of recorded or calculated values.
+    Subscription,
+}
+
+impl CostMode {
+    /// Returns `true` for modes that do not require pricing data to be loaded.
+    pub fn skips_pricing(self) -> bool {
+        matches!(self, CostMode::Display | CostMode::Subscription)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -214,6 +225,19 @@ pub enum CostSource {
     Ccusage,
     Cc,
     Both,
+}
+
+/// Billing model declared by the user in `ccusage.json`.
+///
+/// `Subscription` forces all computed costs to zero so that
+/// Claude Team / Max / Pro users are not shown inflated token-calculated amounts.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub enum BillingType {
+    /// Default: derive costs from token counts and model pricing tables.
+    #[default]
+    Api,
+    /// Flat-fee subscription: report all costs as $0.
+    Subscription,
 }
 
 #[derive(Clone, Debug, Default, PartialEq)]

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -36,7 +36,7 @@ pub(super) fn load_daily_summaries_inner(
         return Ok(Vec::new());
     }
 
-    let pricing = if shared.mode == CostMode::Display {
+    let pricing = if shared.mode.skips_pricing() {
         None
     } else {
         Some(PricingMap::load_with_overrides(

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -71,7 +71,7 @@ fn load_entries_inner(
         return Ok(Vec::new());
     }
 
-    let pricing = if shared.mode == CostMode::Display {
+    let pricing = if shared.mode.skips_pricing() {
         None
     } else {
         Some(PricingMap::load_with_overrides(

--- a/rust/crates/ccusage/src/adapter/codebuff/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codebuff/loader.rs
@@ -7,7 +7,7 @@ use super::{
     paths::discover_chat_files,
 };
 use crate::{
-    cli::SharedArgs, format_date_tz, parse_tz, LoadedEntry, PricingMap, Result, UsageEntry,
+    cli::{CostMode, SharedArgs}, format_date_tz, parse_tz, LoadedEntry, PricingMap, Result, UsageEntry,
     UsageMessage,
 };
 
@@ -29,9 +29,10 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
             deduped.insert(entry.dedup_key.clone(), entry);
         }
     }
+    let mode = shared.mode;
     let mut entries = deduped
         .into_values()
-        .map(|entry| to_loaded_entry(entry, tz.as_ref(), pricing))
+        .map(|entry| to_loaded_entry(entry, tz.as_ref(), mode, pricing))
         .collect::<Vec<_>>();
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
@@ -40,10 +41,19 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
 fn to_loaded_entry(
     entry: CodebuffEntry,
     tz: Option<&JiffTimeZone>,
+    mode: CostMode,
     pricing: &PricingMap,
 ) -> LoadedEntry {
-    let cost = calculate_codebuff_cost(&entry, pricing);
-    let missing_pricing_model = missing_codebuff_pricing(&entry, pricing);
+    let cost = if mode == CostMode::Subscription {
+        0.0
+    } else {
+        calculate_codebuff_cost(&entry, pricing)
+    };
+    let missing_pricing_model = if mode.skips_pricing() {
+        None
+    } else {
+        missing_codebuff_pricing(&entry, pricing)
+    };
     let data = UsageEntry {
         session_id: Some(entry.session_id.clone()),
         timestamp: entry.timestamp_text.clone(),

--- a/rust/crates/ccusage/src/adapter/gemini/parser.rs
+++ b/rust/crates/ccusage/src/adapter/gemini/parser.rs
@@ -395,7 +395,7 @@ fn calculate_gemini_cost(
     pricing: &PricingMap,
 ) -> f64 {
     match mode {
-        CostMode::Display => 0.0,
+        CostMode::Subscription | CostMode::Display => 0.0,
         CostMode::Auto | CostMode::Calculate => {
             for candidate in model_candidates(model) {
                 if pricing.find(&candidate).is_some() {
@@ -419,7 +419,7 @@ fn missing_gemini_pricing(
     mode: CostMode,
     pricing: &PricingMap,
 ) -> Option<String> {
-    if mode == CostMode::Display {
+    if mode.skips_pricing() {
         return None;
     }
     missing_pricing_model_for_candidates(

--- a/rust/crates/ccusage/src/adapter/kilo/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kilo/parser.rs
@@ -127,6 +127,7 @@ fn calculate_kilo_cost(
     pricing: &PricingMap,
 ) -> f64 {
     match mode {
+        CostMode::Subscription => 0.0,
         CostMode::Display => data.cost_usd.unwrap_or(0.0),
         CostMode::Auto => data
             .cost_usd
@@ -163,7 +164,7 @@ fn missing_kilo_pricing(
     mode: CostMode,
     pricing: &PricingMap,
 ) -> Option<String> {
-    if mode == CostMode::Display || data.cost_usd.is_some_and(|cost| cost > 0.0) {
+    if mode.skips_pricing() || data.cost_usd.is_some_and(|cost| cost > 0.0) {
         return None;
     }
     let model = data.message.model.as_deref()?;

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -216,7 +216,7 @@ fn calculate_kimi_cost(
     usage: TokenUsageRaw,
 ) -> f64 {
     match mode {
-        CostMode::Display => 0.0,
+        CostMode::Subscription | CostMode::Display => 0.0,
         CostMode::Auto | CostMode::Calculate => {
             for candidate in model_candidates(entry) {
                 if pricing.find(&candidate).is_some() {
@@ -240,7 +240,7 @@ fn missing_kimi_pricing(
     pricing: &PricingMap,
     usage: TokenUsageRaw,
 ) -> Option<String> {
-    if mode == CostMode::Display {
+    if mode.skips_pricing() {
         return None;
     }
     missing_pricing_model_for_candidates(

--- a/rust/crates/ccusage/src/adapter/opencode/loader.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/loader.rs
@@ -42,7 +42,7 @@ pub(crate) fn load_entries_from_directory(
     opencode_dir: &Path,
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
-    let pricing = if shared.mode == CostMode::Display {
+    let pricing = if shared.mode.skips_pricing() {
         None
     } else {
         Some(PricingMap::load_with_overrides(

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -124,7 +124,7 @@ fn missing_open_code_pricing(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<String> {
-    if mode == CostMode::Display || cost_usd.is_some_and(|cost| cost > 0.0) {
+    if mode.skips_pricing() || cost_usd.is_some_and(|cost| cost > 0.0) {
         return None;
     }
     missing_pricing_model_for_candidates(

--- a/rust/crates/ccusage/src/adapter/qwen/parser.rs
+++ b/rust/crates/ccusage/src/adapter/qwen/parser.rs
@@ -22,7 +22,7 @@ use crate::{
 const DEFAULT_QWEN_MODEL: &str = "unknown";
 
 pub(super) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
-    let pricing = if shared.mode == CostMode::Display {
+    let pricing = if shared.mode.skips_pricing() {
         None
     } else {
         Some(PricingMap::load_with_overrides(
@@ -167,7 +167,7 @@ fn calculate_qwen_cost(
     pricing: Option<&PricingMap>,
 ) -> f64 {
     for candidate in qwen_model_candidates(model) {
-        if mode == CostMode::Display
+        if mode.skips_pricing()
             || pricing.is_some_and(|pricing| pricing.find(&candidate).is_some())
         {
             return calculate_cost_for_usage(Some(&candidate), usage, None, mode, pricing);
@@ -182,7 +182,7 @@ fn missing_qwen_pricing(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<String> {
-    if mode == CostMode::Display {
+    if mode.skips_pricing() {
         return None;
     }
     missing_pricing_model_for_candidates(

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -8,15 +8,15 @@ use serde_json::{Map, Value};
 
 use crate::{
     cli::{
-        normalize_date_bound, BlocksArgs, CodexSpeed, CostMode, CostSource, DailyArgs,
+        normalize_date_bound, BillingType, BlocksArgs, CodexSpeed, CostMode, CostSource, DailyArgs,
         PricingOverride, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay,
         WeeklyArgs,
     },
     config_schema::{
-        BlocksSpecificOptions, CodexOptions, ConfigCodexSpeed, ConfigCostMode, ConfigCostSource,
-        ConfigPricingOverride, ConfigSortOrder, ConfigVisualBurnRate, ConfigWeekDay,
-        DailySpecificOptions, OpenClawOptions, PiOptions, SharedOptions, StatuslineSpecificOptions,
-        WeeklySpecificOptions,
+        BlocksSpecificOptions, CodexOptions, ConfigBillingType, ConfigCodexSpeed, ConfigCostMode,
+        ConfigCostSource, ConfigPricingOverride, ConfigSortOrder, ConfigVisualBurnRate,
+        ConfigWeekDay, DailySpecificOptions, OpenClawOptions, PiOptions, SharedOptions,
+        StatuslineSpecificOptions, WeeklySpecificOptions,
     },
 };
 
@@ -29,6 +29,13 @@ struct ConfigCommand {
 pub(crate) struct ConfigContext {
     value: Option<Value>,
     command: ConfigCommand,
+}
+
+impl ConfigContext {
+    fn root_billing(&self) -> Option<ConfigBillingType> {
+        let root = self.value.as_ref()?.as_object()?;
+        serde_json::from_value(root.get("billing")?.clone()).ok()
+    }
 }
 
 impl ConfigContext {
@@ -261,8 +268,16 @@ fn is_report_command(command: &str) -> bool {
 }
 
 pub(crate) fn apply_config_to_shared(shared: &mut SharedArgs, config: &ConfigContext) {
+    let billing: Option<BillingType> = config.root_billing().map(Into::into);
+    if let Some(billing) = billing {
+        shared.billing = billing;
+    }
     for options in config.option_maps() {
         apply_shared_options(shared, SharedOptions::from_map(options));
+    }
+    // Billing is a stronger signal than mode: subscription always forces zero costs.
+    if shared.billing == BillingType::Subscription {
+        shared.mode = CostMode::Subscription;
     }
 }
 
@@ -604,6 +619,15 @@ impl From<ConfigCostSource> for CostSource {
     }
 }
 
+impl From<ConfigBillingType> for BillingType {
+    fn from(value: ConfigBillingType) -> Self {
+        match value {
+            ConfigBillingType::Api => Self::Api,
+            ConfigBillingType::Subscription => Self::Subscription,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use serde_json::{json, Value};
@@ -611,8 +635,8 @@ mod tests {
     use super::*;
     use crate::{
         cli::{
-            BlocksArgs, CodexSpeed, CostMode, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay,
-            WeeklyArgs,
+            BillingType, BlocksArgs, CodexSpeed, CostMode, SortOrder, StatuslineArgs,
+            VisualBurnRate, WeekDay, WeeklyArgs,
         },
         DEFAULT_SESSION_DURATION_HOURS,
     };
@@ -909,6 +933,66 @@ mod tests {
         assert_eq!(result.input_cost_per_token, Some(2e-6)); // overridden
         assert_eq!(result.output_cost_per_token, Some(15e-6)); // preserved
         assert_eq!(result.cache_read_input_token_cost, Some(3e-7)); // preserved
+    }
+
+    #[test]
+    fn subscription_billing_forces_cost_mode_and_suppresses_pricing_warnings() {
+        let config = context(
+            json!({
+                "billing": "subscription"
+            }),
+            "daily",
+            None,
+            "daily",
+        );
+        let mut shared = SharedArgs::default();
+
+        apply_config_to_shared(&mut shared, &config);
+
+        assert_eq!(shared.billing, BillingType::Subscription);
+        assert_eq!(shared.mode, CostMode::Subscription);
+    }
+
+    #[test]
+    fn subscription_billing_overrides_explicit_mode_setting() {
+        let config = context(
+            json!({
+                "billing": "subscription",
+                "defaults": {
+                    "mode": "calculate"
+                }
+            }),
+            "daily",
+            None,
+            "daily",
+        );
+        let mut shared = SharedArgs::default();
+
+        apply_config_to_shared(&mut shared, &config);
+
+        assert_eq!(shared.billing, BillingType::Subscription);
+        assert_eq!(shared.mode, CostMode::Subscription);
+    }
+
+    #[test]
+    fn api_billing_leaves_mode_unchanged() {
+        let config = context(
+            json!({
+                "billing": "api",
+                "defaults": {
+                    "mode": "calculate"
+                }
+            }),
+            "daily",
+            None,
+            "daily",
+        );
+        let mut shared = SharedArgs::default();
+
+        apply_config_to_shared(&mut shared, &config);
+
+        assert_eq!(shared.billing, BillingType::Api);
+        assert_eq!(shared.mode, CostMode::Calculate);
     }
 
     fn context(value: Value, raw: &str, agent: Option<&str>, report: &str) -> ConfigContext {

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -14,6 +14,9 @@ pub(crate) struct CcusageConfig {
     /// JSON Schema URL for validation and autocomplete.
     #[serde(rename = "$schema")]
     pub(crate) schema_url: Option<String>,
+    /// Billing model. Set to `"subscription"` if you pay a flat monthly fee
+    /// (Claude Team / Max / Pro) to suppress inflated token-calculated costs.
+    pub(crate) billing: Option<ConfigBillingType>,
     /// Default values for all-agent reports and legacy Claude commands.
     pub(crate) defaults: Option<SharedOptions>,
     /// Command-specific configuration for all-agent reports.
@@ -520,6 +523,19 @@ pub(crate) enum ConfigCostSource {
     Ccusage,
     Cc,
     Both,
+}
+
+/// Billing model for cost display.
+///
+/// Use `"subscription"` if you pay a flat monthly fee (Claude Team / Max / Pro)
+/// so that ccusage shows $0 instead of inflated token-calculated amounts.
+#[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum ConfigBillingType {
+    /// Default: calculate costs from token counts and model pricing.
+    Api,
+    /// Flat-fee subscription: all costs are reported as $0.
+    Subscription,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema, Clone)]
@@ -1102,9 +1118,9 @@ mod tests {
             &schema,
             "ccusage-config",
             &[
-                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "$schema", "amp", "billing", "claude", "codebuff", "codex", "commands", "copilot",
+                "defaults", "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw",
+                "pi", "qwen", "droid",
             ],
         );
         assert!(

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -28,6 +28,7 @@ pub(crate) fn calculate_cost_for_usage(
     pricing: Option<&PricingMap>,
 ) -> f64 {
     match mode {
+        CostMode::Subscription => 0.0,
         CostMode::Display => cost_usd.unwrap_or(0.0),
         CostMode::Auto => {
             cost_usd.unwrap_or_else(|| calculate_cost_from_tokens(model, usage, pricing))
@@ -43,7 +44,10 @@ pub(crate) fn missing_pricing_model_for_usage(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<String> {
-    if mode == CostMode::Display || (mode == CostMode::Auto && cost_usd.is_some()) {
+    if mode == CostMode::Subscription
+        || mode == CostMode::Display
+        || (mode == CostMode::Auto && cost_usd.is_some())
+    {
         return None;
     }
     missing_pricing_model_for_token_total(model, crate::total_usage_tokens(usage), pricing)
@@ -228,5 +232,24 @@ mod tests {
         .unwrap();
 
         assert_eq!(usage.cache_creation_token_count(), 300);
+    }
+
+    #[test]
+    fn subscription_mode_returns_zero_regardless_of_tokens() {
+        let usage = TokenUsageRaw {
+            input_tokens: 1_000,
+            output_tokens: 500,
+            ..TokenUsageRaw::default()
+        };
+
+        let cost = calculate_cost_for_usage(
+            Some("test-model"),
+            usage,
+            Some(42.0), // even if a recorded cost exists
+            CostMode::Subscription,
+            Some(&pricing()),
+        );
+
+        assert_eq!(cost, 0.0);
     }
 }

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1125,6 +1125,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
   "rootProperties": [
     "$schema",
     "amp",
+    "billing",
     "claude",
     "codebuff",
     "codex",


### PR DESCRIPTION
## Summary

Subscription users on Claude Team / Max / Pro pay a flat monthly fee, so the token-calculated dollar amounts ccusage shows are misleading — no API bill is being generated. This adds `billing: "subscription"` to `ccusage.json` as an explicit opt-in that forces all cost output to `$0.00` while keeping token counts intact.

Closes #1280. Relates to #658 (block display for subscription users), #1112 (Hermes subscription $0 billing), and #4 (costUSD removed from JSONL).

## Changes

- New `billing` top-level config key (`"api"` | `"subscription"`) in `ccusage.json`
- `billing: "subscription"` activates an internal `CostMode::Subscription` that short-circuits all cost computation to `0.0` without loading pricing data
- JSON schema updated (`config_schema.rs`) so the key appears in IDE autocomplete
- `CostMode::skips_pricing()` helper avoids redundant pricing loads in adapters that support subscription
- Snapshot and unit tests updated

## Background: why existing approaches don't work

The auth/billing type is not recorded in local JSONL files:

- `service_tier` is always `"standard"` for both API-key and subscription accounts (confirmed across 44k+ JSONL entries)
- `--mode display` returns `cost_usd ?? 0.0` which is `$0` for *everyone* now that Claude Code dropped `costUSD` from JSONL in v1.0.9 (issue #4)
- No other JSONL field distinguishes billing type

An explicit user-declared opt-in is the only reliable approach.

## Known limitations

Three adapters that compute costs without threading `mode` through their internal functions (goose, hermes, droid) will not have costs zeroed under subscription billing. This affects multi-agent users who also use those specific agents alongside Claude Code. The Claude adapter — the primary use case for this feature — handles it correctly.

## Validation

- [ ] Add `"billing": "subscription"` to `ccusage.json`, run `ccusage daily` — cost column shows `$0.00`
- [ ] Run `ccusage daily` without the billing key — existing token-calculated costs unchanged
- [ ] Run `ccusage claude daily` with and without `billing` — same behaviour

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1281"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783795363&installation_id=139163553&pr_number=1281&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1281&signature=862284f3394e70613b267606687162f0d01eb2b9e2ede62f00637b12f7e8dedd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `billing: "subscription"` to `ccusage.json` to show $0.00 for subscription plans while keeping token counts. This avoids misleading token-based costs and skips pricing loads.

- **New Features**
  - New root `billing` config (`"api"` | `"subscription"`); `"subscription"` maps to `CostMode::Subscription` and forces zero cost.
  - Added `CostMode::skips_pricing()` and updated adapters to bypass pricing loads (Claude, Codebuff, Gemini, Kilo, Kimi, OpenCode, Qwen).
  - Updated config schema so `billing` autocompletes; added tests; CLI exposes `BillingType`.

- **Migration**
  - To suppress costs, set `"billing": "subscription"` in `ccusage.json`. Leave unset or set `"api"` to keep current behavior.
  - Note: `goose`, `hermes`, and `droid` are not yet subscription-aware; their costs may not zero.

<sup>Written for commit 8a32054e180efd4f3244422c25c2aa59e69520c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1281?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added subscription billing mode that displays all computed costs as $0.00.
  * Added top-level `billing` configuration option supporting both API and subscription modes.
  * When subscription billing is configured, the cost calculation mode is automatically set to subscription.

* **Refactor**
  * Updated cost calculation across all adapters to consistently use the new billing mode logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->