### PR TITLE
Add Mistral Vibe support

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -65,6 +65,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
+| Mistral Vibe       | `ccusage vibe daily`     |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
@@ -117,6 +118,7 @@ bunx ccusage openclaw daily
 bunx ccusage kilo daily
 bunx ccusage kimi daily
 bunx ccusage qwen daily
+bunx ccusage vibe daily
 bunx ccusage copilot daily
 bunx ccusage gemini daily
 bunx ccusage pi daily --pi-path /path/to/sessions
@@ -146,7 +148,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Mistral Vibe, GitHub Copilot CLI, and Gemini CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -92,6 +92,10 @@
 				"description": "Show Qwen usage commands"
 			},
 			{
+				"name": "vibe",
+				"description": "Show Mistral Vibe usage commands"
+			},
+			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
 			}
@@ -690,6 +694,43 @@
 			"path": ["qwen", "session"],
 			"description": "Show Qwen usage grouped by session",
 			"usage": "ccusage qwen session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["vibe"],
+			"description": "Usage reports for vibe.",
+			"usage": "ccusage vibe <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Mistral Vibe usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Mistral Vibe usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Mistral Vibe usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["vibe", "daily"],
+			"description": "Show Mistral Vibe usage grouped by date",
+			"usage": "ccusage vibe daily <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["vibe", "monthly"],
+			"description": "Show Mistral Vibe usage grouped by month",
+			"usage": "ccusage vibe monthly <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["vibe", "session"],
+			"description": "Show Mistral Vibe usage grouped by session",
+			"usage": "ccusage vibe session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -264,6 +264,13 @@ fn parse_command(
             Command::Qwen,
         ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
+        "vibe" => parse_basic_agent_command(
+            parser,
+            shared,
+            "vibe",
+            STANDARD_AGENT_REPORTS,
+            Command::Vibe,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -30,6 +30,7 @@ pub enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+    Vibe(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -6,7 +6,7 @@ use crate::{
     CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result, SessionAccumulator, UsageSummary,
     adapter::{
         amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        opencode, pi, qwen, vibe,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -237,6 +237,21 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 15,
+                agent: "vibe",
+                progress_agent: crate::progress::UsageLoadAgent::Vibe,
+                load: Box::new(|| {
+                    load_priced_summary_agent_rows(
+                        "vibe",
+                        load_kind,
+                        &loader_shared,
+                        &pricing,
+                        vibe::load_entries,
+                        vibe::summarize_entries,
+                    )
+                }),
             },
         ],
         &mut progress,
@@ -483,6 +498,26 @@ fn load_qwen_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRow
     let summaries = qwen::summarize_entries(&entries, kind)?;
     Ok(AgentRows {
         rows: summary_rows("qwen", summaries),
+        detected,
+    })
+}
+
+fn load_vibe_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
+    let entries = vibe::load_entries(shared)?;
+    let detected = !entries.is_empty() || vibe::has_data();
+    if kind == AgentReportKind::Session {
+        let mut summaries = vibe::summarize_entries(&entries, kind)?;
+        filter_session_summaries(&mut summaries, shared);
+        return Ok(AgentRows {
+            rows: summary_rows("vibe", summaries),
+            detected,
+        });
+    }
+    let mut entries = entries;
+    filter_loaded_entries_by_date(&mut entries, shared);
+    let summaries = vibe::summarize_entries(&entries, kind)?;
+    Ok(AgentRows {
+        rows: summary_rows("vibe", summaries),
         detected,
     })
 }

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -15,3 +15,4 @@ pub(crate) mod openclaw;
 pub(crate) mod opencode;
 pub(crate) mod pi;
 pub(crate) mod qwen;
+pub(crate) mod vibe;

