### PR TITLE
fix(kimi): support Kimi Code new wire format

### DIFF
--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -19,7 +19,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `GOOSE_PATH_ROOT`                 | Goose        | Standard Goose data roots          |
 | `OPENCLAW_DIR`                    | OpenClaw     | `~/.openclaw`                      |
 | `KILO_DATA_DIR`                   | Kilo         | `~/.local/share/kilo`              |
-| `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`                          |
+| `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`, `~/.kimi-code`          |
 | `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                          |
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI  | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI   | `~/.gemini/tmp`                    |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -172,7 +172,7 @@ If ccusage shows no data, check:
    - pi-agent: `${PI_AGENT_DIR:-~/.pi/agent/sessions}`
    - Goose: standard Goose data roots or `GOOSE_PATH_ROOT`
    - Kilo: `${KILO_DATA_DIR:-~/.local/share/kilo}`
-   - Kimi: `${KIMI_DATA_DIR:-~/.kimi}`
+   - Kimi: `${KIMI_DATA_DIR:-~/.kimi}` (also scans `~/.kimi-code`)
    - OpenClaw: `${OPENCLAW_DIR:-~/.openclaw}` (also scans `~/.clawdbot`, `~/.moltbot`, `~/.moldbot`)
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,23 +72,23 @@ Each data source page covers the details that only apply to that source, includi
 
 ccusage reads from local coding CLI data directories:
 
-| Agent        | ID         | Default data location                           |
-| ------------ | ---------- | ----------------------------------------------- |
-| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`      |
-| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                       |
-| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}` |
-| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`           |
-| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`    |
-| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`      |
-| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`            |
-| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`         |
-| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`  |
-| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
-| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
-| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
-| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
-| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                       |
-| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`             |
+| Agent        | ID         | Default data location                             |
+| ------------ | ---------- | ------------------------------------------------- |
+| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`        |
+| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                         |
+| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`   |
+| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`             |
+| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`      |
+| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`        |
+| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`              |
+| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`           |
+| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`    |
+| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                    |
+| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`           |
+| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`) |
+| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
+| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
+| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.

--- a/docs/guide/kimi/index.md
+++ b/docs/guide/kimi/index.md
@@ -22,7 +22,7 @@ ccusage daily
 
 ## Data Location
 
-The CLI reads Kimi wire JSONL files from `KIMI_DATA_DIR` (defaults to `~/.kimi`). `KIMI_DATA_DIR` can be one directory or a comma-separated list of directories.
+The CLI reads Kimi wire JSONL files from `KIMI_DATA_DIR` (defaults to `~/.kimi` and `~/.kimi-code`). `KIMI_DATA_DIR` can be one directory or a comma-separated list of directories.
 
 ```sh
 KIMI_DATA_DIR="$HOME/.kimi,/backup/kimi" ccusage kimi daily
@@ -32,6 +32,7 @@ Expected files are discovered under:
 
 ```text
 ~/.kimi/sessions/<group-id>/<session-id>/wire.jsonl
