### PR TITLE
feat: add Android arm64 (Termux) support

### DIFF
--- a/apps/ccusage/scripts/ensure-native-binary.ts
+++ b/apps/ccusage/scripts/ensure-native-binary.ts
@@ -8,6 +8,7 @@ const nativePackageDirs = new Map([
 	['darwin-x64', 'ccusage-darwin-x64'],
 	['linux-arm64', 'ccusage-linux-arm64'],
 	['linux-x64', 'ccusage-linux-x64'],
+	['android-arm64', 'ccusage-linux-arm64'],
 	['win32-arm64', 'ccusage-win32-arm64'],
 	['win32-x64', 'ccusage-win32-x64'],
 ]);
@@ -78,7 +79,7 @@ async function isPortableBinary(binary: string | undefined): Promise<boolean> {
 	if (binary == null) {
 		return false;
 	}
-	if (platform === 'linux') {
+	if (platform === 'linux' || platform === 'android') {
 		// ldd exits non-zero for static executables, so inspect the combined
 		// output instead of the exit code (mirrors the release CI check).
 		const result = await Bun.$`ldd ${binary}`.quiet().nothrow();

--- a/apps/ccusage/src/cli.ts
+++ b/apps/ccusage/src/cli.ts
@@ -41,7 +41,7 @@ function getNativePackageName(
 		return undefined;
 	}
 
-	if (platform === 'linux') {
+	if (platform === 'linux' || platform === 'android') {
 		if (arch === 'arm64') {
 			return '@ccusage/ccusage-linux-arm64';
 		}

--- a/packages/ccusage-linux-arm64/package.json
+++ b/packages/ccusage-linux-arm64/package.json
@@ -12,7 +12,8 @@
 		"bin/ccusage"
 	],
 	"os": [
-		"linux"
+		"linux",
+		"android"
 	],
 	"cpu": [
 		"arm64"


### PR DESCRIPTION
I tried running it on Termux through npx and it didn't work, saying `ccusage native binary is not available for android-arm64. Reinstall ccusage so optional native dependencies are installed.` I threw CC at the problem and it made this. Feel free to edit as needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1298"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783827159&installation_id=139163553&pr_number=1298&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1298&signature=ec9b13edc14b0e5a00ded4fa2edca26b10cbb8a1a95abe634a9ce73f384ed257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Android arm64 (Termux) support so `ccusage` installs and runs on `android-arm64`. Android now resolves to `@ccusage/ccusage-linux-arm64`, the package allows `android` in its `os` field, and the portable-binary check treats Android like Linux.

<sup>Written for commit c6400e918a542710880cd3e84bbe191533f52c65. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1298?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Android platform support for ARM64 architecture, enabling native binary execution on Android devices.
  * Extended native binary resolution to include Android systems, providing the same performance capabilities previously available on Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->