### PR TITLE
feat(cache): preserve historical usage when Claude prunes old logs

### DIFF
--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -31,10 +31,18 @@ ccusage reads Claude Code project logs from the standard Claude data directories
 The tool checks both locations and combines valid data. When `CLAUDE_CONFIG_DIR` is set, that value replaces the default lookup and can contain one directory or a comma-separated list of directories.
 
 ::: warning Retention
-Claude Code can retain logs for only 30 days by default. To review older Claude Code usage, change `cleanupPeriodDays` in your Claude Code settings.
+Claude Code can retain logs for only 30 days by default, deleting older session files on startup. To keep the underlying logs longer, change `cleanupPeriodDays` in your Claude Code settings.
 
 [Claude Code settings - Claude Docs](https://docs.claude.com/en/docs/claude-code/settings#settings-files)
 :::
+
+### Historical cache
+
+So that historical totals do not shrink when Claude Code prunes old logs, the `daily`, `weekly`, and `monthly` reports persist each day's computed totals to a small cache file (`<claude-dir>/ccusage/daily-cache.json`, outside the pruned `projects/` directory). On later runs, days whose logs were deleted are served from the cache, and live data always wins for days that still have logs — the cache only ever adds history back, never overrides or inflates current numbers.
+
+- Pass `--no-cache` to ignore the cache and report strictly from the logs currently on disk.
+- Set `CCUSAGE_CACHE_DIR` to store the cache somewhere other than the Claude data directory.
+- `session` and `blocks` reports always read live data and are not cached.
 
 ## Report Views
 
@@ -54,10 +62,11 @@ Claude Code exposes additional local data that enables features beyond the share
 
 ## Environment Variables
 
-| Variable            | Description                                  |
-| ------------------- | -------------------------------------------- |
-| `CLAUDE_CONFIG_DIR` | Override the root Claude Code data directory |
-| `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace)      |
+| Variable            | Description                                          |
+| ------------------- | --------------------------------------------------- |
+| `CLAUDE_CONFIG_DIR` | Override the root Claude Code data directory         |
+| `CCUSAGE_CACHE_DIR` | Override where the historical usage cache is stored  |
+| `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace)             |
 
 ### Custom Claude Code Paths
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -50,6 +50,10 @@ Empty entries, directories that do not exist, and missing explicit files are ski
 
 Specifies where ccusage should look for Claude Code data. See [Claude Code](/guide/claude/) for default paths, multiple-directory behavior, and Claude-specific examples.
 
