### PR TITLE
fix(kimi): support Kimi Code new wire format (usage.record, camelCase, ms timestamp)

### DIFF
--- a/rust/crates/ccusage/src/adapter/kimi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/loader.rs
@@ -87,6 +87,59 @@ mod tests {
     }
 
     #[test]
+    fn loads_kimi_code_usage_record_format() {
+        let fixture = fs_fixture!({
+            "sessions/workspace/session-b/agents/agent-1/wire.jsonl": [
+                r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":3064,"output":76,"inputCacheRead":14848,"inputCacheCreation":0},"usageScope":"turn","time":1782113184943}"#,
+                r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":5000,"output":200,"inputCacheRead":20000,"inputCacheCreation":100},"usageScope":"session","time":1782113185000}"#,
+            ]
+            .join("\n"),
+        });
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1, "session-scoped record must be skipped");
+        assert_eq!(entries[0].session_id.as_ref(), "session-b");
+        assert_eq!(entries[0].model.as_deref(), Some("kimi-for-coding"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 3064);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 76);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 14848);
+        assert_eq!(entries[0].data.message.usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
+    fn discovers_new_format_wire_files_at_five_component_depth() {
+        let fixture = fs_fixture!({
+            "sessions/ws/session-c/agents/agent-1/wire.jsonl": "",
+            "sessions/ws/session-c/agents/agent-1/other.jsonl": "",
+            "sessions/group/session-d/wire.jsonl": "",
+        });
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
+        let files = super::super::paths::discover_wire_files().unwrap();
+        let names: Vec<_> = files
+            .iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect();
+
+        assert!(
+            names.iter().any(|n| n.contains("session-c")),
+            "new-format file not found: {names:?}"
+        );
+        assert!(
+            names.iter().any(|n| n.contains("session-d")),
+            "old-format file not found: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("other.jsonl")),
+            "non-wire file should be excluded: {names:?}"
+        );
+    }
+
+    #[test]
     fn skips_malformed_and_zero_token_wire_lines() {
         let fixture = fs_fixture!({
             "sessions/group/session-a/wire.jsonl": [

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -25,18 +25,28 @@ struct KimiConfig {
     model: Option<String>,
 }
 
-/// A single Kimi wire JSONL line. Only the fields ccusage consumes are declared;
-/// serde skips everything else.
+/// A single Kimi wire JSONL line. Covers both the old Kimi CLI format
+/// (nested `message.type == "StatusUpdate"`) and the new Kimi Code format
+/// (`type == "usage.record"` with top-level camelCase fields).
 #[derive(Debug, Deserialize)]
 struct KimiWireLine {
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     r#type: Option<String>,
+    // Old format fields
     message: Option<KimiWireMessage>,
     #[serde(default, deserialize_with = "jsonl::lenient_f64")]
     timestamp: Option<f64>,
+    // New Kimi Code format fields
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    usage: Option<KimiCodeUsage>,
+    #[serde(rename = "usageScope", default, deserialize_with = "jsonl::non_empty_string")]
+    usage_scope: Option<String>,
+    /// Timestamp in milliseconds (new format).
+    time: Option<i64>,
 }
 
-/// The `message` block carried by a Kimi wire line.
+/// The `message` block carried by an old-format Kimi wire line.
 #[derive(Debug, Deserialize)]
 struct KimiWireMessage {
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
@@ -52,7 +62,7 @@ struct KimiWirePayload {
     message_id: Option<String>,
 }
 
-/// Token counts reported under `message.payload.token_usage`.
+/// Token counts reported under `message.payload.token_usage` (old format, snake_case).
 #[derive(Debug, Default, Deserialize)]
 struct KimiTokenUsage {
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
@@ -65,6 +75,19 @@ struct KimiTokenUsage {
     input_cache_read: u64,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     total: u64,
+}
+
+/// Token counts from the new Kimi Code `usage.record` format (camelCase).
+#[derive(Debug, Default, Deserialize)]
+struct KimiCodeUsage {
+    #[serde(rename = "inputOther", default, deserialize_with = "jsonl::lenient_u64")]
+    input_other: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    #[serde(rename = "inputCacheCreation", default, deserialize_with = "jsonl::lenient_u64")]
+    input_cache_creation: u64,
+    #[serde(rename = "inputCacheRead", default, deserialize_with = "jsonl::lenient_u64")]
+    input_cache_read: u64,
 }
 
 #[derive(Debug, Clone)]
@@ -85,9 +108,8 @@ pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read(path)?;
-    // Usable Kimi wire lines are `StatusUpdate` records carrying a
-    // `token_usage` payload, so require both substrings before JSON parsing.
-    let prefilter = LinePrefilter::all(&[br#""StatusUpdate""#, br#""token_usage""#]);
+    // Match old format (StatusUpdate + token_usage) or new Kimi Code format (usage.record).
+    let prefilter = LinePrefilter::any(&[br#""token_usage""#, br#""usage.record""#]);
     Ok(jsonl::records::<KimiWireLine>(&content, Some(&prefilter))
         .filter_map(|line| wire_line_to_entry(&line, path, &model, fallback_timestamp))
         .collect::<Vec<_>>())
@@ -107,12 +129,24 @@ fn read_model_from_config(file_path: &Path) -> String {
 }
 
 fn kimi_root_from_wire_path(file_path: &Path) -> Option<PathBuf> {
-    file_path
-        .parent()?
-        .parent()?
-        .parent()?
-        .parent()
-        .map(Path::to_path_buf)
+    // Old: root/sessions/<group>/<session>/wire.jsonl       → 4 parents
+    // New: root/sessions/<ws>/<session>/agents/<agent>/wire.jsonl → 6 parents
+    let agent_dir = file_path.parent()?;
+    if agent_dir.parent()?.file_name()?.to_str() == Some("agents") {
+        agent_dir
+            .parent()?
+            .parent()?
+            .parent()?
+            .parent()
+            .map(Path::to_path_buf)
+    } else {
+        file_path
+            .parent()?
+            .parent()?
+            .parent()?
+            .parent()
+            .map(Path::to_path_buf)
+    }
 }
 
 fn file_modified_timestamp(path: &Path) -> TimestampMs {
@@ -131,29 +165,84 @@ fn wire_line_to_entry(
     model: &str,
     fallback_timestamp: TimestampMs,
 ) -> Option<KimiUsageEntry> {
-    if line.r#type.as_deref() == Some("metadata") {
+    match line.r#type.as_deref() {
+        Some("usage.record") => wire_line_to_entry_new(line, file_path, fallback_timestamp),
+        Some("metadata") => None,
+        _ => wire_line_to_entry_old(line, file_path, model, fallback_timestamp),
+    }
+}
+
+/// Parse a new Kimi Code `usage.record` line (camelCase, ms timestamp, top-level usage).
+fn wire_line_to_entry_new(
+    line: &KimiWireLine,
+    file_path: &Path,
+    fallback_timestamp: TimestampMs,
+) -> Option<KimiUsageEntry> {
+    // Only aggregate turn-level records; session records are cumulative totals.
+    if line.usage_scope.as_deref() != Some("turn") {
         return None;
     }
+    let usage_counts = line.usage.as_ref()?;
+    let usage = TokenUsageRaw {
+        input_tokens: usage_counts.input_other,
+        output_tokens: usage_counts.output,
+        cache_creation_input_tokens: usage_counts.input_cache_creation,
+        cache_read_input_tokens: usage_counts.input_cache_read,
+        speed: None,
+        cache_creation: None,
+    };
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, 0);
+    if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
+        return None;
+    }
+    let timestamp = line
+        .time
+        .map(TimestampMs::from_millis)
+        .unwrap_or(fallback_timestamp);
+    // Strip the "kimi-code/" namespace prefix so pricing lookup uses the bare model name.
+    let model = line
+        .model
+        .as_deref()
+        .unwrap_or(DEFAULT_MODEL)
+        .strip_prefix("kimi-code/")
+        .unwrap_or(line.model.as_deref().unwrap_or(DEFAULT_MODEL))
+        .to_string();
+    Some(KimiUsageEntry {
+        timestamp,
+        timestamp_text: crate::format_rfc3339_millis(timestamp),
+        session_id: extract_session_id(file_path),
+        model,
+        message_id: None,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens,
+        extra_total_tokens,
+    })
+}
+
+/// Parse an old Kimi CLI `StatusUpdate` line (snake_case, seconds timestamp, nested message).
+fn wire_line_to_entry_old(
+    line: &KimiWireLine,
+    file_path: &Path,
+    model: &str,
+    fallback_timestamp: TimestampMs,
+) -> Option<KimiUsageEntry> {
     let message = line.message.as_ref()?;
     if message.r#type.as_deref() != Some("StatusUpdate") {
         return None;
     }
     let payload = message.payload.as_ref()?;
     let token_usage = payload.token_usage.as_ref()?;
-    let input_tokens = token_usage.input_other;
-    let output_tokens = token_usage.output;
-    let cache_creation_tokens = token_usage.input_cache_creation;
-    let cache_read_tokens = token_usage.input_cache_read;
-    let total_tokens = token_usage.total;
     let usage = TokenUsageRaw {
-        input_tokens,
-        output_tokens,
-        cache_creation_input_tokens: cache_creation_tokens,
-        cache_read_input_tokens: cache_read_tokens,
+        input_tokens: token_usage.input_other,
+        output_tokens: token_usage.output,
+        cache_creation_input_tokens: token_usage.input_cache_creation,
+        cache_read_input_tokens: token_usage.input_cache_read,
         speed: None,
         cache_creation: None,
     };
-    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, token_usage.total);
     if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
         return None;
     }
@@ -187,8 +276,20 @@ fn timestamp_from_seconds(seconds: f64) -> Option<TimestampMs> {
 }
 
 fn extract_session_id(file_path: &Path) -> String {
-    file_path
-        .parent()
+    // Old: sessions/<group>/<session>/wire.jsonl       → parent = session dir
+    // New: sessions/<ws>/<session>/agents/<agent>/wire.jsonl → go up 3 levels
+    let parent = file_path.parent();
+    let session_dir = if parent
+        .and_then(|p| p.parent())
+        .and_then(Path::file_name)
+        .and_then(|n| n.to_str())
+        == Some("agents")
+    {
+        parent.and_then(|p| p.parent()).and_then(|p| p.parent())
+    } else {
+        parent
+    };
+    session_dir
         .and_then(Path::file_name)
         .and_then(|name| name.to_str())
         .filter(|name| !name.is_empty())

--- a/rust/crates/ccusage/src/adapter/kimi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/paths.rs
@@ -28,9 +28,11 @@ pub(super) fn paths() -> Result<Vec<PathBuf>> {
     }
 
     if let Some(home) = crate::home::home_dir() {
-        let path = home.join(".kimi");
-        if path.is_dir() && seen.insert(path.clone()) {
-            paths.push(path);
+        for dir in [".kimi", ".kimi-code"] {
+            let path = home.join(dir);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
         }
     }
     Ok(paths)
@@ -60,11 +62,15 @@ fn is_kimi_wire_file(sessions_path: &Path, file_path: &Path) -> bool {
     let Ok(relative) = file_path.strip_prefix(sessions_path) else {
         return false;
     };
-    relative
-        .components()
-        .filter(|component| matches!(component, Component::Normal(_)))
-        .count()
-        == 3
+    // Old format: sessions/<group>/<session>/wire.jsonl             → 3 components
+    // New format: sessions/<workspace>/<session>/agents/<agent>/wire.jsonl → 5 components
+    matches!(
+        relative
+            .components()
+            .filter(|component| matches!(component, Component::Normal(_)))
+            .count(),
+        3 | 5
+    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1357, related to #1261.

Kimi Code (`~/.kimi-code`) uses a different wire format than the old Kimi CLI and the adapter didn't handle it. Changes:

- Add `~/.kimi-code` as a default search directory alongside `~/.kimi`
- Accept the deeper path layout (`sessions/<ws>/<session>/agents/<agent>/wire.jsonl`, 5 components vs 3)
- Parse `usage.record` events: top-level camelCase token fields, millisecond `time` field, and `model` with `kimi-code/` prefix stripped for pricing lookup
- Skip `usageScope:"session"` records (cumulative totals) to avoid double-counting; only sum `"turn"` records
- Old `StatusUpdate` / snake_case format is unchanged

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784743772&installation_id=139163553&pr_number=1360&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1360&signature=295d9f036382d75993055eb44fe1c2ad66518a7188c304c736318dbe755f3504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for Kimi Code’s new wire format so usage from Code sessions is parsed and priced correctly, while keeping the old Kimi CLI format working.

- **Bug Fixes**
  - Discover `wire.jsonl` in `~/.kimi-code` and the deeper path `sessions/<ws>/<session>/agents/<agent>/wire.jsonl`.
  - Parse `type:"usage.record"` with camelCase token fields and millisecond `time`.
  - Strip the `kimi-code/` prefix from `model` for pricing lookup.
  - Ignore `usageScope:"session"` (cumulative) records; sum only `"turn"` records.
  - Preserve support for old `StatusUpdate` + snake_case format.

<sup>Written for commit 096014d9a59634050b7f9e4014b6f4a5e7e7f0e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for parsing Kimi Code `usage.record` format alongside legacy format
  * Enhanced wire file discovery to support new directory structure layouts

* **Tests**
  * Added unit tests validating Kimi code usage record parsing and wire file discovery in nested directories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->