### PR TITLE
test: explicitly use UTC timezone in tests

### DIFF
--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -442,6 +442,7 @@ mod tests {
 
     #[test]
     fn snapshots_message_to_entry_variants_and_model_candidates() {
+        let tz = crate::parse_tz(Some("UTC"));
         let mut pricing = PricingMap::default();
         pricing.load_json(
             r#"{
@@ -469,7 +470,7 @@ mod tests {
             })),
             None,
             None,
-            None,
+            tz.as_ref(),
             CostMode::Auto,
             Some(&pricing),
         )
@@ -485,7 +486,7 @@ mod tests {
             })),
             None,
             Some("explicit-session".to_string()),
-            None,
+            tz.as_ref(),
             CostMode::Display,
             None,
         )

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -542,7 +542,7 @@ mod tests {
         let report = adapter::codex::report_json(
             &events,
             AgentReportKind::Daily,
-            None,
+            Some("UTC"),
             &pricing,
             cli::CodexSpeed::Standard,
         )


### PR DESCRIPTION
I was running tests locally (PDT) and they failed since they didn't explicitly use UTC. This fixes the tests that failed for me.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784583076&installation_id=139163553&pr_number=1343&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1343&signature=f2a3ab94844e43d6f9b59ed2ed995fffbaf6ddba98939f0cad0688ecbd1ae9f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make tests explicitly use UTC to prevent timezone-dependent failures on local runs. Pass UTC to the parser and report generation tests so results are deterministic across environments.

<sup>Written for commit d3449fe9daa8d2761f958d4e768e0b7b0fdba787. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1343?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test cases to use explicit UTC timezone specifications for parsing and report generation operations to ensure consistent and deterministic test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->