+## CCUSAGE_CACHE_DIR
+
+Overrides where the [historical usage cache](/guide/claude/#historical-cache) is stored. By default the cache lives next to the Claude data directory. The cache lets `daily`, `weekly`, and `monthly` reports keep showing past days after Claude Code prunes their logs; pass `--no-cache` to bypass it for a single run.
+
 ## LOG_LEVEL
 
 Controls the verbosity of log output.

--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -143,6 +143,16 @@ ccusage monthly --json
 ccusage monthly --offline
 ```
 
+### Historical Cache
+
+Claude Code deletes session logs older than `cleanupPeriodDays` (30 by default), which would otherwise make past months shrink on every run. ccusage caches each day's totals so pruned months keep showing their original cost. Use `--no-cache` to report strictly from the logs currently on disk:
+
+```bash
+ccusage monthly --no-cache
+```
+
+See [Historical cache](/guide/claude/#historical-cache) for details.
+
 ## Analysis Use Cases
 
 ### Budget Planning

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -103,6 +103,11 @@
 			"default": "false"
 		},
 		{
+			"flags": "--no-cache",
+			"description": "Disable the persistent history cache for daily, weekly, and monthly reports",
+			"default": "false"
+		},
+		{
 			"flags": "--color",
 			"description": "Enable colored output. FORCE_COLOR=1 has the same effect.",
 			"default": "auto"
@@ -300,6 +305,11 @@
 		{
 			"flags": "--single-thread",
 			"description": "Disable parallel JSONL file loading",
+			"default": "false"
+		},
+		{
+			"flags": "--no-cache",
+			"description": "Disable the persistent history cache for daily, weekly, and monthly reports",
 			"default": "false"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -602,6 +602,7 @@ fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(
         "--compact" => shared.compact = true,
         "--single-thread" => shared.single_thread = true,
         "--no-cost" => shared.no_cost = true,
+        "--no-cache" => shared.no_cache = true,
         flag => return Err(format!("Unknown option '{flag}'")),
     }
     Ok(())
@@ -858,6 +859,7 @@ fn is_shared_flag(arg: &str) -> bool {
             | "--compact"
             | "--single-thread"
             | "--no-cost"
+            | "--no-cache"
     )
 }
 

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -62,6 +62,7 @@ OPTIONS:
   --no-offline                         Negatable of -O, --offline
   --compact                            Force compact table layout for narrow terminals (default: false)
   --no-cost                            Hide cost information in table and JSON output (default: false)
+  --no-cache                           Disable the persistent history cache for daily, weekly, and monthly reports (default: false)
   --color                              Enable colored output. FORCE_COLOR=1 has the same effect. (default: auto)
   --no-color                           Disable colored output. NO_COLOR=1 has the same effect. (default: auto)
   --config <config>                    Path to configuration file (default: auto-discovery)

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -52,6 +52,7 @@ pub struct SharedArgs {
     pub compact: bool,
     pub single_thread: bool,
     pub no_cost: bool,
+    pub no_cache: bool,
     pub pricing_overrides: BTreeMap<String, PricingOverride>,
 }
 

--- a/rust/crates/ccusage/src/adapter/all/cache.rs
+++ b/rust/crates/ccusage/src/adapter/all/cache.rs
@@ -1,0 +1,151 @@
+//! Cache integration for the multi-agent (`ccusage daily|weekly|monthly`) report.
+//!
+//! Works on the per-agent, per-day [`AllRow`]s produced before bucket
+//! aggregation. Live rows are kept intact (so metadata and exact token totals
+//! survive); the cache only steps in for days a live scan no longer sees, or
+//! whose cost shrank because logs were pruned. See [`crate::cache`] for the
+//! shared store and the add-back-only merge policy.
+
+use std::collections::BTreeMap;
+
+use crate::{
+    cache::{self, CachedBreakdown, CachedSummary},
+    cli::SharedArgs,
+};
+
+use super::types::AllRow;
+
+enum Choice {
+    Live(AllRow),
+    Cached(CachedSummary),
+}
+
+/// Merge the freshly loaded daily rows with the cached agent-keyed history,
+/// persist the union, and return the rows to aggregate. Disabled runs
+/// (`--no-cache`) return the live rows unchanged.
+pub(super) fn merge_all_daily_rows(rows: Vec<AllRow>, shared: &SharedArgs) -> Vec<AllRow> {
+    let Some(mut session) = cache::open(shared) else {
+        return rows;
+    };
+
+    // The multi-agent view owns agent-keyed rows; project-keyed rows belong to
+    // the Claude-only commands and are preserved untouched.
+    let (relevant, other_view): (Vec<CachedSummary>, Vec<CachedSummary>) = session
+        .take_rows()
+        .into_iter()
+        .partition(|row| row.agent.is_some());
+
+    let mut chosen: BTreeMap<(String, String), Choice> = BTreeMap::new();
+    for record in relevant {
+        let agent = record.agent.clone().unwrap_or_default();
+        chosen.insert((agent, record.date.clone()), Choice::Cached(record));
+    }
+    for row in rows {
+        let key = (row.agent.to_string(), row.period.clone());
+        let keep_cached = matches!(
+            chosen.get(&key),
+            Some(Choice::Cached(record)) if record.total_cost > row.total_cost
+        );
+        if !keep_cached {
+            chosen.insert(key, Choice::Live(row));
+        }
+    }
+
+    let mut out = Vec::with_capacity(chosen.len());
+    let mut to_store = other_view;
+    for (_key, choice) in chosen {
+        match choice {
+            Choice::Live(row) => {
+                to_store.push(record_from_row(&row));
+                out.push(row);
+            }
+            Choice::Cached(record) => {
+                if let Some(row) = row_from_record(&record) {
+                    out.push(row);
+                }
+                to_store.push(record);
+            }
+        }
+    }
+    session.commit(to_store);
+    out
+}
+
+fn record_from_row(row: &AllRow) -> CachedSummary {
+    CachedSummary {
+        date: row.period.clone(),
+        agent: Some(row.agent.to_string()),
+        project: None,
+        input_tokens: row.input_tokens,
+        output_tokens: row.output_tokens,
+        cache_creation_tokens: row.cache_creation_tokens,
+        cache_read_tokens: row.cache_read_tokens,
+        extra_total_tokens: 0,
+        total_tokens: Some(row.total_tokens),
+        total_cost: row.total_cost,
+        credits: None,
+        message_count: None,
+        models_used: row.models_used.clone(),
+        model_breakdowns: row
+            .model_breakdowns
+            .iter()
+            .map(CachedBreakdown::from_breakdown)
+            .collect(),
+    }
+}
+
+fn row_from_record(record: &CachedSummary) -> Option<AllRow> {
+    let agent = static_agent_name(record.agent.as_deref()?)?;
+    let total_tokens = record.total_tokens.unwrap_or(
+        record.input_tokens
+            + record.output_tokens
+            + record.cache_creation_tokens
+            + record.cache_read_tokens
+            + record.extra_total_tokens,
+    );
+    Some(AllRow {
+        period: record.date.clone(),
+        agent,
+        models_used: record.models_used.clone(),
+        input_tokens: record.input_tokens,
+        output_tokens: record.output_tokens,
+        cache_creation_tokens: record.cache_creation_tokens,
+        cache_read_tokens: record.cache_read_tokens,
+        total_tokens,
+        total_cost: record.total_cost,
+        metadata: None,
+        metadata_agents: Some(vec![agent]),
+        agent_breakdowns: None,
+        model_breakdowns: record
+            .model_breakdowns
+            .iter()
+            .cloned()
+            .map(CachedBreakdown::into_breakdown)
+            .collect(),
+    })
+}
+
+/// Resolve a stored agent name back to the `&'static str` the report expects.
+/// Unknown names (e.g. a cache written by a newer ccusage) are dropped rather
+/// than guessed.
+fn static_agent_name(name: &str) -> Option<&'static str> {
+    let resolved = match name {
+        "claude" => "claude",
+        "codex" => "codex",
+        "opencode" => "opencode",
+        "amp" => "amp",
+        "droid" => "droid",
+        "codebuff" => "codebuff",
+        "hermes" => "hermes",
+        "pi" => "pi",
+        "goose" => "goose",
+        "openclaw" => "openclaw",
+        "kilo" => "kilo",
+        "copilot" => "copilot",
+        "gemini" => "gemini",
+        "kimi" => "kimi",
+        "qwen" => "qwen",
+        _ => return None,
+    };
+    Some(resolved)
+}

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -262,12 +262,29 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
         });
     }
 
