### PR TITLE
feat: add today and this-week shortcuts

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -66,7 +66,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
 
-Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
+Use `ccusage today`, `ccusage this-week`, `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
 ## Installation
 
@@ -98,10 +98,12 @@ bunx -p https://pkg.pr.new/ccusage/ccusage@<pr-number> ccusage --offline
 # Basic usage
 bunx ccusage          # Show all detected sources by day (default)
 bunx ccusage daily    # All detected sources by day
-bunx ccusage weekly   # All detected sources by week
-bunx ccusage monthly  # All detected sources by month
-bunx ccusage session  # All detected sources by session
-bunx ccusage blocks   # Claude Code 5-hour billing windows
+bunx ccusage today    # Today's usage across all detected sources
+bunx ccusage this-week  # Daily usage since Monday
+bunx ccusage weekly     # All detected sources by week
+bunx ccusage monthly    # All detected sources by month
+bunx ccusage session    # All detected sources by session
+bunx ccusage blocks     # Claude Code 5-hour billing windows
 bunx ccusage statusline  # Claude Code status line for hooks (Beta)
 
 # Source-focused reports and options
@@ -126,6 +128,8 @@ bunx ccusage pi daily --pi-path /path/to/sessions,/archive/pi/sessions
 bunx ccusage daily --all
 
 # Filters and options
+bunx ccusage today --json
+bunx ccusage this-week --timezone UTC
 bunx ccusage daily --since 2026-04-25 --until 2026-05-16
 bunx ccusage daily --json  # JSON output
 bunx ccusage daily --no-cost  # Hide cost columns and JSON cost fields

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -10,12 +10,16 @@ ccusage aggregates every detected supported data source by default. You do not n
 # Daily usage across every detected source
 ccusage
 ccusage daily
+ccusage today
+ccusage this-week
 
 # Other unified views
 ccusage weekly
 ccusage monthly
 ccusage session
 ```
+
+`ccusage today` shows the current day's daily rows. `ccusage this-week` shows daily rows from Monday through today. Both commands respect `--timezone`.
 
 The `--all` flag is accepted for compatibility, but it is optional because unified views are already the default.
 
@@ -27,11 +31,13 @@ ccusage daily --all
 
 ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
-| Mode    | Command example        | What it shows                           |
-| ------- | ---------------------- | --------------------------------------- |
-| Unified | `ccusage daily`        | Every detected supported source         |
-| Focused | `ccusage codex daily`  | One source using the same report shape  |
-| Focused | `ccusage claude daily` | One source with source-specific options |
+| Mode    | Command example        | What it shows                            |
+| ------- | ---------------------- | ---------------------------------------- |
+| Unified | `ccusage today`        | Today's usage from every detected source |
+| Unified | `ccusage this-week`    | Daily usage since Monday                 |
+| Unified | `ccusage daily`        | Every detected supported source          |
+| Focused | `ccusage codex daily`  | One source using the same report shape   |
+| Focused | `ccusage claude daily` | One source with source-specific options  |
 
 Unified tables include an **Agent** column so you can compare sources in one view. Focused views remove that comparison layer and show the selected source in more detail where applicable.
 

--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -11,6 +11,12 @@ All ccusage commands support these global options:
 Filter usage data by date range:
 
 ```bash
+# Today's usage across all detected sources
+ccusage today
+
+# Daily usage from Monday through today
+ccusage this-week
+
 # Filter by date range
 ccusage daily --since 20260101 --until 20260531
 
@@ -20,6 +26,8 @@ ccusage monthly --since 20260101
 # Show data up to a specific date
 ccusage session --until 20260531
 ```
+
+The `today` and `this-week` shortcuts respect `--timezone` when calculating their date range.
 
 ### Output Format
 

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -10,6 +10,8 @@ Show all daily usage:
 
 ```bash
 ccusage daily
+ccusage today
+ccusage this-week
 # or simply:
 ccusage
 
@@ -21,7 +23,7 @@ ccusage pi daily
 ccusage qwen daily
 ```
 