--- a/rust/crates/ccusage/src/adapter/vibe/loader.rs
+++ b/rust/crates/ccusage/src/adapter/vibe/loader.rs
@@ -1,0 +1,16 @@
+use crate::{LoadedEntry, Result, cli::SharedArgs};
+
+use super::parser;
+
+pub(crate) fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
+    let pricing = if shared.mode == crate::cli::CostMode::Display {
+        None
+    } else {
+        Some(crate::PricingMap::load_with_overrides(
+            shared.offline,
+            crate::log_level() != Some(0),
+            shared.pricing_overrides.iter(),
+        ))
+    };
+    parser::load_entries(shared, pricing.as_ref())
+}

--- a/rust/crates/ccusage/src/adapter/vibe/mod.rs
+++ b/rust/crates/ccusage/src/adapter/vibe/mod.rs
@@ -1,0 +1,86 @@
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result,
+    adapter::opencode,
+    cli::{AgentCommandArgs, AgentReportKind},
+    filter_loaded_entries_by_date, print_json_or_jq, print_usage_table, sort_summaries, wants_json,
+};
+
+pub(crate) use loader::load_entries;
+pub(crate) use report::{report_from_rows, summarize_entries};
+
+#[cfg(test)]
+struct VibeDataDirEnvGuard {
+    _guard: ccusage_test_support::EnvVarGuard,
+}
+
+#[cfg(test)]
+impl VibeDataDirEnvGuard {
+    fn set(path: &std::path::Path) -> Self {
+        Self {
+            _guard: ccusage_test_support::EnvVarGuard::set(paths::VIBE_DATA_DIR_ENV, path),
+        }
+    }
+}
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        opencode::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Mistral Vibe Token Usage Report",
+        opencode::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}
+
+pub(crate) fn has_data() -> bool {
+    paths::discover_session_dirs().is_ok_and(|dirs| !dirs.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{AgentReportKind, CostMode, SharedArgs};
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    #[test]
+    fn has_data_when_sessions_exist() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": "{}",
+        });
+        let _env_guard = VibeDataDirEnvGuard::set(fixture.root());
+        assert!(has_data());
+    }
+
+    #[test]
+    fn no_data_when_no_sessions() {
+        let fixture = fs_fixture!({});
+        let _env_guard = VibeDataDirEnvGuard::set(fixture.root());
+        assert!(!has_data());
+    }
+}

