### PR TITLE
feat(pi): auto-detect oh-my-pi (omp) sessions

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -169,7 +169,7 @@ If ccusage shows no data, check:
    - Droid: `${DROID_SESSIONS_DIR:-~/.factory/sessions}`
    - Codebuff: `${CODEBUFF_DATA_DIR:-~/.config/manicode}`
    - Hermes Agent: `${HERMES_HOME:-~/.hermes}/state.db`
-   - pi-agent: `${PI_AGENT_DIR:-~/.pi/agent/sessions}`
+   - pi-agent: `${PI_AGENT_DIR:-~/.pi/agent/sessions}` (also auto-scans `~/.omp/agent/sessions` for oh-my-pi)
    - Goose: standard Goose data roots or `GOOSE_PATH_ROOT`
    - Kilo: `${KILO_DATA_DIR:-~/.local/share/kilo}`
    - Kimi: `${KIMI_DATA_DIR:-~/.kimi}`

--- a/docs/guide/pi/index.md
+++ b/docs/guide/pi/index.md
@@ -22,11 +22,14 @@ pnpx ccusage pi --help
 
 The CLI reads usage data from pi-agent:
 
-| Source   | Default path            | Override                      |
-| -------- | ----------------------- | ----------------------------- |
-| pi-agent | `~/.pi/agent/sessions/` | `PI_AGENT_DIR` or `--pi-path` |
+| Source   | Default path             | Override                      |
+| -------- | ------------------------ | ----------------------------- |
+| pi-agent | `~/.pi/agent/sessions/`  | `PI_AGENT_DIR` or `--pi-path` |
+| omp      | `~/.omp/agent/sessions/` | `PI_AGENT_DIR` or `--pi-path` |
 
 Both `PI_AGENT_DIR` and `--pi-path` can be one sessions directory or a comma-separated list of sessions directories.