-The daily command is the default, so you can omit it when running ccusage.
+The daily command is the default, so you can omit it when running ccusage. Use `ccusage today` for the current day and `ccusage this-week` for daily rows from Monday through today.
 
 ## Example Output
 
@@ -57,6 +59,12 @@ ccusage automatically adapts to your terminal width:
 Filter reports by date range:
 
 ```bash
+# Show today's usage
+ccusage today
+
+# Show daily usage since Monday
+ccusage this-week
+
 # Show usage from May 2026
 ccusage daily --since 20260501 --until 20260516
 
@@ -66,6 +74,8 @@ ccusage daily --since 20260510 --until 20260516
 # Show usage since a specific date
 ccusage daily --since 20260501
 ```
+
+The shortcut commands respect `--timezone` when calculating today and the current week.
 
 ### Sort Order
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -107,6 +107,8 @@ Now that you have your first unified view, explore these features:
 ### Monitor Daily Usage
 
 ```bash
+ccusage today
+ccusage this-week
 ccusage daily --since 2026-05-01 --until 2026-05-16
 ```
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -100,6 +100,8 @@ Some coding agents have been investigated but are not supported because their lo
 Run ccusage without a source name to aggregate all detected sources:
 
 ```bash
+ccusage today
+ccusage this-week
 ccusage daily
 ccusage weekly
 ccusage monthly

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -16,12 +16,20 @@
 				"description": "Show all detected coding (agent) CLI usage grouped by date"
 			},
 			{
+				"name": "today",
+				"description": "Show all detected coding (agent) CLI usage for today"
+			},
+			{
 				"name": "monthly",
 				"description": "Show all detected coding (agent) CLI usage grouped by month"
 			},
 			{
 				"name": "weekly",
 				"description": "Show all detected coding (agent) CLI usage grouped by week"
+			},
+			{
+				"name": "this-week",
+				"description": "Show all detected coding (agent) CLI usage for this week grouped by date"
 			},
 			{
 				"name": "session",
@@ -105,6 +113,12 @@
 			"options": "all_agent_options"
 		},
 		{
+			"path": ["today"],
+			"description": "Show all detected coding (agent) CLI usage for today",
+			"usage": "ccusage today <OPTIONS>",
+			"options": "all_agent_options"
+		},
+		{
 			"path": ["monthly"],
 			"description": "Show all detected coding (agent) CLI usage grouped by month",
 			"usage": "ccusage monthly <OPTIONS>",
@@ -114,6 +128,12 @@
 			"path": ["weekly"],
 			"description": "Show all detected coding (agent) CLI usage grouped by week",
 			"usage": "ccusage weekly <OPTIONS>",
+			"options": "all_agent_options"
+		},
+		{
+			"path": ["this-week"],
+			"description": "Show all detected coding (agent) CLI usage for this week grouped by date",
+			"usage": "ccusage this-week <OPTIONS>",
 			"options": "all_agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/lib.rs
+++ b/rust/crates/ccusage-cli/src/lib.rs
@@ -5,8 +5,8 @@ mod types;
 
 pub use types::{
     AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig, CodexSpeed, Command, CostMode,
-    CostSource, DailyArgs, NoConfig, PricingOverride, SessionArgs, SharedArgs, SortOrder,
-    StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
+    CostSource, DailyArgs, NoConfig, PricingOverride, SessionArgs, SharedArgs, ShortcutCommand,
+    SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
 };
 
 #[cfg(test)]

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -5,8 +5,8 @@ use crate::help::{print_help_and_exit, print_version_and_exit};
 use crate::types::{OPENCODE_AGENT_REPORTS, STANDARD_AGENT_REPORTS};
 use crate::{
     AgentCommandArgs, AgentReportKind, BlocksArgs, Cli, CliConfig, CodexSpeed, Command, CostMode,
-    CostSource, DailyArgs, NoConfig, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
-    VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
+    CostSource, DailyArgs, NoConfig, SessionArgs, SharedArgs, ShortcutCommand, SortOrder,
+    StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
 };
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -110,6 +110,8 @@ fn parse_command(
 ) -> Result<Command, String> {
     match command {
         "daily" => parse_all_command(parser, shared, AgentReportKind::Daily, config),
+        "today" => parse_shortcut_command(parser, shared, ShortcutCommand::Today),
+        "this-week" => parse_shortcut_command(parser, shared, ShortcutCommand::ThisWeek),
         "monthly" => parse_all_command(parser, shared, AgentReportKind::Monthly, config),
         "weekly" => parse_all_command(parser, shared, AgentReportKind::Weekly, config),
         "session" => parse_top_level_session_command(parser, shared, config),
@@ -266,6 +268,21 @@ fn parse_command(
         "openclaw" => parse_openclaw_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
+}
+
+fn parse_shortcut_command(
+    parser: &mut ArgParser,
+    mut shared: SharedArgs,
+    shortcut: ShortcutCommand,
+) -> Result<Command, String> {
+    while parser.peek().is_some() {
+        if matches!(parser.peek(), Some("--all")) {
+            parser.next();
+            continue;
+        }
+        parse_shared_arg(parser, &mut shared)?;
+    }
+    Ok(Command::Shortcut(shortcut, shared))
 }
 
 fn parse_all_command(
@@ -611,6 +628,8 @@ fn is_command(arg: &str) -> bool {
     matches!(
         arg,
         "daily"
+            | "today"
+            | "this-week"
             | "monthly"
             | "weekly"
             | "session"

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -8,8 +8,10 @@ USAGE:
 
 COMMANDS:
   daily                      Show all detected coding (agent) CLI usage grouped by date
+  today                      Show all detected coding (agent) CLI usage for today
   monthly                    Show all detected coding (agent) CLI usage grouped by month
   weekly                     Show all detected coding (agent) CLI usage grouped by week
+  this-week                  Show all detected coding (agent) CLI usage for this week grouped by date
   session                    Show all detected coding (agent) CLI usage grouped by session
   blocks                     Show usage report grouped by session billing blocks
   statusline                 Display compact status line for Claude Code hooks with hybrid time+file caching (Beta)
@@ -31,8 +33,10 @@ COMMANDS:
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
+  ccusage today --help
   ccusage monthly --help
   ccusage weekly --help
+  ccusage this-week --help
   ccusage session --help
   ccusage blocks --help
   ccusage statusline --help

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
 expression: cases
 ---
 [
@@ -75,6 +75,100 @@ expression: cases
         "singleThread": true,
         "timezone": "Asia/Tokyo",
         "until": "20260110"
+      }
+    }
+  },
+  {
+    "case": "today shortcut",
+    "cli": {
+      "command": {
+        "shared": {
+          "breakdown": false,
+          "color": false,
+          "compact": false,
+          "config": null,
+          "debug": false,
+          "debugSamples": 5,
+          "jq": null,
+          "json": true,
+          "mode": "Auto",
+          "noColor": false,
+          "noOffline": false,
+          "offline": false,
+          "order": "Asc",
+          "since": null,
+          "singleThread": false,
+          "timezone": null,
+          "until": null
+        },
+        "shortcut": "Today",
+        "type": "shortcut"
+      },
+      "shared": {
+        "breakdown": false,
+        "color": false,
+        "compact": false,
+        "config": null,
+        "debug": false,
+        "debugSamples": 5,
+        "jq": null,
+        "json": false,
+        "mode": "Auto",
+        "noColor": false,
+        "noOffline": false,
+        "offline": false,
+        "order": "Asc",
+        "since": null,
+        "singleThread": false,
+        "timezone": null,
+        "until": null
+      }
+    }
+  },
+  {
+    "case": "this-week shortcut",
+    "cli": {
+      "command": {
+        "shared": {
+          "breakdown": false,
+          "color": false,
+          "compact": false,
+          "config": null,
+          "debug": false,
+          "debugSamples": 5,
+          "jq": null,
+          "json": false,
+          "mode": "Auto",
+          "noColor": false,
+          "noOffline": false,
+          "offline": true,
+          "order": "Asc",
+          "since": null,
+          "singleThread": false,
+          "timezone": null,
+          "until": null
+        },
+        "shortcut": "ThisWeek",
+        "type": "shortcut"
+      },
+      "shared": {
+        "breakdown": false,
+        "color": false,
+        "compact": false,
+        "config": null,
+        "debug": false,
+        "debugSamples": 5,
+        "jq": null,
+        "json": false,
+        "mode": "Auto",
+        "noColor": false,
+        "noOffline": false,
+        "offline": false,
+        "order": "Asc",
+        "since": null,
+        "singleThread": false,
+        "timezone": null,
+        "until": null
       }
     }
   },

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -145,6 +145,11 @@ fn command_snapshot(command: Option<Command>) -> Value {
     match command {
         None => Value::Null,
         Some(Command::All(args)) => agent_command_snapshot("all", args),
+        Some(Command::Shortcut(shortcut, shared)) => json!({
+            "type": "shortcut",
+            "shortcut": format!("{:?}", shortcut),
+            "shared": shared_snapshot(&shared),
+        }),
         Some(Command::Daily(args)) => json!({
             "type": "daily",
             "shared": shared_snapshot(&args.shared),
@@ -225,6 +230,29 @@ fn parses_root_daily_as_all_agent_report() {
     assert_eq!(args.kind, AgentReportKind::Daily);
     assert!(args.shared.json);
     assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+}
+
+#[test]
+fn parses_today_as_date_shortcut() {
+    let cli = parse(&["ccusage", "today", "--json", "--timezone", "Asia/Tokyo"]);
+    let Some(Command::Shortcut(shortcut, shared)) = cli.command else {
+        panic!("expected shortcut command");
+    };
+
+    assert_eq!(shortcut, ShortcutCommand::Today);
+    assert!(shared.json);
+    assert_eq!(shared.timezone.as_deref(), Some("Asia/Tokyo"));
+}
+
+#[test]
+fn parses_this_week_as_date_shortcut() {
+    let cli = parse(&["ccusage", "this-week", "--offline"]);
+    let Some(Command::Shortcut(shortcut, shared)) = cli.command else {
+        panic!("expected shortcut command");
+    };
+
+    assert_eq!(shortcut, ShortcutCommand::ThisWeek);
+    assert!(shared.offline);
 }
 
 #[test]
@@ -371,10 +399,34 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
 fn root_help_lists_command_descriptions_and_follow_up_help_commands() {
     let help = help_text();
 
+    assert!(help.contains("today"));
+    assert!(help.contains("Show all detected coding (agent) CLI usage for today"));
+    assert!(
+        help.contains("Show all detected coding (agent) CLI usage for this week grouped by date")
+    );
     assert!(help.contains("codex                      Show Codex token usage commands"));
     assert!(help.contains("For more info, run any command with the `--help` flag:"));
+    assert!(help.contains("ccusage today --help"));
+    assert!(help.contains("ccusage this-week --help"));
     assert!(help.contains("ccusage codex --help"));
     assert!(!help.contains("ccusage codex daily --help"));
+}
+
+#[test]
+fn contextual_shortcut_help_lists_all_agent_options() {
+    let help = help_text_for_args(&["ccusage".to_string(), "today".to_string()]);
+
+    assert!(help.contains("Show all detected coding (agent) CLI usage for today"));
+    assert!(help.contains("USAGE:\n  ccusage today <OPTIONS>"));
+    assert!(help.contains("--timezone"));
+
+    let help = help_text_for_args(&["ccusage".to_string(), "this-week".to_string()]);
+
+    assert!(
+        help.contains("Show all detected coding (agent) CLI usage for this week grouped by date")
+    );
+    assert!(help.contains("USAGE:\n  ccusage this-week <OPTIONS>"));
+    assert!(help.contains("--timezone"));
 }
 
 #[test]
@@ -503,6 +555,14 @@ fn snapshots_representative_cli_parse_shapes() {
                 "--single-thread",
                 "daily",
             ])),
+        }),
+        json!({
+            "case": "today shortcut",
+            "cli": cli_snapshot(parse(&["ccusage", "today", "--json"])),
+        }),
+        json!({
+            "case": "this-week shortcut",
+            "cli": cli_snapshot(parse(&["ccusage", "this-week", "--offline"])),
         }),
         json!({
             "case": "claude weekly monday",

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -10,6 +10,7 @@ pub struct Cli {
 
 pub enum Command {
     All(AgentCommandArgs),
+    Shortcut(ShortcutCommand, SharedArgs),
     Daily(DailyArgs),
     Monthly(SharedArgs),
     Weekly(WeeklyArgs),
@@ -30,6 +31,12 @@ pub enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ShortcutCommand {
+    Today,
+    ThisWeek,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -15,17 +15,18 @@ use crate::{
     MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, block_json,
     calculate_burn_rate,
     cli::{
-        BlocksArgs, CostSource, DailyArgs, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
-        VisualBurnRate, WeekDay, WeeklyArgs,
+        AgentCommandArgs, AgentReportKind, BlocksArgs, CostSource, DailyArgs, SessionArgs,
+        SharedArgs, ShortcutCommand, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay,
+        WeeklyArgs, normalize_date_bound,
     },
-    color,
+    cli_error, color,
     fast::FxHashMap,
     filter_and_sort_summaries, filter_blocks_by_date, format_currency, format_date, format_number,
     format_remaining_time, format_rfc3339_millis, group_project_output, identify_session_blocks,
     load_daily_summaries, load_entries, print_active_block_detail, print_blocks_table,
     print_json_or_jq, print_usage_table, session_summary_json, sort_blocks, sort_summaries,
     summarize_by_key, summarize_summaries_by_bucket, summary_json, total_usage_tokens, totals_json,
-    utc_now, wants_json,
+    utc_now, wants_json, week_start,
 };
 
 pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
@@ -546,6 +547,36 @@ fn statusline_today_shared(
     }
 }
 
+pub(crate) fn shortcut_agent_args(
+    shortcut: ShortcutCommand,
+    shared: SharedArgs,
+    now: TimestampMs,
+) -> Result<AgentCommandArgs> {
+    Ok(AgentCommandArgs {
+        shared: shortcut_shared_args(shortcut, shared, now)?,
+        kind: AgentReportKind::Daily,
+        pi_path: None,
+        open_claw_path: None,
+        codex_speed: crate::cli::CodexSpeed::Auto,
+    })
+}
+
+fn shortcut_shared_args(
+    shortcut: ShortcutCommand,
+    mut shared: SharedArgs,
+    now: TimestampMs,
+) -> Result<SharedArgs> {
+    let today = format_date(now, shared.timezone.as_deref());
+    let since = match shortcut {
+        ShortcutCommand::Today => today.clone(),
+        ShortcutCommand::ThisWeek => week_start(&today, WeekDay::Monday)
+            .ok_or_else(|| cli_error("Failed to calculate this week's start date"))?,
+    };
+    shared.since = Some(normalize_date_bound(&since));
+    shared.until = Some(normalize_date_bound(&today));
+    Ok(shared)
+}
+
 fn calculate_session_cost(session_id: &str, shared: &SharedArgs) -> Result<f64> {
     Ok(load_entries(shared, None)?
         .into_iter()
@@ -917,6 +948,43 @@ mod tests {
                 .pricing_overrides
                 .contains_key("statusline-model")
         );
+    }
+
+    #[test]
+    fn builds_today_shortcut_filter_from_timezone() {
+        let shared = SharedArgs {
+            since: Some("20260101".to_string()),
+            until: Some("20260131".to_string()),
+            json: true,
+            timezone: Some("Asia/Tokyo".to_string()),
+            ..SharedArgs::default()
+        };
+        let now = crate::parse_ts_timestamp("2026-06-14T15:30:00Z").unwrap();
+
+        let today_shared =
+            shortcut_shared_args(crate::cli::ShortcutCommand::Today, shared, now).unwrap();
+
+        assert_eq!(today_shared.since.as_deref(), Some("20260615"));
+        assert_eq!(today_shared.until.as_deref(), Some("20260615"));
+        assert!(today_shared.json);
+        assert_eq!(today_shared.timezone.as_deref(), Some("Asia/Tokyo"));
+    }
+
+    #[test]
+    fn builds_this_week_shortcut_filter_from_monday() {
+        let shared = SharedArgs {
+            offline: true,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let now = crate::parse_ts_timestamp("2026-06-17T12:00:00Z").unwrap();
+
+        let week_shared =
+            shortcut_shared_args(crate::cli::ShortcutCommand::ThisWeek, shared, now).unwrap();
+
+        assert_eq!(week_shared.since.as_deref(), Some("20260615"));
+        assert_eq!(week_shared.until.as_deref(), Some("20260617"));
+        assert!(week_shared.offline);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -125,6 +125,9 @@ fn main() -> Result<()> {
     let cli = cli::parse();
     match cli.command {
         Some(Command::All(args)) => adapter::all::run(args),
+        Some(Command::Shortcut(shortcut, shared)) => {
+            adapter::all::run(commands::shortcut_agent_args(shortcut, shared, utc_now())?)
+        }
         Some(Command::Daily(args)) => commands::run_daily(args),
         Some(Command::Monthly(shared)) => commands::run_bucket(shared, BucketKind::Monthly),
         Some(Command::Weekly(args)) => commands::run_weekly(args),


### PR DESCRIPTION
## Summary
- add top-level `ccusage today` and `ccusage this-week` shortcuts for unified all-agent daily reports
- calculate `today` from the selected timezone, and calculate `this-week` from Monday through today
- update generated CLI help snapshots plus README and guide docs

## Test plan
- `cargo fmt --manifest-path rust/Cargo.toml --all --check`
- `git diff --check`
- `cargo test --manifest-path rust/Cargo.toml --workspace`
- `CCUSAGE_PRICING_JSON_PATH="$(pwd)/rust/crates/ccusage/src/models-dev-pricing.json" cargo run --manifest-path rust/Cargo.toml -p ccusage --bin ccusage -- today --offline --json --no-cost --jq '.daily | length'`
- `CCUSAGE_PRICING_JSON_PATH="$(pwd)/rust/crates/ccusage/src/models-dev-pricing.json" cargo run --manifest-path rust/Cargo.toml -p ccusage --bin ccusage -- this-week --offline --json --no-cost --jq '.daily | length'`

Closes #1300

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1321"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784086214&installation_id=139163553&pr_number=1321&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1321&signature=843bb3cbcb50893e02ec933e8e9de9083d4f2c8a1268aef1ff9aa89a3fd162e5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ccusage today` and `ccusage this-week` as fast shortcuts for unified daily reports across all detected sources. Both respect `--timezone` and map to daily reports with the correct `since`/`until`.

- **New Features**
  - `ccusage today`: today’s daily rows across all sources.
  - `ccusage this-week`: daily rows from Monday through today.
  - Shortcuts honor `--timezone`; internally set `since`/`until`.
  - CLI gains a `Shortcut` command path; parser, types, and main dispatch updated.
  - Root and contextual `--help` updated; README and guides refreshed.
  - Tests and help snapshots added for parsing and help output.

<sup>Written for commit 6e71eec8606f546a0320c1a05d07d088eb979cc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ccusage today` shortcut command for viewing today's usage
  * Added `ccusage this-week` shortcut command for viewing this week's usage grouped by date
  * Both shortcuts respect `--timezone` setting when computing date ranges

* **Documentation**
  * Updated usage guides with new shortcut command examples and options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->