### PR TITLE
perf: cache PricingMap::find() results and skip redundant opencode pricing checks

### DIFF
--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -130,8 +130,14 @@ pub(crate) fn message_value_to_entry(
     };
     let cost =
         calculate_open_code_cost(&model, &provider, cost_usage, data.cost_usd, mode, pricing);
-    let missing_pricing_model =
-        missing_open_code_pricing(&model, &provider, cost_usage, data.cost_usd, mode, pricing);
+    // If we already have a usable positive cost (calculated or stored), skip
+    // the redundant missing-pricing check — it would iterate through the same
+    // model candidates and find nothing missing.
+    let missing_pricing_model = if cost > 0.0 {
+        None
+    } else {
+        missing_open_code_pricing(&model, &provider, cost_usage, data.cost_usd, mode, pricing)
+    };
     let loaded_session_id = data
         .session_id
         .clone()

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -56,12 +56,25 @@ impl Pricing {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct PricingMap {
     entries: FxHashMap<String, Pricing>,
     context_limits: FxHashMap<String, u64>,
     enable_models_dev_fallback: bool,
     enable_embedded_models_dev_fallback: bool,
+    find_cache: OnceLock<Mutex<FxHashMap<String, Option<Pricing>>>>,
+}
+
+impl Default for PricingMap {
+    fn default() -> Self {
+        Self {
+            entries: FxHashMap::default(),
+            context_limits: FxHashMap::default(),
+            enable_models_dev_fallback: false,
+            enable_embedded_models_dev_fallback: false,
+            find_cache: OnceLock::new(),
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -298,6 +311,7 @@ impl PricingMap {
             }
             loaded_count += 1;
         }
+        self.clear_find_cache();
         loaded_count
     }
 
@@ -357,13 +371,30 @@ impl PricingMap {
             }
             loaded_count += 1;
         }
+        self.clear_find_cache();
         loaded_count
     }
 
     pub(crate) fn find(&self, model: &str) -> Option<Pricing> {
+        // Fast path: check the model-level cache first. When the same model
+        // name is looked up repeatedly (e.g. across thousands of entries with
+        // only a few dozen unique models), the cache avoids re-running the
+        // expensive fuzzy fallback on every call.
+        {
+            let cache = self
+                .find_cache
+                .get_or_init(|| Mutex::new(FxHashMap::default()));
+            let guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+            if let Some(&cached) = guard.get(model) {
+                return cached;
+            }
+        }
+        // Full lookup (dropped the lock above so concurrent callers are not
+        // serialized on the expensive fuzzy path).
         let alias = crate::model_aliases::resolve_model_name(model);
         let resolved_alias = alias.as_ref();
-        self.find_entry_or_alias(model)
+        let result = self
+            .find_entry_or_alias(model)
             .or_else(|| {
                 (resolved_alias != model)
                     .then(|| self.find_entry_or_alias(resolved_alias))
@@ -384,7 +415,16 @@ impl PricingMap {
                 self.enable_embedded_models_dev_fallback
                     .then(|| embedded_models_dev_pricing().find_entry_or_alias(resolved_alias))
                     .flatten()
-            })
+            });
+        // Store the result (including None for misses) so repeated lookups
+        // for the same model that fails to match any pricing entry are also
+        // short-circuited.
+        let cache = self
+            .find_cache
+            .get_or_init(|| Mutex::new(FxHashMap::default()));
+        let mut guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+        guard.insert(model.to_string(), result);
+        result
     }
 
     fn find_entry_or_alias(&self, model: &str) -> Option<Pricing> {
@@ -461,6 +501,7 @@ impl PricingMap {
         for (model, override_value) in overrides {
             self.apply_override(model, override_value);
         }
+        self.clear_find_cache();
     }
 
     fn apply_override(&mut self, model: &str, override_value: &PricingOverride) {
@@ -548,6 +589,13 @@ impl PricingMap {
         self.entries.insert(model.to_string(), pricing);
         if let Some(limit) = override_value.max_input_tokens {
             self.context_limits.insert(model.to_string(), limit);
+        }
+    }
+
+    fn clear_find_cache(&self) {
+        if let Some(cache) = self.find_cache.get() {
+            let mut guard = cache.lock().unwrap_or_else(|error| error.into_inner());
+            guard.clear();
         }
     }
 


### PR DESCRIPTION
Closes #1344

Thank you for your interest in my PR!

## Summary

`bunx ccusage@latest opencode` was taking over **two minutes** on my machine with a large OpenCode history (~3.6 GB, 87k messages). Profiling showed that `PricingMap::find()` accounted for **91%** of execution time — despite only 47 unique model names being present, each of the 87k messages independently repeated the full fuzzy lookup through ~2,200 pricing entries.

This PR addresses the issue with two independent optimizations:
1. A result cache for `PricingMap::find()` so repeated lookups for the same model complete in O(1)
2. Skipping the redundant missing-pricing check in the OpenCode adapter when cost is already known

## Changes

### `rust/crates/ccusage/src/pricing.rs`

- Added `find_cache: OnceLock<Mutex<FxHashMap<String, Option<Pricing>>>>` to `PricingMap`
- `find()` now checks the cache first; on cache miss the full lookup runs and the result (including `None` for models not in pricing) is stored for subsequent calls
- Added `clear_find_cache()` called from `load_json_with_overrides()`, `load_models_dev_models()`, and `apply_overrides()` to maintain consistency when the  pricing table is mutated
- Changed from derived `Default` to manual implementation to accommodate the `OnceLock` field
- Fixed Mutex lock poisoning recovery to use `unwrap_or_else(|error| error.into_inner())` consistently across all cache operations

### `rust/crates/ccusage/src/adapter/opencode/parser.rs`

- Both `calculate_open_code_cost` and `missing_open_code_pricing` independently iterated the same model candidates. When cost calculation already returned a positive cost  (`cost > 0.0`), the missing-pricing check is now skipped entirely.

## Benchmark

Measured on the same machine with the same 3.6 GB OpenCode history:

```
$ hyperfine --warmup 1 --runs 3 \
    "ccusage opencode" (before) \
    "ccusage opencode" (after)

  Before: 122.2s
  After:   2.3s  (54× faster)
```

The cache is in the shared `PricingMap` layer, so other adapters (Claude Code, Codex, Amp, etc.) may benefit from it as well. Memory overhead is proportional to the number of unique model names looked up, typically a few kilobytes.

## Checklist

- [x] `direnv exec . just fmt`
- [x] `direnv exec . just test` (368/368 passed)
- [x] `cargo build --release` succeeds
- [x] Verified output parity (`NO_COLOR=1 TZ=UTC`) between cached and uncached paths

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1358"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784725751&installation_id=139163553&pr_number=1358&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1358&signature=78926f7d777798b807a1e155c8e0fbe8015e57e565903edfa31b1781380c4ae8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cache results of `PricingMap::find()` and skip redundant OpenCode pricing checks to massively speed up large runs (e.g., `ccusage opencode` from ~122s to ~2.3s). The cache lives in the shared pricing layer, so other adapters benefit too.

- **Refactors**
  - Memoize `find()` results (including misses) in an `OnceLock<Mutex<FxHashMap>>` keyed by model.
  - Invalidate the cache when pricing data changes (JSON loads, dev models, overrides).
  - In OpenCode, skip the missing-pricing check when a positive cost is already known.

<sup>Written for commit 82c5d8440feb72e0481d8572297339577145850f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1358?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pricing lookups with caching for improved resolution speed
  * Enhanced computational efficiency by eliminating redundant calculations in cost determination

<!-- end of auto-generated comment: release notes by coderabbit.ai -->