+
+When neither `PI_AGENT_DIR` nor `--pi-path` is set, ccusage auto-detects both `~/.pi/agent/sessions/` and `~/.omp/agent/sessions/`. [oh-my-pi](https://github.com/can1357/oh-my-pi) (omp) is a widely used pi fork that writes identical JSONL session files, so its usage is reported alongside pi-agent's. Setting `PI_AGENT_DIR` or `--pi-path` overrides this and scans only the given paths.
 
 ## Report Views
 

--- a/rust/crates/ccusage/src/adapter/pi/README.md
+++ b/rust/crates/ccusage/src/adapter/pi/README.md
@@ -1,9 +1,10 @@
 # pi-agent Source
 
-Data source:
+Data sources (auto-detected when `--pi-path`/`PI_AGENT_DIR` are unset):
 
 ```text
 ${PI_AGENT_DIR:-~/.pi/agent/sessions/}
+~/.omp/agent/sessions/   # oh-my-pi (omp), a pi fork with identical JSONL
 ```
 
 Commands:

--- a/rust/crates/ccusage/src/adapter/pi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/pi/paths.rs
@@ -1,8 +1,18 @@
-use std::{collections::HashSet, env, path::PathBuf};
+use std::{
+    collections::HashSet,
+    env,
+    path::{Path, PathBuf},
+};
 
 use crate::Result;
 
 const PI_AGENT_DIR_ENV: &str = "PI_AGENT_DIR";
+
+/// Session directories scanned by default when neither `--pi-path` nor
+/// `PI_AGENT_DIR` is set. `oh-my-pi` (omp) is a widely used pi fork that writes
+/// identical JSONL session files, so its directory is auto-detected alongside
+/// pi's; entries from both are deduplicated by the loader.
+const DEFAULT_SESSION_DIRS: [&str; 2] = [".pi/agent/sessions", ".omp/agent/sessions"];
 
 pub(super) fn paths(custom_path: Option<&str>) -> Result<Vec<PathBuf>> {
     if let Some(custom_path) = custom_path.filter(|path| !path.trim().is_empty()) {
@@ -16,8 +26,7 @@ pub(super) fn paths(custom_path: Option<&str>) -> Result<Vec<PathBuf>> {
 
     let home =
         crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
-    let path = home.join(".pi/agent/sessions");
-    Ok(path.is_dir().then_some(path).into_iter().collect())
+    Ok(default_session_dirs(&home))
 }
 
 fn existing_path_list(raw: &str) -> Vec<PathBuf> {
@@ -28,4 +37,51 @@ fn existing_path_list(raw: &str) -> Vec<PathBuf> {
         .map(PathBuf::from)
         .filter(|path| path.is_dir() && seen.insert(path.clone()))
         .collect()
+}
+
+fn default_session_dirs(home: &Path) -> Vec<PathBuf> {
+    DEFAULT_SESSION_DIRS
+        .iter()
+        .map(|relative| home.join(relative))
+        .filter(|path| path.is_dir())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use ccusage_test_support::Fixture;
+
+    #[test]
+    fn detects_pi_and_omp_session_dirs() {
+        let fixture = Fixture::new();
+        let pi = fixture.create_dir_all(".pi/agent/sessions");
+        let omp = fixture.create_dir_all(".omp/agent/sessions");
+
+        assert_eq!(default_session_dirs(fixture.root()), vec![pi, omp]);
+    }
+
+    #[test]
+    fn detects_omp_when_pi_dir_is_missing() {
+        let fixture = Fixture::new();
+        let omp = fixture.create_dir_all(".omp/agent/sessions");
+
+        assert_eq!(default_session_dirs(fixture.root()), vec![omp]);
+    }
+
+    #[test]
+    fn detects_pi_when_omp_dir_is_missing() {
+        let fixture = Fixture::new();
+        let pi = fixture.create_dir_all(".pi/agent/sessions");
+
+        assert_eq!(default_session_dirs(fixture.root()), vec![pi]);
+    }
+
+    #[test]
+    fn returns_no_dirs_when_neither_default_exists() {
+        let fixture = Fixture::new();
+
+        assert!(default_session_dirs(fixture.root()).is_empty());
+    }
 }


### PR DESCRIPTION
oh-my-pi (omp) is a widely used pi fork that writes identical JSONL session files with the same message.usage schema. 

Auto-detect ~/.omp/agent/sessions alongside ~/.pi/agent/sessions when neither --pi-path nor PI_AGENT_DIR is set, so omp users get usage reports without having to pass --pi-path manually. 

Both directories are scanned and entries are deduplicated by the loader; setting PI_AGENT_DIR or --pi-path overrides detection and scans only the given paths.

Closes #1193

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784382651&installation_id=139163553&pr_number=1338&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1338&signature=e941c823788a617e2a0df3a250b8b68df4f9cd7f5f3d9eb1ae5e22e08553ca22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect `~/.omp/agent/sessions` alongside `~/.pi/agent/sessions` so oh-my-pi users get usage reports without setting `--pi-path` or `PI_AGENT_DIR`.

- **New Features**
  - When neither `--pi-path` nor `PI_AGENT_DIR` is set, scan both default dirs; overrides scan only the provided paths.
  - Loader deduplicates entries across sources.
  - Docs updated in the getting started guide and pi guide; added tests for detection logic.

<sup>Written for commit c0241a9c10d4bbd9a966a06ee02a78e58924555a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic discovery of oh-my-pi (omp) session directories alongside pi-agent sessions.
  * The tool now auto-scans both `~/.pi/agent/sessions` and `~/.omp/agent/sessions` when custom paths aren’t specified.

* **Documentation**
  * Updated the guides and pi adapter README to clarify default session-path autodetection and how scanning behavior changes with `PI_AGENT_DIR`/`--pi-path`.

* **Tests**
  * Added coverage for detecting default session directories when both, one, or neither exists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->