--- a/rust/crates/ccusage/src/adapter/vibe/parser.rs
+++ b/rust/crates/ccusage/src/adapter/vibe/parser.rs
@@ -1,0 +1,394 @@
+use std::{fs, path::Path, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde_json::Value;
+
+use super::paths;
+use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz,
+    missing_pricing_model_for_usage, parse_ts_timestamp, parse_tz,
+};
+
+/// Represents the token usage data from a Mistral Vibe session
+#[derive(Debug, Clone)]
+pub(super) struct VibeSessionUsage {
+    pub session_id: String,
+    pub start_time: String,
+    pub end_time: Option<String>,
+    pub prompt_tokens: u64,
+    pub completion_tokens: u64,
+    pub total_llm_tokens: Option<u64>,
+    pub cost: Option<f64>,
+    pub input_price_per_million: Option<f64>,
+    pub output_price_per_million: Option<f64>,
+    pub model: Option<String>,
+    pub session_path: std::path::PathBuf,
+}
+
+/// Parse a meta.json file and extract usage data
+pub(super) fn parse_meta_json(path: &Path) -> Result<Option<VibeSessionUsage>> {
+    let content = match fs::read_to_string(path) {
+        Ok(c) => c,
+        Err(_) => return Ok(None),
+    };
+
+    let value: Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Ok(None),
+    };
+
+    let record = match value.as_object() {
+        Some(r) => r,
+        None => return Ok(None),
+    };
+
+    // Extract session metadata
+    let session_id = match paths::extract_session_id_from_path(path) {
+        Some(id) => id,
+        None => {
+            // Try to get from meta.json
+            match record.get("session_id").and_then(Value::as_str) {
+                Some(id) => id.to_string(),
+                None => return Ok(None),
+            }
+        }
+    };
+
+    let start_time = match record.get("start_time").and_then(Value::as_str) {
+        Some(t) => t.to_string(),
+        None => return Ok(None),
+    };
+
+    let end_time = record.get("end_time").and_then(Value::as_str).map(|t| t.to_string());
+
+    // Extract token usage from stats
+    let stats = match record.get("stats").and_then(Value::as_object) {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+
+    let prompt_tokens = match stats.get("session_prompt_tokens").and_then(Value::as_u64) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let completion_tokens = match stats.get("session_completion_tokens").and_then(Value::as_u64) {
+        Some(t) => t,
+        None => return Ok(None),
+    };
+
+    let total_llm_tokens = stats.get("session_total_llm_tokens").and_then(Value::as_u64);
+
+    let cost = stats.get("session_cost").and_then(Value::as_f64);
+
+    let input_price_per_million = stats.get("input_price_per_million").and_then(Value::as_f64);
+    let output_price_per_million = stats.get("output_price_per_million").and_then(Value::as_f64);
+
+    // Try to get model from meta.json
+    let model = record.get("model").and_then(Value::as_str).map(|m| m.to_string());
+
+    Ok(Some(VibeSessionUsage {
+        session_id,
+        start_time,
+        end_time,
+        prompt_tokens,
+        completion_tokens,
+        total_llm_tokens,
+        cost,
+        input_price_per_million,
+        output_price_per_million,
+        model,
+        session_path: path.to_path_buf(),
+    }))
+}
+
+/// Convert a VibeSessionUsage to a LoadedEntry
+pub(super) fn session_to_loaded_entry(
+    session: VibeSessionUsage,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<LoadedEntry> {
+    // Parse the start timestamp
+    let timestamp = match parse_ts_timestamp(&session.start_time) {
+        Some(ts) => ts,
+        None => return None,
+    };
+
+    let date = format_date_tz(timestamp, tz);
+
+    // Build usage data
+    let usage = TokenUsageRaw {
+        input_tokens: session.prompt_tokens,
+        output_tokens: session.completion_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: 0,
+        speed: None,
+        cache_creation: None,
+    };
+
+    // Calculate cost
+    let cost = if mode == CostMode::Display {
+        0.0
+    } else {
+        let model = session.model.as_deref();
+        calculate_cost_for_usage(
+            model,
+            usage,
+            None,
+            CostMode::Calculate,
+            pricing,
+        )
+    };
+
+    // Check for missing pricing
+    let missing_pricing_model = if mode == CostMode::Display {
+        None
+    } else {
+        missing_pricing_model_for_usage(
+            session.model.as_deref(),
+            usage,
+            session.cost,
+            mode,
+            pricing,
+        )
+    };
+
+    // Build the usage entry
+    let data = UsageEntry {
+        session_id: Some(session.session_id.clone()),
+        timestamp: session.start_time.clone(),
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: session.model.clone(),
+            id: None,
+        },
+        cost_usd: session.cost,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+
+    Some(LoadedEntry {
+        data,
+        timestamp,
+        date,
+        project: Arc::from("vibe"),
+        session_id: Arc::from(session.session_id),
+        project_path: Arc::from("Mistral Vibe"),
+        cost,
+        extra_total_tokens: session
+            .total_llm_tokens
+            .map(|t| t.saturating_sub(session.prompt_tokens + session.completion_tokens))
+            .unwrap_or(0),
+        credits: None,
+        message_count: None,
+        model: session.model,
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+    })
+}
+
+/// Load all entries from Mistral Vibe session directories
+pub(super) fn load_entries(
+    shared: &crate::cli::SharedArgs,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mode = shared.mode;
+    let mut entries = Vec::new();
+
+    for session_dir in paths::discover_session_dirs()? {
+        let meta_path = session_dir.join("meta.json");
+        if !meta_path.is_file() {
+            continue;
+        }
+
+        let session = match parse_meta_json(&meta_path)? {
+            Some(s) => s,
+            None => continue,
+        };
+
+        if let Some(entry) = session_to_loaded_entry(session, tz.as_ref(), mode, pricing) {
+            entries.push(entry);
+        }
+    }
+
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+    use crate::cli::{CostMode, SharedArgs};
+
+    #[test]
+    fn parses_meta_json_with_all_fields() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "session_id": "abc123",
+                "start_time": "2026-06-15T17:24:47.685591+00:00",
+                "end_time": "2026-06-15T17:30:02.272580+00:00",
+                "model": "mistral-large",
+                "stats": {
+                    "session_prompt_tokens": 1000,
+                    "session_completion_tokens": 500,
+                    "session_total_llm_tokens": 1500,
+                    "session_cost": 0.0015,
+                    "input_price_per_million": 1.5,
+                    "output_price_per_million": 7.5
+                }
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap().unwrap();
+
+        assert_eq!(session.session_id, "abc123");
+        assert_eq!(session.prompt_tokens, 1000);
+        assert_eq!(session.completion_tokens, 500);
+        assert_eq!(session.total_llm_tokens, Some(1500));
+        assert_eq!(session.cost, Some(0.0015));
+        assert_eq!(session.model, Some("mistral-large".to_string()));
+    }
+
+    #[test]
+    fn parses_meta_json_with_minimal_fields() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "start_time": "2026-06-15T17:24:47Z",
+                "stats": {
+                    "session_prompt_tokens": 100,
+                    "session_completion_tokens": 50
+                }
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap().unwrap();
+
+        assert_eq!(session.prompt_tokens, 100);
+        assert_eq!(session.completion_tokens, 50);
+        assert_eq!(session.total_llm_tokens, None);
+        assert_eq!(session.cost, None);
+        assert_eq!(session.model, None);
+    }
+
+    #[test]
+    fn returns_none_for_invalid_json() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": "not valid json",
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap();
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn returns_none_for_missing_stats() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "start_time": "2026-06-15T17:24:47Z"
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap();
+        assert!(session.is_none());
+    }
+
+    #[test]
+    fn converts_session_to_loaded_entry_with_display_mode() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "session_id": "abc123",
+                "start_time": "2026-06-15T17:24:47Z",
+                "model": "mistral-large",
+                "stats": {
+                    "session_prompt_tokens": 1000,
+                    "session_completion_tokens": 500,
+                    "session_total_llm_tokens": 1500
+                }
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap().unwrap();
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entry = session_to_loaded_entry(session, parse_tz(Some("UTC")), shared.mode, None).unwrap();
+
+        assert_eq!(entry.session_id.as_ref(), "abc123");
+        assert_eq!(entry.date, "2026-06-15");
+        assert_eq!(entry.data.message.usage.input_tokens, 1000);
+        assert_eq!(entry.data.message.usage.output_tokens, 500);
+        assert_eq!(entry.model.as_deref(), Some("mistral-large"));
+        assert_eq!(entry.project_path.as_ref(), "Mistral Vibe");
+    }
+
+    #[test]
+    fn calculates_extra_total_tokens() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "session_id": "abc123",
+                "start_time": "2026-06-15T17:24:47Z",
+                "model": "mistral-large",
+                "stats": {
+                    "session_prompt_tokens": 1000,
+                    "session_completion_tokens": 500,
+                    "session_total_llm_tokens": 2000
+                }
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap().unwrap();
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entry = session_to_loaded_entry(session, parse_tz(Some("UTC")), shared.mode, None).unwrap();
+
+        // extra_total_tokens = total_llm_tokens - (prompt + completion) = 2000 - 1500 = 500
+        assert_eq!(entry.extra_total_tokens, 500);
+    }
+
+    #[test]
+    fn handles_zero_extra_tokens() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": serde_json::json!({
+                "session_id": "abc123",
+                "start_time": "2026-06-15T17:24:47Z",
+                "stats": {
+                    "session_prompt_tokens": 1000,
+                    "session_completion_tokens": 500,
+                    "session_total_llm_tokens": 1500
+                }
+            })
+        });
+
+        let meta_path = fixture.path("session_20260615_172447_abc123/meta.json");
+        let session = parse_meta_json(meta_path).unwrap().unwrap();
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entry = session_to_loaded_entry(session, parse_tz(Some("UTC")), shared.mode, None).unwrap();
+
+        // extra_total_tokens = 1500 - (1000 + 500) = 0
+        assert_eq!(entry.extra_total_tokens, 0);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/vibe/paths.rs
+++ b/rust/crates/ccusage/src/adapter/vibe/paths.rs
@@ -1,0 +1,142 @@
+use std::{collections::HashSet, env, path::PathBuf};
+
+use crate::Result;
+
+pub(super) const VIBE_DATA_DIR_ENV: &str = "VIBE_DATA_DIR";
+
+/// Returns the default paths where Mistral Vibe stores session data
+pub(super) fn paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+
+    // Check for custom environment variable
+    if let Ok(env_paths) = env::var(VIBE_DATA_DIR_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+        if !paths.is_empty() {
+            return Ok(paths);
+        }
+    }
+
+    // Default path: ~/.vibe/logs/session
+    if let Some(home) = crate::home::home_dir() {
+        let path = home.join(".vibe").join("logs").join("session");
+        if path.is_dir() && seen.insert(path.clone()) {
+            paths.push(path);
+        }
+    }
+
+    Ok(paths)
+}
+
+/// Discover all session directories containing meta.json files
+pub(super) fn discover_session_dirs() -> Result<Vec<PathBuf>> {
+    let mut dirs = Vec::new();
+    for path in paths()? {
+        if !path.is_dir() {
+            continue;
+        }
+        for entry in std::fs::read_dir(&path)? {
+            let entry = entry?;
+            let entry_path = entry.path();
+            if entry_path.is_dir() {
+                // Check if this directory contains a meta.json file
+                let meta_path = entry_path.join("meta.json");
+                if meta_path.is_file() {
+                    dirs.push(entry_path);
+                }
+            }
+        }
+    }
+    dirs.sort();
+    Ok(dirs)
+}
+
+/// Extract session ID from session directory name
+/// Session directories are named like: session_20260615_172447_ea8f636f
+/// The session ID is the last component (ea8f636f)
+pub(super) fn extract_session_id_from_path(path: &std::path::Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| {
+            if let Some(last_underscore) = name.rfind('_') {
+                let id = &name[last_underscore + 1..];
+                if !id.is_empty() {
+                    Some(id.to_string())
+                } else {
+                    None
+                }
+            } else {
+                Some(name.to_string())
+            }
+        })
+}
+
+/// Get the timestamp from session directory name
+/// Session directories are named like: session_20260615_172447_ea8f636f
+/// The timestamp is: 20260615_172447 (date and time)
+pub(super) fn extract_timestamp_from_path(path: &std::path::Path) -> Option<String> {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .and_then(|name| {
+            // Remove "session_" prefix if present
+            let trimmed = name.strip_prefix("session_").unwrap_or(name);
+            // Find the last underscore before the session ID
+            if let Some(last_underscore) = trimmed.rfind('_') {
+                let timestamp_part = &trimmed[..last_underscore];
+                // Format: YYYYMMDD_HHMMSS
+                if timestamp_part.len() >= 15 {
+                    // Try to parse as 20260615_172447
+                    Some(format!("{}T{}:00Z", &timestamp_part[..8], &timestamp_part[9..15]))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn discovers_session_directories() {
+        let fixture = fs_fixture!({
+            "session_20260615_172447_abc123/meta.json": "{}",
+            "session_20260615_172500_def456/meta.json": "{}",
+            "ignore_dir/": {},
+        });
+        let _env_guard = super::super::VibeDataDirEnvGuard::set(fixture.root());
+        let dirs = discover_session_dirs().unwrap();
+
+        assert_eq!(dirs.len(), 2);
+        assert!(dirs[0].to_string_lossy().contains("session_20260615_172447_abc123"));
+        assert!(dirs[1].to_string_lossy().contains("session_20260615_172500_def456"));
+    }
+
+    #[test]
+    fn extracts_session_id_from_directory_name() {
+        let path = std::path::Path::new("session_20260615_172447_abc123");
+        assert_eq!(extract_session_id_from_path(path), Some("abc123".to_string()));
+    }
+
+    #[test]
+    fn extracts_timestamp_from_directory_name() {
+        let path = std::path::Path::new("session_20260615_172447_abc123");
+        assert_eq!(
+            extract_timestamp_from_path(path),
+            Some("20260615T17:24:47Z".to_string())
+        );
+    }
+}

--- a/rust/crates/ccusage/src/adapter/vibe/report.rs
+++ b/rust/crates/ccusage/src/adapter/vibe/report.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| {
+            super::super::opencode::agent_summary_json(row, kind, kind == AgentReportKind::Session)
+        })
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(|group| group.into_summary())
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -141,6 +141,7 @@ fn main() -> Result<()> {
         Some(Command::Goose(args)) => adapter::goose::run(args),
         Some(Command::Kilo(args)) => adapter::kilo::run(args),
         Some(Command::Qwen(args)) => adapter::qwen::run(args),
+        Some(Command::Vibe(args)) => adapter::vibe::run(args),
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -30,6 +30,7 @@ pub(crate) enum UsageLoadAgent {
     Gemini,
     Kimi,
     OpenClaw,
+    Vibe,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
         UsageLoadAgent::OpenClaw => "OpenClaw",
+        UsageLoadAgent::Vibe => "Mistral Vibe",
     }
 }
 


### PR DESCRIPTION
## Add Mistral Vibe support

Adds support for tracking Mistral Vibe CLI token usage and costs.

### What's added
- New vibe adapter that reads session data from ~/.vibe/logs/session/
- Parses meta.json files containing session_prompt_tokens, session_completion_tokens, and session_cost
- Supports all report types: daily, weekly, monthly, session
- Custom data directory via VIBE_DATA_DIR environment variable
- Full integration with unified reports (ccusage daily includes Mistral Vibe)

### Files changed
- New: rust/crates/ccusage/src/adapter/vibe/ (5 files, ~17KB)
- Modified: 8 existing files for integration
- Tests: 11 unit tests added

### Usage
ccusage vibe daily
ccusage vibe monthly
ccusage daily  # Includes Mistral Vibe automatically

### Notes
- Mistral Vibe stores session-level aggregates (not per-message), so reports show session totals
- Token data includes session_prompt_tokens, session_completion_tokens, and session_total_llm_tokens
- Model names are extracted from meta.json when available

Generated by Mistral Vibe.
Co-Authored-By: Mistral Vibe <vibe@mistral.ai>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1330"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784145258&installation_id=139163553&pr_number=1330&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1330&signature=94fd46eeb56eea4116ffbcbff3c5ca5acea588f729ef07780d3ea5c685842f30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Mistral Vibe support to track CLI session token usage and costs, and includes it in unified `ccusage` reports.

- **New Features**
  - New `vibe` adapter reads `meta.json` from `~/.vibe/logs/session/` and extracts prompt, completion, total tokens, cost, and model.
  - Added CLI commands: `ccusage vibe daily`, `ccusage vibe monthly`, `ccusage vibe session`.
  - Included in unified reports: `ccusage daily|weekly|monthly|session` now aggregates Mistral Vibe.
  - Supports `VIBE_DATA_DIR` (comma‑separated paths) to override data directories.
  - README and CLI help updated; unit tests added.

- **Migration**
  - No breaking changes. Run `ccusage daily` to include Vibe automatically, or `ccusage vibe daily`.
  - If logs aren’t in the default path, set `VIBE_DATA_DIR=/path1,/path2`.

<sup>Written for commit 91b63f8d32cebd89f0ead1682b6c6001c8b352ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1330?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for Mistral Vibe usage reporting with `daily`, `monthly`, and `session` report types via the `ccusage vibe` command.

* **Documentation**
  * Updated README to include Mistral Vibe in supported sources and unified CLI reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->