### PR TITLE
fix(pricing): add glm-5.2 pricing and fix Auto mode zero-cost fallback

### DIFF
--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -29,9 +29,14 @@ pub(crate) fn calculate_cost_for_usage(
 ) -> f64 {
     match mode {
         CostMode::Display => cost_usd.unwrap_or(0.0),
-        CostMode::Auto => {
-            cost_usd.unwrap_or_else(|| calculate_cost_from_tokens(model, usage, pricing))
-        }
+        CostMode::Auto => match cost_usd {
+            Some(cost) if cost > 0.0 => cost,
+            Some(0.0) if crate::total_usage_tokens(usage) > 0 => {
+                calculate_cost_from_tokens(model, usage, pricing)
+            }
+            Some(cost) => cost,
+            None => calculate_cost_from_tokens(model, usage, pricing),
+        },
         CostMode::Calculate => calculate_cost_from_tokens(model, usage, pricing),
     }
 }
@@ -43,7 +48,7 @@ pub(crate) fn missing_pricing_model_for_usage(
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Option<String> {
-    if mode == CostMode::Display || (mode == CostMode::Auto && cost_usd.is_some()) {
+    if mode == CostMode::Display || (mode == CostMode::Auto && cost_usd.is_some_and(|c| c > 0.0)) {
         return None;
     }
     missing_pricing_model_for_token_total(model, crate::total_usage_tokens(usage), pricing)

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -982,10 +982,20 @@ impl PricingMap {
                 ..glm_base
             },
         );
+        self.entries.insert(
+            "glm-5.2".to_string(),
+            Pricing {
+                input: 1.4e-6,
+                output: 4.4e-6,
+                cache_read: 0.26e-6,
+                ..glm_base
+            },
+        );
         self.context_limits.insert("gpt-5.5".to_string(), 1_050_000);
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
+        self.context_limits.insert("glm-5.2".to_string(), 1_000_000);
         for model in [
             "claude-opus-4-8",
             "claude-opus-4-7",
@@ -1306,6 +1316,14 @@ mod tests {
         assert_eq!(glm_51.cache_create, 0.0);
         assert_eq!(glm_51.cache_read, 0.26e-6);
         assert!(glm_51.cache_read_explicit);
+
+        let glm_52 = pricing.find("glm-5.2").unwrap();
+        assert_eq!(glm_52.input, 1.4e-6);
+        assert_eq!(glm_52.output, 4.4e-6);
+        assert_eq!(glm_52.cache_create, 0.0);
+        assert_eq!(glm_52.cache_read, 0.26e-6);
+        assert!(glm_52.cache_read_explicit);
+        assert_eq!(pricing.context_limit("glm-5.2"), Some(1_000_000));
 
         let glm_5 = pricing.find("glm-5").unwrap();
         assert_eq!(glm_5.input, 1.0e-6);


### PR DESCRIPTION
## Summary

Adds pricing support for the `glm-5.2` model (Z.ai's latest flagship, released 2026-06-16) and fixes a subtle Auto-mode cost bug where agents store a zero display cost for models they cannot price.

## What Changed

### 1. Add `glm-5.2` built-in pricing (`pricing.rs`)
- Pricing matches `glm-5.1`: $1.40/1M input, $4.40/1M output, $0.26/1M cache read
- 1M-token context window
- Extended the Z.ai GLM embedded pricing test to cover `glm-5.2`

### 2. Fix Auto cost mode for zero display costs (`cost.rs`)
- When an agent stores `costUSD: 0` for a model it does not recognize (e.g. pi storing `cost.total: 0` for `glm-5.2`), Auto mode now falls through to token-based calculation instead of trusting the zero.
- A display cost of exactly `0` with non-zero tokens is treated as "unknown pricing" rather than "this model is free". Zero-cost models with no tokens continue to report `$0.00`.

## Before / After

```
# Before (default Auto mode)
└─ [pi] glm-5.2  │ 334,076 │ 139,931 │ 0 │ 15,623,360 │ 16,097,367 │ $0.00

# After
└─ [pi] glm-5.2  │ 334,076 │ 139,931 │ 0 │ 15,623,360 │ 16,097,367 │ $5.15
```

## Source
https://z.ai/blog/glm-5.2

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1347"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784668283&installation_id=139163553&pr_number=1347&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1347&signature=b8a931c93ef14072177fba355f8ccbb4c05d10565db23f2d7fe854b016c05928"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add built-in pricing for Z.ai `glm-5.2` and fix Auto cost mode so zero display costs don’t hide real usage. This prevents $0.00 totals for `glm-5.2` sessions.

- **New Features**
  - Added pricing for `glm-5.2`: $1.40/1M input, $4.40/1M output, $0.26/1M cache read, 1M context.
  - Extended tests to cover `glm-5.2`.

- **Bug Fixes**
  - Auto mode now ignores a display cost of 0 when tokens > 0 and falls back to token-based pricing.
  - Zero-cost with no tokens still reports $0.00.

<sup>Written for commit aa98c4c3d00c21e17c4a12f37e2bcdca84fc12e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic cost calculation to ignore strictly zero `cost_usd` values and fall back to token-based cost when appropriate.
  * Tightened missing-pricing detection so it only bypasses checks when `cost_usd` is greater than `0.0`.

* **New Features**
  * Added built-in pricing support for the `glm-5.2` model, including its context limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->