+~/.kimi-code/sessions/<workspace-id>/<session-id>/agents/<agent-id>/wire.jsonl
 ```
 
 ## Supported Reports
@@ -44,12 +45,12 @@ Expected files are discovered under:
 
 ## Token Mapping
 
-- **Input tokens** - `token_usage.input_other`
-- **Output tokens** - `token_usage.output`
-- **Cache read tokens** - `token_usage.input_cache_read`
-- **Cache creation tokens** - `token_usage.input_cache_creation`
+- **Input tokens** - `token_usage.input_other` (or `usage.inputOther` in Kimi Code logs)
+- **Output tokens** - `token_usage.output` (or `usage.output`)
+- **Cache read tokens** - `token_usage.input_cache_read` (or `usage.inputCacheRead`)
+- **Cache creation tokens** - `token_usage.input_cache_creation` (or `usage.inputCacheCreation`)
 
-Only `StatusUpdate` messages with non-zero token usage are included.
+Only `StatusUpdate` messages with non-zero token usage are included. Kimi Code logs instead emit `usage.record` lines; only turn-scoped records are counted, since session-scoped records are cumulative totals.
 
 ## Cost Calculation
 
@@ -64,5 +65,5 @@ Kimi rows do not store recorded USD cost, so ccusage estimates cost from token c
 ## Troubleshooting
 
 ::: details No Kimi usage data found
-Ensure the data directory exists at `~/.kimi/sessions/`. Set `KIMI_DATA_DIR` if your Kimi data lives elsewhere or in multiple archive roots.
+Ensure the data directory exists at `~/.kimi/sessions/` or `~/.kimi-code/sessions/`. Set `KIMI_DATA_DIR` if your Kimi data lives elsewhere or in multiple archive roots.
 :::

--- a/rust/crates/ccusage/src/adapter/kimi/loader.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/loader.rs
@@ -87,6 +87,31 @@ mod tests {
     }
 
     #[test]
+    fn loads_kimi_code_usage_record_format() {
+        let fixture = fs_fixture!({
+            "sessions/workspace/session-b/agents/agent-1/wire.jsonl": [
+                r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":3064,"output":76,"inputCacheRead":14848,"inputCacheCreation":0},"usageScope":"turn","time":1782113184943}"#,
+                r#"{"type":"usage.record","model":"kimi-code/kimi-for-coding","usage":{"inputOther":5000,"output":200,"inputCacheRead":20000,"inputCacheCreation":100},"usageScope":"session","time":1782113185000}"#,
+            ]
+            .join("\n"),
+        });
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1, "session-scoped record must be skipped");
+        assert_eq!(entries[0].session_id.as_ref(), "session-b");
+        assert_eq!(entries[0].model.as_deref(), Some("kimi-for-coding"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 3064);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 76);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 14848);
+        assert_eq!(entries[0].data.message.usage.cache_creation_input_tokens, 0);
+    }
+
+    #[test]
     fn skips_malformed_and_zero_token_wire_lines() {
         let fixture = fs_fixture!({
             "sessions/group/session-a/wire.jsonl": [

--- a/rust/crates/ccusage/src/adapter/kimi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/parser.rs
@@ -31,9 +31,22 @@ struct KimiConfig {
 struct KimiWireLine {
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     r#type: Option<String>,
+    // old format
     message: Option<KimiWireMessage>,
     #[serde(default, deserialize_with = "jsonl::lenient_f64")]
     timestamp: Option<f64>,
+    // new Kimi Code format
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model: Option<String>,
+    usage: Option<KimiCodeUsage>,
+    #[serde(
+        rename = "usageScope",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    usage_scope: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_i64")]
+    time: Option<i64>,
 }
 
 /// The `message` block carried by a Kimi wire line.
@@ -67,6 +80,30 @@ struct KimiTokenUsage {
     total: u64,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct KimiCodeUsage {
+    #[serde(
+        rename = "inputOther",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    input_other: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output: u64,
+    #[serde(
+        rename = "inputCacheCreation",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    input_cache_creation: u64,
+    #[serde(
+        rename = "inputCacheRead",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    input_cache_read: u64,
+}
+
 #[derive(Debug, Clone)]
 pub(super) struct KimiUsageEntry {
     timestamp: TimestampMs,
@@ -85,9 +122,8 @@ pub(super) fn read_wire_file(path: &Path) -> Result<Vec<KimiUsageEntry>> {
     let model = read_model_from_config(path);
     let fallback_timestamp = file_modified_timestamp(path);
     let content = fs::read(path)?;
-    // Usable Kimi wire lines are `StatusUpdate` records carrying a
-    // `token_usage` payload, so require both substrings before JSON parsing.
-    let prefilter = LinePrefilter::all(&[br#""StatusUpdate""#, br#""token_usage""#]);
+    // Usable Kimi wire lines carry either `token_usage` (old format) or `usage.record` (new).
+    let prefilter = LinePrefilter::any(&[br#""token_usage""#, br#""usage.record""#]);
     Ok(jsonl::records::<KimiWireLine>(&content, Some(&prefilter))
         .filter_map(|line| wire_line_to_entry(&line, path, &model, fallback_timestamp))
         .collect::<Vec<_>>())
@@ -107,12 +143,25 @@ fn read_model_from_config(file_path: &Path) -> String {
 }
 
 fn kimi_root_from_wire_path(file_path: &Path) -> Option<PathBuf> {
-    file_path
-        .parent()?
-        .parent()?
-        .parent()?
-        .parent()
-        .map(Path::to_path_buf)
+    // Old layout: root/sessions/<group>/<session>/wire.jsonl
+    // New layout: root/sessions/<ws>/<session>/agents/<agent>/wire.jsonl
+    let agent_dir = file_path.parent()?;
+    if agent_dir.parent()?.file_name()?.to_str() == Some("agents") {
+        agent_dir
+            .parent()?
+            .parent()?
+            .parent()?
+            .parent()?
+            .parent()
+            .map(Path::to_path_buf)
+    } else {
+        file_path
+            .parent()?
+            .parent()?
+            .parent()?
+            .parent()
+            .map(Path::to_path_buf)
+    }
 }
 
 fn file_modified_timestamp(path: &Path) -> TimestampMs {
@@ -131,29 +180,79 @@ fn wire_line_to_entry(
     model: &str,
     fallback_timestamp: TimestampMs,
 ) -> Option<KimiUsageEntry> {
-    if line.r#type.as_deref() == Some("metadata") {
+    match line.r#type.as_deref() {
+        Some("usage.record") => wire_line_to_entry_new(line, file_path, fallback_timestamp),
+        Some("metadata") => None,
+        _ => wire_line_to_entry_old(line, file_path, model, fallback_timestamp),
+    }
+}
+
+fn wire_line_to_entry_new(
+    line: &KimiWireLine,
+    file_path: &Path,
+    fallback_timestamp: TimestampMs,
+) -> Option<KimiUsageEntry> {
+    // Only aggregate turn-level records; session records are cumulative totals.
+    if line.usage_scope.as_deref() != Some("turn") {
         return None;
     }
+    let usage_counts = line.usage.as_ref()?;
+    let usage = TokenUsageRaw {
+        input_tokens: usage_counts.input_other,
+        output_tokens: usage_counts.output,
+        cache_creation_input_tokens: usage_counts.input_cache_creation,
+        cache_read_input_tokens: usage_counts.input_cache_read,
+        speed: None,
+        cache_creation: None,
+    };
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, 0);
+    if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
+        return None;
+    }
+    let timestamp = line
+        .time
+        .map(TimestampMs::from_millis)
+        .unwrap_or(fallback_timestamp);
+    let model = line.model.as_deref().unwrap_or(DEFAULT_MODEL);
+    let model = model
+        .strip_prefix("kimi-code/")
+        .unwrap_or(model)
+        .to_string();
+    Some(KimiUsageEntry {
+        timestamp,
+        timestamp_text: crate::format_rfc3339_millis(timestamp),
+        session_id: extract_session_id(file_path),
+        model,
+        message_id: None,
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens,
+        extra_total_tokens,
+    })
+}
+
+fn wire_line_to_entry_old(
+    line: &KimiWireLine,
+    file_path: &Path,
+    model: &str,
+    fallback_timestamp: TimestampMs,
+) -> Option<KimiUsageEntry> {
     let message = line.message.as_ref()?;
     if message.r#type.as_deref() != Some("StatusUpdate") {
         return None;
     }
     let payload = message.payload.as_ref()?;
     let token_usage = payload.token_usage.as_ref()?;
-    let input_tokens = token_usage.input_other;
-    let output_tokens = token_usage.output;
-    let cache_creation_tokens = token_usage.input_cache_creation;
-    let cache_read_tokens = token_usage.input_cache_read;
-    let total_tokens = token_usage.total;
     let usage = TokenUsageRaw {
-        input_tokens,
-        output_tokens,
-        cache_creation_input_tokens: cache_creation_tokens,
-        cache_read_input_tokens: cache_read_tokens,
+        input_tokens: token_usage.input_other,
+        output_tokens: token_usage.output,
+        cache_creation_input_tokens: token_usage.input_cache_creation,
+        cache_read_input_tokens: token_usage.input_cache_read,
         speed: None,
         cache_creation: None,
     };
-    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
+    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, token_usage.total);
     if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
         return None;
     }
@@ -187,8 +286,20 @@ fn timestamp_from_seconds(seconds: f64) -> Option<TimestampMs> {
 }
 
 fn extract_session_id(file_path: &Path) -> String {
-    file_path
-        .parent()
+    // Old layout: sessions/<group>/<session>/wire.jsonl
+    // New layout: sessions/<ws>/<session>/agents/<agent>/wire.jsonl
+    let parent = file_path.parent();
+    let session_dir = if parent
+        .and_then(|p| p.parent())
+        .and_then(Path::file_name)
+        .and_then(|n| n.to_str())
+        == Some("agents")
+    {
+        parent.and_then(|p| p.parent()).and_then(|p| p.parent())
+    } else {
+        parent
+    };
+    session_dir
         .and_then(Path::file_name)
         .and_then(|name| name.to_str())
         .filter(|name| !name.is_empty())
@@ -327,6 +438,22 @@ fn kimi_for_coding_pricing_model(timestamp: TimestampMs) -> &'static str {
 mod tests {
     use super::*;
     use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn kimi_root_resolves_correctly_for_both_path_layouts() {
+        let fixture = fs_fixture!({
+            "sessions/group/session-a/wire.jsonl": "",
+            "sessions/ws/session-b/agents/agent-1/wire.jsonl": "",
+        });
+        let old_path = fixture.path("sessions/group/session-a/wire.jsonl");
+        let new_path = fixture.path("sessions/ws/session-b/agents/agent-1/wire.jsonl");
+
+        let old_root = kimi_root_from_wire_path(&old_path).unwrap();
+        let new_root = kimi_root_from_wire_path(&new_path).unwrap();
+
+        assert_eq!(old_root, fixture.root().to_path_buf());
+        assert_eq!(new_root, fixture.root().to_path_buf());
+    }
 
     #[test]
     fn falls_back_to_total_tokens_when_kimi_parts_are_missing() {

--- a/rust/crates/ccusage/src/adapter/kimi/paths.rs
+++ b/rust/crates/ccusage/src/adapter/kimi/paths.rs
@@ -28,9 +28,11 @@ pub(super) fn paths() -> Result<Vec<PathBuf>> {
     }
 
     if let Some(home) = crate::home::home_dir() {
-        let path = home.join(".kimi");
-        if path.is_dir() && seen.insert(path.clone()) {
-            paths.push(path);
+        for dir in [".kimi", ".kimi-code"] {
+            let path = home.join(dir);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
         }
     }
     Ok(paths)
@@ -60,11 +62,15 @@ fn is_kimi_wire_file(sessions_path: &Path, file_path: &Path) -> bool {
     let Ok(relative) = file_path.strip_prefix(sessions_path) else {
         return false;
     };
-    relative
-        .components()
-        .filter(|component| matches!(component, Component::Normal(_)))
-        .count()
-        == 3
+    // Old format: sessions/<group>/<session>/wire.jsonl             → 3 components
+    // New format: sessions/<workspace>/<session>/agents/<agent>/wire.jsonl → 5 components
+    matches!(
+        relative
+            .components()
+            .filter(|component| matches!(component, Component::Normal(_)))
+            .count(),
+        3 | 5
+    )
 }
 
 #[cfg(test)]
@@ -85,6 +91,25 @@ mod tests {
         assert_eq!(
             files,
             vec![fixture.path("sessions/group/session/wire.jsonl")]
+        );
+    }
+
+    #[test]
+    fn discovers_both_old_and_new_layouts_and_skips_non_wire_files() {
+        let fixture = fs_fixture!({
+            "sessions/ws/session-c/agents/agent-1/wire.jsonl": "{}\n",
+            "sessions/ws/session-c/agents/agent-1/other.jsonl": "{}\n",
+            "sessions/group/session-d/wire.jsonl": "{}\n",
+        });
+        let _cleanup = EnvVarGuard::set(KIMI_DATA_DIR_ENV, fixture.root());
+        let files = discover_wire_files().unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                fixture.path("sessions/group/session-d/wire.jsonl"),
+                fixture.path("sessions/ws/session-c/agents/agent-1/wire.jsonl"),
+            ]
         );
     }
 }


### PR DESCRIPTION
Fixes #1261

Kimi Code (`~/.kimi-code`) uses a new `wire.jsonl` format that the old adapter couldn't parse, so its usage was silently dropped. This adds support for the new format while keeping the old Kimi CLI format working.

## What changed

- Detect `~/.kimi-code` and the deeper layout `sessions/<ws>/<session>/agents/<agent>/wire.jsonl` (5 path components) alongside the legacy 3-component layout.
- Parse top-level `type == "usage.record"` lines: camelCase token fields (`inputOther`, `inputCacheRead`, `inputCacheCreation`), millisecond `time`, and `model` with the `kimi-code/` prefix stripped for pricing lookup.
- Skip cumulative `usageScope == "session"` records; only sum `"turn"` records to avoid double-counting.
- Deserialize `time` leniently so a float- or string-encoded timestamp degrades to the file-mtime fallback instead of dropping the whole line.
- Walk the correct number of parents in `kimi_root_from_wire_path` for the deeper layout so config resolution looks at the right root.
- Old `StatusUpdate` / snake_case format is unchanged.
- Update the Kimi guide and data-source docs for `~/.kimi-code`.

## Testing

- `cargo test --bin ccusage -- adapter::kimi` — 8 passing (parser, path discovery for both layouts, root resolution, aggregation).
- Verified against my own `~/.kimi-code` data: `ccusage kimi` now shows the previously-missing `kimi-for-coding` usage that 20.0.14 dropped.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1362"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784750957&installation_id=139163553&pr_number=1362&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1362&signature=f57ab320c966a6efd937fe8ed35da91f513beb0ad93c349050b36f5304d4aed5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for Kimi Code’s new `wire.jsonl` in `~/.kimi-code` and restore missing usage data while keeping the legacy Kimi format working. Fixes #1261.

- **Bug Fixes**
  - Detect `~/.kimi-code` and the deeper `sessions/<ws>/<session>/agents/<agent>/wire.jsonl` layout alongside legacy `~/.kimi` paths.
  - Parse `type: "usage.record"` entries with camelCase token fields and ms `time`; strip `kimi-code/` from `model` for pricing.
  - Aggregate only turn-scoped records and skip session-scoped totals to avoid double counting; fall back to file mtime if `time` is malformed.
  - Resolve the correct root in `kimi_root_from_wire_path` for the deeper layout; keep `StatusUpdate` parsing unchanged; update docs to include `~/.kimi-code`.

<sup>Written for commit ccddf6b69259d93b7a49106e940b740d0626bc53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1362?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated environment variable guides and troubleshooting sections to reference support for additional data directory locations
  * Expanded data sources reference tables to document extended directory scanning behavior
  * Clarified token counting methodology across different record types

* **Improvements**
  * Enhanced wire log parsing to support multiple record formats and directory layouts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->