+    // Merge the per-agent daily rows with cached history (adding back days whose
+    // logs Claude Code has since pruned), then re-apply the date window so
+    // resurrected rows still honor --since/--until.
+    let mut rows = super::cache::merge_all_daily_rows(rows, shared);
+    retain_rows_in_date_window(&mut rows, shared);
+
     let mut aggregated = aggregate_rows(rows, kind);
     sort_rows(&mut aggregated, &shared.order);
     Ok(AllLoadResult {
         rows: aggregated,
         detected_agents,
     })
+}
+
+fn retain_rows_in_date_window(rows: &mut Vec<AllRow>, shared: &SharedArgs) {
+    if shared.since.is_none() && shared.until.is_none() {
+        return;
+    }
+    rows.retain(|row| {
+        let date = row.period.replace('-', "");
+        shared.since.as_ref().is_none_or(|since| &date >= since)
+            && shared.until.as_ref().is_none_or(|until| &date <= until)
+    });
 }
 
 pub(super) fn load_agent_rows_parallel(

--- a/rust/crates/ccusage/src/adapter/all/mod.rs
+++ b/rust/crates/ccusage/src/adapter/all/mod.rs
@@ -1,3 +1,4 @@
+mod cache;
 mod loader;
 mod report;
 mod types;

--- a/rust/crates/ccusage/src/cache.rs
+++ b/rust/crates/ccusage/src/cache.rs
@@ -1,0 +1,434 @@
+//! Persistent cache for date-bucketed usage reports.
+//!
+//! Claude Code deletes session transcripts under `~/.claude/projects/` once they
+//! are older than `cleanupPeriodDays` (default 30). Because `daily`/`weekly`/
+//! `monthly` rescan and recompute from the surviving JSONL files on every run and
+//! persist nothing, pruned days silently disappear from historical reports.
+//!
+//! This module keeps a small on-disk snapshot of the per-day summaries so that a
+//! day whose logs were pruned is served from cache instead of vanishing. The
+//! cache only ever *adds back* history: for any day it keeps the higher-cost of
+//! `{live, cached}`, and live data wins on ties, so it can never override or
+//! inflate what the live scan currently reports.
+//!
+//! Two independent views share one file, isolated by an `agent` discriminator:
+//! the Claude-only commands (`ccusage claude daily|weekly|monthly`) cache
+//! project-keyed rows with `agent = None`, while the multi-agent report
+//! (`ccusage daily|weekly|monthly`) caches agent-keyed rows. Rows are further
+//! isolated by a scope (timezone + cost mode) so incompatible runs never mix.
+
+use std::{collections::BTreeMap, env, fs, path::PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ModelBreakdown, UsageSummary,
+    cli::{CostMode, SharedArgs},
+};
+
+const CACHE_VERSION: u32 = 1;
+
+#[derive(Default, Serialize, Deserialize)]
+struct CacheStore {
+    version: u32,
+    scopes: BTreeMap<String, Vec<CachedSummary>>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct CachedSummary {
+    pub(crate) date: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) agent: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) project: Option<String>,
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) cache_creation_tokens: u64,
+    pub(crate) cache_read_tokens: u64,
+    #[serde(default)]
+    pub(crate) extra_total_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) total_tokens: Option<u64>,
+    pub(crate) total_cost: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) credits: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) message_count: Option<u64>,
+    #[serde(default)]
+    pub(crate) models_used: Vec<String>,
+    #[serde(default)]
+    pub(crate) model_breakdowns: Vec<CachedBreakdown>,
+}
+
+#[derive(Clone, Serialize, Deserialize)]
+pub(crate) struct CachedBreakdown {
+    pub(crate) model_name: String,
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) cache_creation_tokens: u64,
+    pub(crate) cache_read_tokens: u64,
+    #[serde(default)]
+    pub(crate) extra_total_tokens: u64,
+    pub(crate) cost: f64,
+    #[serde(default)]
+    pub(crate) missing_pricing: bool,
+}
+
+impl CachedSummary {
+    fn from_summary(row: &UsageSummary) -> Option<Self> {
+        let date = row.date.clone()?;
+        Some(Self {
+            date,
+            agent: None,
+            project: row.project.clone(),
+            input_tokens: row.input_tokens,
+            output_tokens: row.output_tokens,
+            cache_creation_tokens: row.cache_creation_tokens,
+            cache_read_tokens: row.cache_read_tokens,
+            extra_total_tokens: row.extra_total_tokens,
+            total_tokens: None,
+            total_cost: row.total_cost,
+            credits: row.credits,
+            message_count: row.message_count,
+            models_used: row.models_used.clone(),
+            model_breakdowns: row
+                .model_breakdowns
+                .iter()
+                .map(CachedBreakdown::from_breakdown)
+                .collect(),
+        })
+    }
+
+    fn into_summary(self) -> UsageSummary {
+        UsageSummary {
+            date: Some(self.date),
+            month: None,
+            week: None,
+            session_id: None,
+            project_path: None,
+            last_activity: None,
+            first_activity: None,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            extra_total_tokens: self.extra_total_tokens,
+            total_cost: self.total_cost,
+            credits: self.credits,
+            message_count: self.message_count,
+            models_used: self.models_used,
+            model_breakdowns: self
+                .model_breakdowns
+                .into_iter()
+                .map(CachedBreakdown::into_breakdown)
+                .collect(),
+            project: self.project,
+            versions: None,
+        }
+    }
+}
+
+impl CachedBreakdown {
+    pub(crate) fn from_breakdown(breakdown: &ModelBreakdown) -> Self {
+        Self {
+            model_name: breakdown.model_name.clone(),
+            input_tokens: breakdown.input_tokens,
+            output_tokens: breakdown.output_tokens,
+            cache_creation_tokens: breakdown.cache_creation_tokens,
+            cache_read_tokens: breakdown.cache_read_tokens,
+            extra_total_tokens: breakdown.extra_total_tokens,
+            cost: breakdown.cost,
+            missing_pricing: breakdown.missing_pricing,
+        }
+    }
+
+    pub(crate) fn into_breakdown(self) -> ModelBreakdown {
+        ModelBreakdown {
+            model_name: self.model_name,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            extra_total_tokens: self.extra_total_tokens,
+            cost: self.cost,
+            missing_pricing: self.missing_pricing,
+        }
+    }
+}
+
+/// An opened cache scope, holding the on-disk store so a caller can read the
+/// rows for the active scope, merge in fresh data, and commit the result.
+pub(crate) struct CacheSession {
+    path: PathBuf,
+    store: CacheStore,
+    scope: String,
+}
+
+/// Open the cache for this run, or `None` when caching is disabled (`--no-cache`)
+/// or no cache location can be resolved.
+pub(crate) fn open(shared: &SharedArgs) -> Option<CacheSession> {
+    if shared.no_cache {
+        return None;
+    }
+    let path = cache_file_path()?;
+    let scope = scope_key(shared);
+    let store = load_store(&path);
+    Some(CacheSession { path, store, scope })
+}
+
+impl CacheSession {
+    /// Remove and return all cached rows for the active scope. The caller
+    /// partitions these into the rows relevant to its view and the rest, then
+    /// passes both back to [`commit`](Self::commit).
+    pub(crate) fn take_rows(&mut self) -> Vec<CachedSummary> {
+        self.store.scopes.remove(&self.scope).unwrap_or_default()
+    }
+
+    /// Persist the full set of rows for the active scope (best effort).
+    pub(crate) fn commit(mut self, rows: Vec<CachedSummary>) {
+        self.store.scopes.insert(self.scope.clone(), rows);
+        save_store(&self.path, &self.store);
+    }
+}
+
+/// Merge freshly computed Claude per-day summaries with the on-disk cache,
+/// persist the result, and return the merged rows. Used by the Claude-only
+/// `daily`/`weekly`/`monthly` commands.
+///
+/// `group_by_project` selects the view (per-project vs project-agnostic) and a
+/// single-project `project_filter` keeps `daily --project foo` from resurrecting
+/// other projects. Disabled runs return the live rows unchanged.
+pub(crate) fn merge_daily_summaries(
+    rows: Vec<UsageSummary>,
+    shared: &SharedArgs,
+    group_by_project: bool,
+    project_filter: Option<&str>,
+) -> Vec<UsageSummary> {
+    let Some(mut session) = open(shared) else {
+        return rows;
+    };
+
+    // A row belongs to this run only when it is project-keyed (no agent), matches
+    // the view, and — when a single project is requested — that project.
+    let (relevant, other_view): (Vec<CachedSummary>, Vec<CachedSummary>) =
+        session.take_rows().into_iter().partition(|row| {
+            row.agent.is_none()
+                && row.project.is_some() == group_by_project
+                && project_filter.is_none_or(|filter| row.project.as_deref() == Some(filter))
+        });
+
+    let merged = merge_view(relevant, rows);
+
+    let mut to_store = other_view;
+    to_store.extend(merged.iter().filter_map(CachedSummary::from_summary));
+    session.commit(to_store);
+
+    merged
+}
+
+/// Pure merge step for the Claude view: keep the higher-cost summary per
+/// `(project, date)`, preferring live on ties, and preserve cached-only days.
+fn merge_view(cached: Vec<CachedSummary>, live: Vec<UsageSummary>) -> Vec<UsageSummary> {
+    let mut merged: BTreeMap<(Option<String>, String), UsageSummary> = BTreeMap::new();
+    let mut passthrough = Vec::new();
+
+    for row in cached {
+        let key = (row.project.clone(), row.date.clone());
+        merged.insert(key, row.into_summary());
+    }
+
+    for row in live {
+        let Some(date) = row.date.clone() else {
+            passthrough.push(row);
+            continue;
+        };
+        let key = (row.project.clone(), date);
+        match merged.get(&key) {
+            Some(existing) if existing.total_cost > row.total_cost => {}
+            _ => {
+                merged.insert(key, row);
+            }
+        }
+    }
+
+    let mut result = merged.into_values().collect::<Vec<_>>();
+    result.append(&mut passthrough);
+    result
+}
+
+fn scope_key(shared: &SharedArgs) -> String {
+    let tz = shared.timezone.as_deref().unwrap_or("system");
+    let mode = match shared.mode {
+        CostMode::Auto => "auto",
+        CostMode::Calculate => "calculate",
+        CostMode::Display => "display",
+    };
+    format!("{tz}|{mode}")
+}
+
+fn cache_file_path() -> Option<PathBuf> {
+    if let Ok(dir) = env::var("CCUSAGE_CACHE_DIR") {
+        let dir = dir.trim();
+        if !dir.is_empty() {
+            return Some(PathBuf::from(dir).join("daily-cache.json"));
+        }
+    }
+    // Store alongside the Claude config dir but outside `projects/`, the path
+    // Claude prunes, so the cache itself survives cleanup.
+    let base = crate::claude_paths().ok()?.into_iter().next()?;
+    Some(base.join("ccusage").join("daily-cache.json"))
+}
+
+fn load_store(path: &PathBuf) -> CacheStore {
+    let Ok(contents) = fs::read_to_string(path) else {
+        return CacheStore::default();
+    };
+    match serde_json::from_str::<CacheStore>(&contents) {
+        Ok(store) if store.version == CACHE_VERSION => store,
+        // Unknown/older format: start fresh rather than risk corrupt merges.
+        _ => CacheStore::default(),
+    }
+}
+
+fn save_store(path: &PathBuf, store: &CacheStore) {
+    let store = CacheStore {
+        version: CACHE_VERSION,
+        scopes: store.scopes.clone(),
+    };
+    let Ok(serialized) = serde_json::to_string(&store) else {
+        return;
+    };
+    if let Some(parent) = path.parent()
+        && fs::create_dir_all(parent).is_err()
+    {
+        return;
+    }
+    // Best effort, atomic-ish write: a failure must never break the report.
+    let tmp = path.with_extension("json.tmp");
+    if fs::write(&tmp, serialized).is_ok() {
+        let _ = fs::rename(&tmp, path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn summary(date: &str, project: Option<&str>, cost: f64, input: u64) -> UsageSummary {
+        UsageSummary {
+            date: Some(date.to_string()),
+            month: None,
+            week: None,
+            session_id: None,
+            project_path: None,
+            last_activity: None,
+            first_activity: None,
+            input_tokens: input,
+            output_tokens: 0,
+            cache_creation_tokens: 0,
+            cache_read_tokens: 0,
+            extra_total_tokens: 0,
+            total_cost: cost,
+            credits: None,
+            message_count: None,
+            models_used: vec!["claude-sonnet-4-20250514".to_string()],
+            model_breakdowns: vec![ModelBreakdown {
+                model_name: "claude-sonnet-4-20250514".to_string(),
+                input_tokens: input,
+                output_tokens: 0,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                extra_total_tokens: 0,
+                cost,
+                missing_pricing: false,
+            }],
+            project: project.map(str::to_string),
+            versions: None,
+        }
+    }
+
+    fn cached(date: &str, project: Option<&str>, cost: f64, input: u64) -> CachedSummary {
+        CachedSummary::from_summary(&summary(date, project, cost, input)).unwrap()
+    }
+
+    fn by_date(rows: &[UsageSummary], date: &str) -> Option<f64> {
+        rows.iter()
+            .find(|row| row.date.as_deref() == Some(date))
+            .map(|row| row.total_cost)
+    }
+
+    #[test]
+    fn keeps_cached_day_when_live_logs_were_pruned() {
+        let cached = vec![cached("2026-01-01", None, 10.0, 100)];
+        let live = vec![summary("2026-02-01", None, 5.0, 50)];
+
+        let merged = merge_view(cached, live);
+
+        assert_eq!(by_date(&merged, "2026-01-01"), Some(10.0));
+        assert_eq!(by_date(&merged, "2026-02-01"), Some(5.0));
+    }
+
+    #[test]
+    fn never_lets_a_day_shrink_below_its_cached_cost() {
+        // Same day, live partially pruned (lower cost) than the cached snapshot.
+        let cached = vec![cached("2026-01-01", None, 10.0, 100)];
+        let live = vec![summary("2026-01-01", None, 4.0, 40)];
+
+        let merged = merge_view(cached, live);
+
+        assert_eq!(by_date(&merged, "2026-01-01"), Some(10.0));
+    }
+
+    #[test]
+    fn refreshes_day_when_live_cost_grew() {
+        // A still-active day that accumulated more usage since the cache write.
+        let cached = vec![cached("2026-01-01", None, 10.0, 100)];
+        let live = vec![summary("2026-01-01", None, 14.0, 140)];
+
+        let merged = merge_view(cached, live);
+
+        assert_eq!(by_date(&merged, "2026-01-01"), Some(14.0));
+        let row = merged
+            .iter()
+            .find(|row| row.date.as_deref() == Some("2026-01-01"))
+            .unwrap();
+        assert_eq!(row.input_tokens, 140);
+    }
+
+    #[test]
+    fn live_wins_on_a_cost_tie() {
+        let cached = vec![cached("2026-01-01", None, 10.0, 100)];
+        let live = vec![summary("2026-01-01", None, 10.0, 999)];
+
+        let merged = merge_view(cached, live);
+
+        let row = merged
+            .iter()
+            .find(|row| row.date.as_deref() == Some("2026-01-01"))
+            .unwrap();
+        assert_eq!(row.input_tokens, 999);
+    }
+
+    #[test]
+    fn per_project_rows_do_not_collide_across_projects() {
+        let cached = vec![
+            cached("2026-01-01", Some("/a"), 10.0, 100),
+            cached("2026-01-01", Some("/b"), 7.0, 70),
+        ];
+        let live = vec![summary("2026-01-01", Some("/a"), 4.0, 40)];
+
+        let merged = merge_view(cached, live);
+
+        assert_eq!(merged.len(), 2);
+        let a = merged
+            .iter()
+            .find(|row| row.project.as_deref() == Some("/a"))
+            .unwrap();
+        let b = merged
+            .iter()
+            .find(|row| row.project.as_deref() == Some("/b"))
+            .unwrap();
+        assert_eq!(a.total_cost, 10.0);
+        assert_eq!(b.total_cost, 7.0);
+    }
+}

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -30,11 +30,14 @@ use crate::{
 
 pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
     let shared = args.shared.clone();
-    let mut rows = load_daily_summaries(
+    let group_by_project = args.instances || args.project.is_some();
+    let rows = load_daily_summaries(&shared, args.project.as_deref(), group_by_project)?;
+    let mut rows = crate::cache::merge_daily_summaries(
+        rows,
         &shared,
+        group_by_project,
         args.project.as_deref(),
-        args.instances || args.project.is_some(),
-    )?;
+    );
     filter_and_sort_summaries(&mut rows, &shared, |row| {
         row.date.as_deref().unwrap_or_default()
     });
@@ -69,11 +72,12 @@ pub(crate) fn run_daily(args: DailyArgs) -> Result<()> {
 
 pub(crate) fn run_bucket(shared: SharedArgs, kind: BucketKind) -> Result<()> {
     let entries = load_entries(&shared, None)?;
-    let mut daily = summarize_by_key(
+    let daily = summarize_by_key(
         &entries,
         |entry| entry.date.clone(),
         |key| (key.to_string(), None),
     )?;
+    let mut daily = crate::cache::merge_daily_summaries(daily, &shared, false, None);
     filter_and_sort_summaries(&mut daily, &shared, |row| {
         row.date.as_deref().unwrap_or_default()
     });
@@ -108,11 +112,12 @@ pub(crate) fn run_bucket(shared: SharedArgs, kind: BucketKind) -> Result<()> {
 pub(crate) fn run_weekly(args: WeeklyArgs) -> Result<()> {
     let shared = args.shared.clone();
     let entries = load_entries(&shared, None)?;
-    let mut daily = summarize_by_key(
+    let daily = summarize_by_key(
         &entries,
         |entry| entry.date.clone(),
         |key| (key.to_string(), None),
     )?;
+    let mut daily = crate::cache::merge_daily_summaries(daily, &shared, false, None);
     filter_and_sort_summaries(&mut daily, &shared, |row| {
         row.date.as_deref().unwrap_or_default()
     });

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -2,6 +2,7 @@ use std::{fmt, io};
 
 mod adapter;
 mod blocks;
+mod cache;
 mod cli;
 mod commands;
 mod config;
@@ -21,7 +22,7 @@ mod types;
 mod utils;
 
 pub(crate) use adapter::claude::{
-    chunk_file_indexes_by_size, collect_files_with_extension, collect_usage_files,
+    chunk_file_indexes_by_size, claude_paths, collect_files_with_extension, collect_usage_files,
     filter_loaded_entries_by_date, load_daily_summaries, load_entries,
 };
 pub(crate) use adapter::read_files_parallel;


### PR DESCRIPTION
## Summary

Implements #1245.

Claude Code deletes session transcripts under `~/.claude/projects/` once they are older than `cleanupPeriodDays` (default 30). ccusage rescans and recomputes from the surviving JSONL files on every run and persisted nothing, so pruned days silently disappeared from `daily`/`weekly`/`monthly` reports and historical totals shrank over time. This is confirmed upstream behavior: anthropics/claude-code [#41591](https://github.com/anthropics/claude-code/issues/41591), [#59248](https://github.com/anthropics/claude-code/issues/59248), [#62272](https://github.com/anthropics/claude-code/issues/62272).

This adds a small on-disk cache of per-day totals that **only ever adds history back** — it never overrides or inflates current numbers.

## How it works

- New `crate::cache` module: a versioned JSON store keyed by `(agent, project, date)`, isolated by a timezone + cost-mode scope, stored at `<claude-dir>/ccusage/daily-cache.json` — outside the pruned `projects/` directory, so the cache itself survives Claude's cleanup. Override the location with `CCUSAGE_CACHE_DIR`.
- For each day, the merge keeps the higher-cost of `{live, cached}` and **live wins on ties**, so a day whose logs were partially or fully pruned can't shrink, while still-active days are refreshed from live data.
- Wired into the Claude `daily`/`weekly`/`monthly` commands **and** the default multi-agent report (`ccusage daily|weekly|monthly`), which is the path most users hit. `--since`/`--until` is re-applied after the merge so resurrected days still honor the window.
- `--no-cache` reports strictly from the logs currently on disk.
- `session` and `blocks` need per-entry data, so they stay live-only.

## Testing

- `cargo test` (workspace): all pass, including 5 new cache merge tests and existing CLI/JSON/help snapshots.
- `cargo clippy --workspace --all-targets` and `cargo fmt --all`: clean.
- End-to-end against a real `ccusage monthly`: with two months of logs, deleting the older month's file keeps its cost intact on a cached run, while `--no-cache` reproduces the shrinking behavior.

## Notes

- The cache is **default-on** (opt out with `--no-cache`), since automatically preventing history loss is the goal. Happy to make it opt-in instead if preferred.
- Docs updated: historical cache section in the Claude guide, the monthly guide, and the `CCUSAGE_CACHE_DIR` environment variable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1336"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784310726&installation_id=139163553&pr_number=1336&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1336&signature=ec9e2ab3ef12e17f0faf82425363fdfb9f92c7245aa406f63903860cbb267f6c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a persistent daily usage cache so `daily`/`weekly`/`monthly` reports keep historical totals even after Claude Code deletes old logs. Prevents shrinking history while ensuring live data still wins for current days.

- **New Features**
  - Adds a versioned on-disk cache for per-day totals, scoped by timezone and cost mode, stored at `<claude-dir>/ccusage/daily-cache.json` (override with `CCUSAGE_CACHE_DIR`).
  - Uses a safe merge: keeps the higher cost of {live, cached}; live wins on ties; never overrides or inflates current numbers.
  - Integrates with multi-agent `ccusage daily|weekly|monthly` and Claude-specific `daily`/`weekly`/`monthly`; `--since`/`--until` are applied after merge.
  - Adds `--no-cache` to bypass the cache; `session` and `blocks` remain live-only.
  - Updates docs and CLI help to cover the cache, `--no-cache`, and `CCUSAGE_CACHE_DIR`.

<sup>Written for commit f406881cd07a08e83a5ef60dcb5aa8da9502607b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1336?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--no-cache` CLI flag to disable persistent report caching
  * Added `CCUSAGE_CACHE_DIR` environment variable to customize cache storage location
  * Introduced historical cache feature that preserves daily/weekly/monthly report totals when old logs are pruned

* **Documentation**
  * Updated guides to document 30-day default log retention and `cleanupPeriodDays` configuration
  * Documented historical cache behavior, new CLI flag, and environment variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->