### PR TITLE
fix(codex): skip forked session replay history

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -973,6 +973,174 @@ mod tests {
     }
 
     #[test]
+    fn skips_replayed_parent_token_history_in_forked_session_files() {
+        let fixture = fs_fixture!({
+            "2026-05-12T08-00-00-parent.jsonl": [
+                json!({
+                    "timestamp": "2026-05-12T08:00:00.000Z",
+                    "type": "turn_context",
+                    "payload": {"model": "gpt-5.2"},
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-12T08:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 100,
+                                "output_tokens": 200,
+                                "total_tokens": 1_200,
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 100,
+                                "output_tokens": 200,
+                                "total_tokens": 1_200,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-12T08:02:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 500,
+                                "cached_input_tokens": 50,
+                                "output_tokens": 100,
+                                "total_tokens": 600,
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 1_500,
+                                "cached_input_tokens": 150,
+                                "output_tokens": 300,
+                                "total_tokens": 1_800,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+            "2026-05-12T08-03-00-fork.jsonl": [
+                json!({
+                    "timestamp": "2026-05-12T08:03:00.000Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "fork-abc",
+                        "forked_from_id": "parent-xyz",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-12T08:03:00.000Z",
+                    "type": "session_meta",
+                    "payload": {"id": "parent-xyz"},
+                })
+                .to_string(),
+                // replayed parent history with timestamps rewritten to fork creation time
+                json!({
+                    "timestamp": "2026-05-12T08:03:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 100,
+                                "output_tokens": 200,
+                                "total_tokens": 1_200,
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 1_000,
+                                "cached_input_tokens": 100,
+                                "output_tokens": 200,
+                                "total_tokens": 1_200,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-12T08:03:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 500,
+                                "cached_input_tokens": 50,
+                                "output_tokens": 100,
+                                "total_tokens": 600,
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 1_500,
+                                "cached_input_tokens": 150,
+                                "output_tokens": 300,
+                                "total_tokens": 1_800,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+                // fork's own entry
+                json!({
+                    "timestamp": "2026-05-12T08:04:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 100,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 20,
+                                "total_tokens": 120,
+                            },
+                            "total_token_usage": {
+                                "input_tokens": 100,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 20,
+                                "total_tokens": 120,
+                            },
+                            "model": "gpt-5.2",
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        for single_thread in [true, false] {
+            let events = load_codex_events_from_directory(fixture.root(), single_thread).unwrap();
+
+            assert_eq!(
+                events.len(),
+                3,
+                "expected 3 events (2 parent + 1 fork real), got {} with single_thread={}",
+                events.len(),
+                single_thread
+            );
+
+            let fork_events: Vec<_> = events
+                .iter()
+                .filter(|event| event.session_id.contains("fork"))
+                .collect();
+            assert_eq!(fork_events.len(), 1);
+            assert_eq!(fork_events[0].input_tokens, 100);
+            assert_eq!(fork_events[0].cached_input_tokens, 10);
+            assert_eq!(fork_events[0].output_tokens, 20);
+            assert_eq!(fork_events[0].total_tokens, 120);
+        }
+    }
+
+    #[test]
     fn keeps_cumulative_baseline_when_skipping_subagent_replay() {
         let fixture = fs_fixture!({
             "2026-05-12T08-03-00-subagent.jsonl": [

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -34,6 +34,8 @@ static PROMPT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""prompt_tokens":"#));
 static THREAD_SPAWN_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(b"thread_spawn"));
+static FORKED_FROM_ID_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(b"forked_from_id"));
 
 const CODEX_AUTO_REVIEW_MODEL: &str = "codex-auto-review";
 const CODEX_AUTO_REVIEW_FALLBACKS_JSON: &str = include_str!("codex-auto-review-fallbacks.json");
@@ -62,7 +64,7 @@ struct CodexExecTimestamps {
     model: String,
 }
 
-fn is_codex_subagent_session(path: &Path) -> bool {
+fn is_codex_replay_session(path: &Path) -> bool {
     let Ok(mut file) = fs::File::open(path) else {
         return false;
     };
@@ -70,10 +72,10 @@ fn is_codex_subagent_session(path: &Path) -> bool {
     let Ok(n) = file.read(&mut buf) else {
         return false;
     };
-    THREAD_SPAWN_FINDER.find(&buf[..n]).is_some()
+    THREAD_SPAWN_FINDER.find(&buf[..n]).is_some() || FORKED_FROM_ID_FINDER.find(&buf[..n]).is_some()
 }
 
-fn detect_subagent_replay_second(path: &Path) -> Option<[u8; 19]> {
+fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
     let Ok(file) = fs::File::open(path) else {
         return None;
     };
@@ -138,9 +140,9 @@ pub(super) fn visit_codex_session_file(
     path: &Path,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let is_subagent = is_codex_subagent_session(path);
-    let replay_second = is_subagent
-        .then(|| detect_subagent_replay_second(path))
+    let is_replay_session = is_codex_replay_session(path);
+    let replay_second = is_replay_session
+        .then(|| detect_replay_second(path))
         .flatten();
     let Ok(file) = fs::File::open(path) else {
         return Ok(());


### PR DESCRIPTION
Summary:
- Treat Codex Desktop forked session logs as replay candidates when they contain `forked_from_id` metadata.
- Reuse the existing replay-prefix skipping path so copied parent `token_count` history is not counted again under the fork timestamp.
- Add a regression test covering forked sessions whose parent history timestamps are rewritten to the fork creation time.

Testing:
- `cargo fmt --manifest-path /Users/zilliz/.config/superpowers/worktrees/ccusage/fix-codex-fork-usage-dedupe/rust/Cargo.toml --all --check`
- `cargo test --manifest-path /Users/zilliz/.config/superpowers/worktrees/ccusage/fix-codex-fork-usage-dedupe/rust/Cargo.toml --workspace`
- `cargo run --quiet --manifest-path /Users/zilliz/.config/superpowers/worktrees/ccusage/fix-codex-fork-usage-dedupe/rust/Cargo.toml -p ccusage --bin ccusage -- codex daily --since 2026-06-25 --until 2026-06-25 --json --no-cost`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784952251&installation_id=139163553&pr_number=1369&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1369&signature=40b351209061d8a6aa6bf0d07fb83de4acb733f33b2dbb25fd4f66627b2cdc37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent double-counting tokens in Codex Desktop when a session is forked. Forked session files are treated as replays so copied parent history is skipped.

- **Bug Fixes**
  - Detect replay sessions by scanning for `forked_from_id` and `thread_spawn`.
  - Skip replayed parent `token_count` entries in forked files, even when timestamps are rewritten to the fork time.
  - Added a regression test to ensure only the fork’s own usage is counted.

<sup>Written for commit e0697ce8296022e02ac7c707c150ac6b106ce953. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of forked session replays so any duplicated parent token history is ignored.
  * Corrected token usage reporting for forked sessions to reflect only the fork’s actual activity.
  * Enhanced replay detection to recognize additional fork-related markers for more consistent session loading.
* **Tests**
  * Added a regression test covering forked-session replay behavior to ensure token counts remain accurate in both single-threaded and parallel processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->