### PR TITLE
fix(cowork): add missing CLI entries and Windows default path

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -87,6 +87,7 @@ bunx ccusage statusline  # Claude Code status line for hooks (Beta)
 # Source-focused reports and options
 bunx ccusage claude daily --mode display
 bunx ccusage cowork daily
+bunx ccusage cowork monthly
 bunx ccusage cowork session
 bunx ccusage codex daily --speed fast
 bunx ccusage opencode weekly

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -30,6 +30,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Source             | Focused command example  |
 | ------------------ | ------------------------ |
 | Claude Code        | `ccusage claude daily`   |
+| Cowork             | `ccusage cowork daily`   |
 | Codex              | `ccusage codex daily`    |
 | OpenCode           | `ccusage opencode daily` |
 | Amp                | `ccusage amp daily`      |
@@ -85,6 +86,8 @@ bunx ccusage statusline  # Claude Code status line for hooks (Beta)
 
 # Source-focused reports and options
 bunx ccusage claude daily --mode display
+bunx ccusage cowork daily
+bunx ccusage cowork session
 bunx ccusage codex daily --speed fast
 bunx ccusage opencode weekly
 bunx ccusage amp session
@@ -124,7 +127,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -3246,6 +3246,452 @@
 					},
 					"type": "object"
 				},
+				"cowork": {
+					"additionalProperties": false,
+					"description": "Cowork configuration.",
+					"markdownDescription": "Cowork configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"defaults": {
 					"additionalProperties": false,
 					"description": "Default values for all-agent reports and legacy Claude commands.",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -69,6 +69,7 @@ export default defineConfig({
 					text: 'Data Sources',
 					items: [
 						{ text: 'Claude Code', link: '/guide/claude/' },
+						{ text: 'Cowork', link: '/guide/cowork/' },
 						{ text: 'Codex', link: '/guide/codex/' },
 						{ text: 'OpenCode', link: '/guide/opencode/' },
 						{ text: 'Amp', link: '/guide/amp/' },

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -25,7 +25,7 @@ ccusage daily --all
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. Unified daily, weekly, monthly, and session views include every supported source they can load. Focused views use a source namespace and vary by source.
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -25,7 +25,7 @@ ccusage daily --all
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |
@@ -40,6 +40,7 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | Source       | Namespace  | Example focused view      |
 | ------------ | ---------- | ------------------------- |
 | Claude Code  | `claude`   | `ccusage claude daily`    |
+| Cowork       | `cowork`   | `ccusage cowork daily`    |
 | Codex        | `codex`    | `ccusage codex daily`     |
 | OpenCode     | `opencode` | `ccusage opencode weekly` |
 | Amp          | `amp`      | `ccusage amp session`     |
@@ -62,6 +63,7 @@ Use a source namespace when you want source-specific options or when you are deb
 ```bash
 ccusage codex daily --speed fast
 ccusage claude daily --mode display
+ccusage cowork session
 ccusage opencode session --json
 ccusage amp monthly --compact
 ccusage droid session

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -1,6 +1,6 @@
 # Claude Code Data Source
 
-ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 
@@ -75,7 +75,7 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
-For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
+For Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -4,7 +4,7 @@
 
 > ⚠️ Codex log support is experimental while the Codex CLI log format continues to evolve.
 
-ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, Cowork, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -176,7 +176,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `cowork`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
 
 ```json
 {
@@ -201,6 +201,13 @@ Use data source namespaces to set defaults and report overrides. Supported names
 		"commands": {
 			"weekly": {
 				"timezone": "Europe/London"
+			}
+		}
+	},
+	"cowork": {
+		"commands": {
+			"session": {
+				"json": true
 			}
 		}
 	},
@@ -258,6 +265,7 @@ This configuration affects source-focused commands such as:
 
 ```bash
 ccusage codex daily
+ccusage cowork session
 ccusage opencode weekly
 ccusage droid daily
 ccusage codebuff daily

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -109,7 +109,7 @@ For individual developers working on multiple projects:
 
 ### Multiple Sources
 
-Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
+Configure Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
 
 ```json
 // ~/.config/claude/ccusage.json
@@ -122,6 +122,13 @@ Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-a
 		"commands": {
 			"daily": {
 				"instances": true
+			}
+		}
+	},
+	"cowork": {
+		"commands": {
+			"session": {
+				"json": true
 			}
 		}
 	},
@@ -140,7 +147,7 @@ Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-a
 }
 ```
 
-Source sections apply to focused commands such as `ccusage codex daily` and `ccusage amp session`. They are also used by unified reports such as `ccusage daily`, where each source receives its own merged options before data is loaded.
+Source sections apply to focused commands such as `ccusage cowork session`, `ccusage codex daily`, and `ccusage amp session`. They are also used by unified reports such as `ccusage daily`, where each source receives its own merged options before data is loaded.
 
 ### Team Collaboration
 

--- a/docs/guide/cowork/index.md
+++ b/docs/guide/cowork/index.md
@@ -21,8 +21,8 @@ Most users can start with unified reports such as `ccusage daily`. Add the `cowo
 
 ccusage discovers Cowork data from Claude Desktop's local agent mode sessions:
 
-| Source | Default path |
-| ------ | ------------ |
+| Source | Default path                                                     |
+| ------ | ---------------------------------------------------------------- |
 | Cowork | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
 
 The expected session layout is:
@@ -42,20 +42,20 @@ Cowork is intentionally separate from Claude Code in unified reports. If the sam
 
 ## Report Views
 
-| Focused view              | Description                    | See also                                |
-| ------------------------- | ------------------------------ | --------------------------------------- |
-| `ccusage cowork daily`    | Aggregate usage by date        | [Daily Usage](/guide/daily-reports)     |
-| `ccusage cowork monthly`  | Aggregate usage by month       | [Monthly Usage](/guide/monthly-reports) |
-| `ccusage cowork session`  | Group usage by Cowork session  | [Session Usage](/guide/session-reports) |
+| Focused view             | Description                   | See also                                |
+| ------------------------ | ----------------------------- | --------------------------------------- |
+| `ccusage cowork daily`   | Aggregate usage by date       | [Daily Usage](/guide/daily-reports)     |
+| `ccusage cowork monthly` | Aggregate usage by month      | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage cowork session` | Group usage by Cowork session | [Session Usage](/guide/session-reports) |
 
 Cowork does not expose a focused weekly command. Use `ccusage weekly` to include Cowork in the unified weekly report.
 
 ## Environment Variables
 
-| Variable             | Description |
-| -------------------- | ----------- |
-| `COWORK_CONFIG_DIR`  | Override Cowork data discovery |
-| `LOG_LEVEL`          | Adjust verbosity (0 silent ... 5 trace) |
+| Variable            | Description                             |
+| ------------------- | --------------------------------------- |
+| `COWORK_CONFIG_DIR` | Override Cowork data discovery          |
+| `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace) |
 
 ### Custom Cowork Paths
 

--- a/docs/guide/cowork/index.md
+++ b/docs/guide/cowork/index.md
@@ -1,0 +1,84 @@
+# Cowork Data Source
+
+ccusage can read Cowork local agent session logs from Claude Desktop as a separate supported data source. Cowork stores Claude-compatible `.claude/projects/**/*.jsonl` data under Claude Desktop's local agent session directory, so ccusage reuses the Claude parser but reports Cowork as its own `cowork` source.
+
+## Focused Views
+
+```bash
+# Daily Cowork usage
+ccusage cowork daily
+
+# Monthly Cowork usage
+ccusage cowork monthly
+
+# Cowork sessions
+ccusage cowork session
+```
+
+Most users can start with unified reports such as `ccusage daily`. Add the `cowork` namespace when you want to inspect Claude Desktop Cowork usage separately from Claude Code.
+
+## Data Source
+
+ccusage discovers Cowork data from Claude Desktop's local agent mode sessions:
+
+| Source | Default path |
+| ------ | ------------ |
+| Cowork | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
+
+The expected session layout is:
+
+```text
+local-agent-mode-sessions/
+`-- <workspace-id>/
+    `-- <session-id>/
+        `-- local_<id>/
+            `-- .claude/
+                `-- projects/
+                    `-- <project>/
+                        `-- <session>.jsonl
+```
+
+Cowork is intentionally separate from Claude Code in unified reports. If the same model or message IDs appear in both sources, ccusage keeps them under separate `claude` and `cowork` agent rows.
+
+## Report Views
+
+| Focused view              | Description                    | See also                                |
+| ------------------------- | ------------------------------ | --------------------------------------- |
+| `ccusage cowork daily`    | Aggregate usage by date        | [Daily Usage](/guide/daily-reports)     |
+| `ccusage cowork monthly`  | Aggregate usage by month       | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage cowork session`  | Group usage by Cowork session  | [Session Usage](/guide/session-reports) |
+
+Cowork does not expose a focused weekly command. Use `ccusage weekly` to include Cowork in the unified weekly report.
+
+## Environment Variables
+
+| Variable             | Description |
+| -------------------- | ----------- |
+| `COWORK_CONFIG_DIR`  | Override Cowork data discovery |
+| `LOG_LEVEL`          | Adjust verbosity (0 silent ... 5 trace) |
+
+### Custom Cowork Paths
+
+Set `COWORK_CONFIG_DIR` when Cowork logs live outside the default Claude Desktop path:
+
+```bash
+export COWORK_CONFIG_DIR="/path/to/local-agent-mode-sessions"
+ccusage cowork daily
+```
+
+The variable accepts comma-separated entries. Each entry can be:
+
+- a `local-agent-mode-sessions` root;
+- a concrete `.claude` config directory;
+- a `projects` directory inside a `.claude` config directory.
+
+```bash
+export COWORK_CONFIG_DIR="/path/to/local-agent-mode-sessions,/backup/cowork/.claude,/archive/cowork/.claude/projects"
+ccusage cowork monthly
+```
+
+## Troubleshooting
+
+::: details No Cowork usage data found
+Check whether Claude Desktop has created local agent sessions under `~/Library/Application Support/Claude/local-agent-mode-sessions`. If your data lives elsewhere, set `COWORK_CONFIG_DIR` to the session root, the nested `.claude` directory, or the nested `projects` directory.
+:::

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -14,6 +14,7 @@ ccusage daily
 ccusage
 
 # Focus on one source:
+ccusage cowork daily
 ccusage codex daily
 ccusage opencode daily
 ccusage amp daily

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -6,24 +6,24 @@ ccusage supports several environment variables for configuration and customizati
 
 ccusage detects supported data source files from conventional locations by default. Set these variables when your data lives somewhere else. Directory variables can be one directory or a comma-separated list of directories; the Copilot variable points at one explicit JSONL export file:
 
-| Variable                          | Agent        | Default                            |
-| --------------------------------- | ------------ | ---------------------------------- |
-| `CLAUDE_CONFIG_DIR`               | Claude Code  | `~/.config/claude` and `~/.claude` |
+| Variable                          | Agent        | Default                                                          |
+| --------------------------------- | ------------ | ---------------------------------------------------------------- |
+| `CLAUDE_CONFIG_DIR`               | Claude Code  | `~/.config/claude` and `~/.claude`                               |
 | `COWORK_CONFIG_DIR`               | Cowork       | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
-| `CODEX_HOME`                      | Codex        | `~/.codex`                         |
-| `OPENCODE_DATA_DIR`               | OpenCode     | `~/.local/share/opencode`          |
-| `AMP_DATA_DIR`                    | Amp          | `~/.local/share/amp`               |
-| `DROID_SESSIONS_DIR`              | Droid        | `~/.factory/sessions`              |
-| `CODEBUFF_DATA_DIR`               | Codebuff     | `~/.config/manicode`               |
-| `HERMES_HOME`                     | Hermes Agent | `~/.hermes`                        |
-| `PI_AGENT_DIR`                    | pi-agent     | `~/.pi/agent/sessions`             |
-| `GOOSE_PATH_ROOT`                 | Goose        | Standard Goose data roots          |
-| `OPENCLAW_DIR`                    | OpenClaw     | `~/.openclaw`                      |
-| `KILO_DATA_DIR`                   | Kilo         | `~/.local/share/kilo`              |
-| `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`                          |
-| `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                          |
-| `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI  | Explicit `.jsonl` file             |
-| `GEMINI_DATA_DIR`                 | Gemini CLI   | `~/.gemini/tmp`                    |
+| `CODEX_HOME`                      | Codex        | `~/.codex`                                                       |
+| `OPENCODE_DATA_DIR`               | OpenCode     | `~/.local/share/opencode`                                        |
+| `AMP_DATA_DIR`                    | Amp          | `~/.local/share/amp`                                             |
+| `DROID_SESSIONS_DIR`              | Droid        | `~/.factory/sessions`                                            |
+| `CODEBUFF_DATA_DIR`               | Codebuff     | `~/.config/manicode`                                             |
+| `HERMES_HOME`                     | Hermes Agent | `~/.hermes`                                                      |
+| `PI_AGENT_DIR`                    | pi-agent     | `~/.pi/agent/sessions`                                           |
+| `GOOSE_PATH_ROOT`                 | Goose        | Standard Goose data roots                                        |
+| `OPENCLAW_DIR`                    | OpenClaw     | `~/.openclaw`                                                    |
+| `KILO_DATA_DIR`                   | Kilo         | `~/.local/share/kilo`                                            |
+| `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`                                                        |
+| `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                                                        |
+| `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI  | Explicit `.jsonl` file                                           |
+| `GEMINI_DATA_DIR`                 | Gemini CLI   | `~/.gemini/tmp`                                                  |
 
 Example:
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -9,6 +9,7 @@ ccusage detects supported data source files from conventional locations by defau
 | Variable                          | Agent        | Default                            |
 | --------------------------------- | ------------ | ---------------------------------- |
 | `CLAUDE_CONFIG_DIR`               | Claude Code  | `~/.config/claude` and `~/.claude` |
+| `COWORK_CONFIG_DIR`               | Cowork       | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
 | `CODEX_HOME`                      | Codex        | `~/.codex`                         |
 | `OPENCODE_DATA_DIR`               | OpenCode     | `~/.local/share/opencode`          |
 | `AMP_DATA_DIR`                    | Amp          | `~/.local/share/amp`               |
@@ -28,6 +29,7 @@ Example:
 
 ```bash
 export CODEX_HOME="/path/to/codex,/archive/codex,/path/to/codex-exec-jsonl"
+export COWORK_CONFIG_DIR="/path/to/local-agent-mode-sessions,/archive/cowork/.claude"
 export OPENCODE_DATA_DIR="/path/to/opencode,/archive/opencode"
 export AMP_DATA_DIR="/path/to/amp,/archive/amp"
 export DROID_SESSIONS_DIR="/path/to/factory/sessions,/archive/factory/sessions"
@@ -49,6 +51,10 @@ Empty entries, directories that do not exist, and missing explicit files are ski
 ## CLAUDE_CONFIG_DIR
 
 Specifies where ccusage should look for Claude Code data. See [Claude Code](/guide/claude/) for default paths, multiple-directory behavior, and Claude-specific examples.
+
+## COWORK_CONFIG_DIR
+
+Specifies where ccusage should look for Cowork local agent session data. See [Cowork](/guide/cowork/) for the default Claude Desktop path and accepted override shapes.
 
 ## LOG_LEVEL
 
@@ -210,7 +216,7 @@ To see which environment variables are being used:
 
 ```bash
 # Show all environment variables
-env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
+env | grep -E "CLAUDE|COWORK|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
 
 # Debug mode shows environment variable usage
 LOG_LEVEL=4 ccusage daily --debug

--- a/docs/guide/gemini/index.md
+++ b/docs/guide/gemini/index.md
@@ -2,7 +2,7 @@
 
 > Gemini CLI support is experimental while the Gemini CLI log format continues to evolve.
 
-ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, and GitHub Copilot CLI.
+ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as Claude Code, Cowork, Codex, OpenCode, Amp, pi-agent, and GitHub Copilot CLI.
 
 ## Focused Views
 

--- a/docs/guide/gemini/index.md
+++ b/docs/guide/gemini/index.md
@@ -2,7 +2,7 @@
 
 > Gemini CLI support is experimental while the Gemini CLI log format continues to evolve.
 
-ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as Claude Code, Cowork, Codex, OpenCode, Amp, pi-agent, and GitHub Copilot CLI.
+ccusage can read Gemini CLI chat logs as one of its supported local data sources. Gemini uses the same unified and focused report model as other local sources; see [All Sources](/guide/all-reports) for the full list.
 
 ## Focused Views
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -45,6 +45,7 @@ Use a data source namespace when you want the same report focused on one source:
 
 ```bash
 ccusage claude daily
+ccusage cowork daily
 ccusage codex daily
 ccusage opencode weekly
 ccusage amp session
@@ -101,6 +102,7 @@ Now that you have your first unified view, explore these features:
 4. **[Session Usage](/guide/session-reports)** - Analyze individual conversations
 5. **[Configuration](/guide/configuration)** - Customize ccusage behavior
 6. **[Claude Code](/guide/claude/)** - Claude Code-specific setup and features
+7. **[Cowork](/guide/cowork/)** - Claude Desktop Cowork local agent sessions
 
 ## Common Use Cases
 
@@ -114,6 +116,7 @@ ccusage daily --since 2026-05-01 --until 2026-05-16
 
 ```bash
 ccusage codex daily
+ccusage cowork session
 ccusage claude monthly
 ```
 
@@ -163,6 +166,7 @@ If ccusage shows no data, check:
 1. **A supported coding CLI is installed and used** - ccusage reads from local usage files
 2. **Data directory exists** - Common locations:
    - Claude Code: `~/.config/claude/projects/` or `~/.claude/projects/`
+   - Cowork: `~/Library/Application Support/Claude/local-agent-mode-sessions`
    - Codex: `${CODEX_HOME:-~/.codex}`
    - OpenCode: `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`
    - Amp: `${AMP_DATA_DIR:-~/.local/share/amp}`
@@ -183,6 +187,7 @@ If your agent data is in a custom location, set the matching environment variabl
 
 ```bash
 export CLAUDE_CONFIG_DIR="/path/to/your/claude/data"
+export COWORK_CONFIG_DIR="/path/to/local-agent-mode-sessions"
 export CODEX_HOME="/path/to/codex"
 export OPENCODE_DATA_DIR="/path/to/opencode"
 export AMP_DATA_DIR="/path/to/amp"
@@ -202,6 +207,7 @@ Each source-specific path variable can also contain comma-separated directories:
 
 ```bash
 export CODEX_HOME="/path/to/codex,/archive/codex,/path/to/codex-exec-jsonl"
+export COWORK_CONFIG_DIR="/path/to/local-agent-mode-sessions,/archive/cowork/.claude"
 export OPENCODE_DATA_DIR="/path/to/opencode,/archive/opencode"
 export AMP_DATA_DIR="/path/to/amp,/archive/amp"
 export DROID_SESSIONS_DIR="/path/to/factory/sessions,/archive/factory/sessions"

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As Cowork, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -75,6 +75,7 @@ ccusage reads from local coding CLI data directories:
 | Agent        | ID         | Default data location                           |
 | ------------ | ---------- | ----------------------------------------------- |
 | Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`      |
+| Cowork       | `cowork`   | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
 | Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                       |
 | OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}` |
 | Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`           |
@@ -110,6 +111,7 @@ Add a data source namespace when you want the same report focused on one source:
 
 ```bash
 ccusage claude daily
+ccusage cowork daily
 ccusage codex daily --speed fast
 ccusage opencode weekly
 ccusage amp session
@@ -128,7 +130,7 @@ ccusage gemini daily
 
 Use `ccusage <source> <report>` only when you want to narrow a report to one source.
 
-For Claude Code-specific setup and features, start from the [Claude Code data source](/guide/claude/) page.
+For Claude Code-specific setup and features, start from the [Claude Code data source](/guide/claude/) page. For Claude Desktop local agent sessions, use the [Cowork data source](/guide/cowork/) page.
 
 ## Privacy & Security
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,24 +72,24 @@ Each data source page covers the details that only apply to that source, includi
 
 ccusage reads from local coding CLI data directories:
 
-| Agent        | ID         | Default data location                           |
-| ------------ | ---------- | ----------------------------------------------- |
-| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`      |
+| Agent        | ID         | Default data location                                            |
+| ------------ | ---------- | ---------------------------------------------------------------- |
+| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`                       |
 | Cowork       | `cowork`   | `~/Library/Application Support/Claude/local-agent-mode-sessions` |
-| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                       |
-| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}` |
-| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`           |
-| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`    |
-| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`      |
-| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`            |
-| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`         |
-| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`  |
-| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
-| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
-| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
-| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
-| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                       |
-| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`             |
+| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                                        |
+| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`                  |
+| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`                            |
+| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`                     |
+| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`                       |
+| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`                             |
+| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`                          |
+| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`                   |
+| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                                   |
+| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`                          |
+| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                                      |
+| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                                      |
+| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                                        |
+| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`                              |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.

--- a/docs/guide/kimi/index.md
+++ b/docs/guide/kimi/index.md
@@ -2,7 +2,7 @@
 
 > Kimi support is experimental. Expect breaking changes while both ccusage and [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) continue to evolve.
 
-ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as Claude Code, Cowork, Codex, OpenCode, Amp, pi-agent, GitHub Copilot CLI, and Gemini CLI.
 
 ## Usage
 

--- a/docs/guide/kimi/index.md
+++ b/docs/guide/kimi/index.md
@@ -2,7 +2,7 @@
 
 > Kimi support is experimental. Expect breaking changes while both ccusage and [Kimi CLI](https://github.com/MoonshotAI/kimi-cli) continue to evolve.
 
-ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as Claude Code, Cowork, Codex, OpenCode, Amp, pi-agent, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Kimi CLI wire logs as one of its supported local data sources. Kimi uses the same unified and focused report model as other local sources; see [All Sources](/guide/all-reports) for the full list.
 
 ## Usage
 

--- a/docs/guide/monthly-reports.md
+++ b/docs/guide/monthly-reports.md
@@ -6,6 +6,7 @@ Monthly usage aggregates coding (agent) CLI usage by calendar month, providing a
 
 ```bash
 ccusage monthly
+ccusage cowork monthly
 ccusage codex monthly
 ccusage amp monthly
 ccusage pi monthly

--- a/docs/guide/session-reports.md
+++ b/docs/guide/session-reports.md
@@ -6,6 +6,7 @@ Session usage shows usage grouped by individual conversations, threads, or sessi
 
 ```bash
 ccusage session
+ccusage cowork session
 ccusage codex session
 ccusage opencode session
 ccusage amp session

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: ccusage
   text: Coding (Agent) CLI Usage Analysis
-  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
+  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
   image:
     src: /logo.svg
     alt: ccusage logo
@@ -27,7 +27,7 @@ features:
     link: /guide/getting-started
   - icon: 📁
     title: Local Data Sources
-    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
+    details: Reads local usage logs from Claude Code, Cowork, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
     link: /guide/
   - icon: 💰
     title: Cost Analysis

--- a/docs/superpowers/plans/2026-06-01-cowork-usage-source.md
+++ b/docs/superpowers/plans/2026-06-01-cowork-usage-source.md
@@ -32,6 +32,7 @@
 ### Task 1: Add CLI Parser Support
 
 **Files:**
+
 - Modify: `rust/crates/ccusage-cli/src/types.rs`
 - Modify: `rust/crates/ccusage-cli/src/parser.rs`
 - Modify: `rust/crates/ccusage-cli/src/tests.rs`
@@ -137,6 +138,7 @@ git commit -m "feat(cowork): add CLI command parser"
 ### Task 2: Refactor Claude Loaders for Reuse
 
 **Files:**
+
 - Modify: `rust/crates/ccusage/src/adapter/claude/mod.rs`
 - Modify: `rust/crates/ccusage/src/adapter/claude/daily.rs`
 - Modify: `rust/crates/ccusage/src/adapter/claude/paths.rs`
@@ -385,6 +387,7 @@ git commit -m "refactor(claude): share compatible usage loaders"
 ### Task 3: Add Cowork Path Discovery
 
 **Files:**
+
 - Create: `rust/crates/ccusage/src/adapter/cowork/paths.rs`
 - Create: `rust/crates/ccusage/src/adapter/cowork/mod.rs`
 - Modify: `rust/crates/ccusage/src/adapter/mod.rs`
@@ -605,6 +608,7 @@ git commit -m "feat(cowork): discover local agent sessions"
 ### Task 4: Add Cowork Runtime Adapter
 
 **Files:**
+
 - Modify: `rust/crates/ccusage/src/adapter/cowork/mod.rs`
 - Modify: `rust/crates/ccusage/src/main.rs`
 - Modify: `rust/crates/ccusage/src/progress.rs`
@@ -945,6 +949,7 @@ git commit -m "feat(cowork): add usage report adapter"
 ### Task 5: Add Cowork to All-Agent Reports
 
 **Files:**
+
 - Modify: `rust/crates/ccusage/src/adapter/all/loader.rs`
 - Modify: `rust/crates/ccusage/src/adapter/all/tests.rs`
 
@@ -1080,6 +1085,7 @@ git commit -m "feat(cowork): include source in all-agent reports"
 ### Task 6: Add Source README and User-Facing Docs
 
 **Files:**
+
 - Create: `rust/crates/ccusage/src/adapter/cowork/README.md`
 - Modify: `README.md`
 - Modify: `apps/ccusage/README.md`
@@ -1170,6 +1176,7 @@ git commit -m "docs(cowork): document usage source"
 ### Task 7: Final Verification and Cleanup
 
 **Files:**
+
 - No planned source edits unless verification exposes issues.
 
 - [ ] **Step 1: Run formatter**

--- a/docs/superpowers/plans/2026-06-01-cowork-usage-source.md
+++ b/docs/superpowers/plans/2026-06-01-cowork-usage-source.md
@@ -1,0 +1,1241 @@
+# Cowork Usage Source Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Cowork as a separate `ccusage` agent source that reads Claude-compatible local agent session logs from Claude Desktop.
+
+**Architecture:** Cowork gets its own adapter, CLI command, progress label, and all-agent source id. Runtime parsing and aggregation reuse Claude-compatible loader helpers so Claude Code and Cowork do not drift. Cowork owns only path discovery and command wiring.
+
+**Tech Stack:** Rust 2021, `ccusage-cli`, `ccusage` native CLI, fixture-backed Rust tests, existing `pnpm` repository scripts.
+
+---
+
+## File Structure
+
+- Modify `rust/crates/ccusage-cli/src/types.rs`: add `Command::Cowork`.
+- Modify `rust/crates/ccusage-cli/src/parser.rs`: parse `ccusage cowork [daily|monthly|session]`.
+- Modify `rust/crates/ccusage-cli/src/tests.rs`: parser snapshots and command parsing tests.
+- Modify `rust/crates/ccusage/src/main.rs`: dispatch `Command::Cowork`.
+- Modify `rust/crates/ccusage/src/progress.rs`: add `UsageLoadAgent::Cowork`.
+- Modify `rust/crates/ccusage/src/adapter/mod.rs`: register `cowork`.
+- Modify `rust/crates/ccusage/src/adapter/claude/mod.rs`: expose Claude-compatible loader helpers that accept explicit config paths.
+- Modify `rust/crates/ccusage/src/adapter/claude/daily.rs`: expose daily summary helper that accepts explicit config paths.
+- Modify `rust/crates/ccusage/src/adapter/claude/paths.rs`: make path normalization helpers reusable inside the adapter tree.
+- Create `rust/crates/ccusage/src/adapter/cowork/mod.rs`: Cowork command runtime.
+- Create `rust/crates/ccusage/src/adapter/cowork/paths.rs`: Cowork source discovery and env override handling.
+- Create `rust/crates/ccusage/src/adapter/cowork/README.md`: source-specific notes.
+- Modify `rust/crates/ccusage/src/adapter/all/loader.rs`: include Cowork in all-agent reports.
+- Modify docs that list supported agents: `README.md`, `apps/ccusage/README.md`, and relevant `docs/guide/` pages found by `rg -n "Claude Code|Codex|OpenCode|supported|agent" README.md apps/ccusage/README.md docs/guide`.
+
+---
+
+### Task 1: Add CLI Parser Support
+
+**Files:**
+- Modify: `rust/crates/ccusage-cli/src/types.rs`
+- Modify: `rust/crates/ccusage-cli/src/parser.rs`
+- Modify: `rust/crates/ccusage-cli/src/tests.rs`
+
+- [ ] **Step 1: Write failing parser tests**
+
+Add these tests near the existing agent command tests in `rust/crates/ccusage-cli/src/tests.rs`:
+
+```rust
+#[test]
+fn parses_cowork_default_command() {
+    let cli = parse(["ccusage", "cowork"]);
+    let Some(Command::Cowork(args)) = cli.command else {
+        panic!("expected Cowork command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+}
+
+#[test]
+fn parses_cowork_report_commands() {
+    for (report, expected) in [
+        ("daily", AgentReportKind::Daily),
+        ("monthly", AgentReportKind::Monthly),
+        ("session", AgentReportKind::Session),
+    ] {
+        let cli = parse(["ccusage", "cowork", report]);
+        let Some(Command::Cowork(args)) = cli.command else {
+            panic!("expected Cowork command for {report}");
+        };
+        assert_eq!(args.kind, expected);
+    }
+}
+
+#[test]
+fn rejects_unknown_cowork_report_command() {
+    let error = parse_err(["ccusage", "cowork", "weekly"]);
+    assert_eq!(error, "Unknown cowork command 'weekly'");
+}
+```
+
+Also extend the existing command snapshot match:
+
+```rust
+Some(Command::Cowork(args)) => agent_command_snapshot("cowork", args),
+```
+
+- [ ] **Step 2: Run parser tests and verify failure**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage-cli cowork -- --nocapture
+```
+
+Expected: FAIL because `Command::Cowork` does not exist.
+
+- [ ] **Step 3: Add the Cowork command variant**
+
+In `rust/crates/ccusage-cli/src/types.rs`, add:
+
+```rust
+Cowork(AgentCommandArgs),
+```
+
+near the other agent command variants.
+
+- [ ] **Step 4: Parse the cowork command**
+
+In `rust/crates/ccusage-cli/src/parser.rs`, add this match arm next to the other standard agent commands:
+
+```rust
+"cowork" => parse_basic_agent_command(
+    parser,
+    shared,
+    "cowork",
+    STANDARD_AGENT_REPORTS,
+    Command::Cowork,
+),
+```
+
+- [ ] **Step 5: Run parser tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage-cli cowork -- --nocapture
+```
+
+Expected: PASS for Cowork parser tests.
+
+- [ ] **Step 6: Commit CLI parser support**
+
+Run:
+
+```bash
+git add rust/crates/ccusage-cli/src/types.rs rust/crates/ccusage-cli/src/parser.rs rust/crates/ccusage-cli/src/tests.rs
+git diff --staged
+git commit -m "feat(cowork): add CLI command parser"
+```
+
+---
+
+### Task 2: Refactor Claude Loaders for Reuse
+
+**Files:**
+- Modify: `rust/crates/ccusage/src/adapter/claude/mod.rs`
+- Modify: `rust/crates/ccusage/src/adapter/claude/daily.rs`
+- Modify: `rust/crates/ccusage/src/adapter/claude/paths.rs`
+
+- [ ] **Step 1: Add failing helper-level tests**
+
+Add a test in `rust/crates/ccusage/src/main.rs` near the existing Claude loader tests:
+
+```rust
+#[test]
+fn loads_claude_compatible_entries_from_explicit_config_paths() {
+    let fixture = fs_fixture!({
+        "config-a/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        "config-b/projects/project-b/session-b.jsonl": r#"{"timestamp":"2025-01-11T10:00:00.000Z","message":{"id":"msg_b","model":"claude-sonnet-4-20250514","usage":{"input_tokens":20,"output_tokens":30,"cache_creation_input_tokens":4,"cache_read_input_tokens":2}},"requestId":"req_b","costUSD":0.04}"#,
+    });
+    let shared = SharedArgs {
+        mode: CostMode::Display,
+        timezone: Some("UTC".to_string()),
+        ..SharedArgs::default()
+    };
+
+    let entries = adapter::claude::load_entries_from_paths(
+        &shared,
+        &[fixture.path("config-a"), fixture.path("config-b")],
+        None,
+        "Test",
+    )
+    .unwrap();
+    let daily = adapter::claude::load_daily_summaries_from_paths(
+        &shared,
+        &[fixture.path("config-a"), fixture.path("config-b")],
+        None,
+        false,
+    )
+    .unwrap();
+
+    assert_eq!(entries.len(), 2);
+    assert_eq!(daily.len(), 2);
+    assert_eq!(entries[0].project.as_ref(), "project-a");
+    assert_eq!(entries[1].project.as_ref(), "project-b");
+}
+```
+
+- [ ] **Step 2: Run the targeted test and verify failure**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage loads_claude_compatible_entries_from_explicit_config_paths -- --nocapture
+```
+
+Expected: FAIL because `load_entries_from_paths` and `load_daily_summaries_from_paths` do not exist.
+
+- [ ] **Step 3: Expose explicit-path loader helpers**
+
+In `rust/crates/ccusage/src/adapter/claude/mod.rs`, keep `load_entries` unchanged externally, but route it through a new helper:
+
+```rust
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+) -> Result<Vec<LoadedEntry>> {
+    progress::track_usage_load(progress::UsageLoadAgent::Claude, shared.json, || {
+        let paths = claude_paths()?;
+        load_entries_from_paths(shared, &paths, project_filter, "Claude")
+    })
+}
+
+pub(crate) fn load_entries_from_paths(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    debug_label: &str,
+) -> Result<Vec<LoadedEntry>> {
+    load_entries_inner(shared, paths, project_filter, debug_label)
+}
+
+fn load_entries_inner(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    debug_label: &str,
+) -> Result<Vec<LoadedEntry>> {
+    debug_log(
+        shared,
+        format!(
+            "Scanning {debug_label} data directories: {}",
+            paths
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    );
+    let files = usage_files(paths, project_filter);
+    debug_log(shared, format!("Found {} JSONL usage files", files.len()));
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let pricing = if shared.mode == CostMode::Display {
+        None
+    } else {
+        Some(PricingMap::load(shared.offline, log_level() != Some(0)))
+    };
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mode = shared.mode;
+    let loaded_files = if shared.single_thread {
+        files
+            .iter()
+            .map(|file| read_usage_file(file, tz.as_ref(), mode, pricing.as_ref()))
+            .collect::<Vec<_>>()
+    } else {
+        read_usage_files_parallel(&files, tz.as_ref(), mode, pricing.as_ref())
+    };
+    let loaded_entry_count = loaded_files
+        .iter()
+        .map(|file| file.entries.len())
+        .sum::<usize>();
+    debug_log(
+        shared,
+        format!(
+            "Loaded {loaded_entry_count} usage entries from {} JSONL files",
+            loaded_files.len()
+        ),
+    );
+
+    let mut deduped_indexes: FxHashMap<u64, SmallIndexVec> = FxHashMap::default();
+    let mut deduped: Vec<LoadedEntry> =
+        Vec::with_capacity(loaded_files.iter().map(|file| file.entries.len()).sum());
+    for loaded_file in loaded_files {
+        for entry in loaded_file.entries {
+            if let Some(filter) = project_filter {
+                if entry.project.as_ref() != filter {
+                    continue;
+                }
+            }
+            push_deduped_entry(entry, &mut deduped_indexes, &mut deduped);
+        }
+    }
+    debug_log(
+        shared,
+        format!("Kept {} usage entries after deduplication", deduped.len()),
+    );
+    Ok(deduped)
+}
+```
+
+Remove the old `let paths = claude_paths()?;` block from the previous `load_entries_inner` body so there is only one implementation.
+
+- [ ] **Step 4: Expose explicit-path daily summary helper**
+
+In `rust/crates/ccusage/src/adapter/claude/mod.rs`, change daily entry points to:
+
+```rust
+pub(crate) fn load_daily_summaries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    progress::track_usage_load(progress::UsageLoadAgent::Claude, shared.json, || {
+        let paths = claude_paths()?;
+        daily::load_daily_summaries_from_paths(shared, &paths, project_filter, group_by_project)
+    })
+}
+
+pub(crate) fn load_daily_summaries_from_paths(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    daily::load_daily_summaries_from_paths(shared, paths, project_filter, group_by_project)
+}
+```
+
+In `rust/crates/ccusage/src/adapter/claude/daily.rs`, replace the top of the loader with:
+
+```rust
+pub(super) fn load_daily_summaries_from_paths(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    let files = usage_files(paths, project_filter);
+    if files.is_empty() {
+        return Ok(Vec::new());
+    }
+    // keep the existing function body from pricing onward unchanged
+}
+```
+
+Remove the direct `claude_paths()?` call from `daily.rs`. Remove the now-unused import of `claude_paths` from the `use super::paths::{...}` list.
+
+- [ ] **Step 5: Make path normalization reusable**
+
+In `rust/crates/ccusage/src/adapter/claude/paths.rs`, change:
+
+```rust
+fn normalize_claude_config_path(raw: &str) -> PathBuf
+fn expand_home_path(raw: &str) -> PathBuf
+```
+
+to:
+
+```rust
+pub(crate) fn normalize_claude_config_path(raw: &str) -> PathBuf
+pub(crate) fn expand_home_path(raw: &str) -> PathBuf
+```
+
+In `rust/crates/ccusage/src/adapter/claude/mod.rs`, add `normalize_claude_config_path` to the existing `pub(crate) use paths::{...}` list.
+
+- [ ] **Step 6: Run the targeted test and verify it passes**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage loads_claude_compatible_entries_from_explicit_config_paths -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run existing Claude loader tests**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage claude -- --nocapture
+```
+
+Expected: PASS. Existing Claude behavior must not change.
+
+- [ ] **Step 8: Commit Claude loader refactor**
+
+Run:
+
+```bash
+git add rust/crates/ccusage/src/adapter/claude/mod.rs rust/crates/ccusage/src/adapter/claude/daily.rs rust/crates/ccusage/src/adapter/claude/paths.rs rust/crates/ccusage/src/main.rs
+git diff --staged
+git commit -m "refactor(claude): share compatible usage loaders"
+```
+
+---
+
+### Task 3: Add Cowork Path Discovery
+
+**Files:**
+- Create: `rust/crates/ccusage/src/adapter/cowork/paths.rs`
+- Create: `rust/crates/ccusage/src/adapter/cowork/mod.rs`
+- Modify: `rust/crates/ccusage/src/adapter/mod.rs`
+
+- [ ] **Step 1: Create Cowork module shell and failing path tests**
+
+Create `rust/crates/ccusage/src/adapter/cowork/mod.rs`:
+
+```rust
+mod paths;
+
+#[cfg(test)]
+pub(crate) use paths::cowork_paths_from_root;
+```
+
+Add to `rust/crates/ccusage/src/adapter/mod.rs`:
+
+```rust
+pub(crate) mod cowork;
+```
+
+Create `rust/crates/ccusage/src/adapter/cowork/paths.rs` with tests first:
+
+```rust
+use std::path::{Path, PathBuf};
+
+use crate::Result;
+
+pub(crate) fn cowork_paths() -> Result<Vec<PathBuf>> {
+    Ok(Vec::new())
+}
+
+#[cfg(test)]
+pub(crate) fn cowork_paths_from_root(_root: &Path) -> Vec<PathBuf> {
+    Vec::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use ccusage_test_support::fs_fixture;
+
+    use super::cowork_paths_from_root;
+
+    #[test]
+    fn discovers_local_agent_mode_claude_config_dirs() {
+        let fixture = fs_fixture!({
+            "workspace-a/session-a/local_111/.claude/projects/project-a/session-a.jsonl": "",
+            "workspace-a/session-a/local_222/.claude/projects/project-b/session-b.jsonl": "",
+            "workspace-a/session-a/not-local/.claude/projects/project-c/session-c.jsonl": "",
+            "workspace-b/session-b/local_333/no-claude/projects/project-d/session-d.jsonl": "",
+        });
+
+        let paths = cowork_paths_from_root(fixture.root());
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("workspace-a/session-a/local_111/.claude"),
+                fixture.path("workspace-a/session-a/local_222/.claude"),
+            ]
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run the path discovery test and verify failure**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage discovers_local_agent_mode_claude_config_dirs -- --nocapture
+```
+
+Expected: FAIL because discovery returns an empty vector.
+
+- [ ] **Step 3: Implement recursive Cowork discovery**
+
+Replace `cowork_paths_from_root` in `paths.rs` with:
+
+```rust
+pub(crate) fn cowork_paths() -> Result<Vec<PathBuf>> {
+    if let Ok(env_paths) = std::env::var("COWORK_CONFIG_DIR") {
+        return cowork_paths_from_env(&env_paths);
+    }
+    let home = crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
+    Ok(cowork_paths_from_root(
+        &home.join("Library/Application Support/Claude/local-agent-mode-sessions"),
+    ))
+}
+
+fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = crate::fast::FxHashSet::default();
+    for raw in env_paths
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        let path = crate::adapter::claude::normalize_claude_config_path(raw);
+        if path.join("projects").is_dir() {
+            if seen.insert(path.clone()) {
+                paths.push(path);
+            }
+            continue;
+        }
+        for discovered in cowork_paths_from_root(&path) {
+            if seen.insert(discovered.clone()) {
+                paths.push(discovered);
+            }
+        }
+    }
+    if paths.is_empty() {
+        return Err(crate::cli_error(format!(
+            "No valid Cowork data directories found in COWORK_CONFIG_DIR. Expected each path to be a Cowork local-agent-mode-sessions directory, a .claude config directory containing 'projects/', or the 'projects/' directory itself: {env_paths}"
+        )));
+    }
+    Ok(paths)
+}
+
+pub(crate) fn cowork_paths_from_root(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_cowork_paths(root, &mut paths);
+    paths.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
+    paths
+}
+
+fn collect_cowork_paths(dir: &Path, paths: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("local_"))
+        {
+            let config = path.join(".claude");
+            if config.join("projects").is_dir() {
+                paths.push(config);
+            }
+        }
+        collect_cowork_paths(&path, paths);
+    }
+}
+```
+
+- [ ] **Step 4: Add env override tests**
+
+Add these tests to `paths.rs`:
+
+```rust
+#[test]
+fn accepts_direct_claude_and_projects_env_paths() {
+    let fixture = fs_fixture!({
+        "direct/.claude/projects/project-a/session-a.jsonl": "",
+        "other/.claude/projects/project-b/session-b.jsonl": "",
+    });
+
+    let paths = super::cowork_paths_from_env(&format!(
+        "{},{}",
+        fixture.path("direct/.claude").display(),
+        fixture.path("other/.claude/projects").display()
+    ))
+    .unwrap();
+
+    assert_eq!(
+        paths,
+        vec![
+            fixture.path("direct/.claude"),
+            fixture.path("other/.claude"),
+        ]
+    );
+}
+
+#[test]
+fn rejects_invalid_cowork_env_paths() {
+    let fixture = fs_fixture!({
+        "empty": "",
+    });
+
+    let error = super::cowork_paths_from_env(&fixture.path("empty").display().to_string())
+        .unwrap_err()
+        .to_string();
+
+    assert!(error.contains("No valid Cowork data directories found in COWORK_CONFIG_DIR"));
+}
+```
+
+- [ ] **Step 5: Run path tests and verify they pass**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage cowork::paths -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Cowork path discovery**
+
+Run:
+
+```bash
+git add rust/crates/ccusage/src/adapter/mod.rs rust/crates/ccusage/src/adapter/cowork/mod.rs rust/crates/ccusage/src/adapter/cowork/paths.rs rust/crates/ccusage/src/adapter/claude/mod.rs rust/crates/ccusage/src/adapter/claude/paths.rs
+git diff --staged
+git commit -m "feat(cowork): discover local agent sessions"
+```
+
+---
+
+### Task 4: Add Cowork Runtime Adapter
+
+**Files:**
+- Modify: `rust/crates/ccusage/src/adapter/cowork/mod.rs`
+- Modify: `rust/crates/ccusage/src/main.rs`
+- Modify: `rust/crates/ccusage/src/progress.rs`
+
+- [ ] **Step 1: Add failing Cowork loader/runtime tests**
+
+Add this test module to `rust/crates/ccusage/src/adapter/cowork/mod.rs`:
+
+```rust
+use crate::{
+    cli::{AgentReportKind, SharedArgs},
+    Result, UsageSummary,
+};
+
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+) -> Result<Vec<crate::LoadedEntry>> {
+    crate::adapter::claude::load_entries_from_paths(
+        shared,
+        &paths::cowork_paths()?,
+        project_filter,
+        "Cowork",
+    )
+}
+
+pub(crate) fn load_daily_summaries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    crate::adapter::claude::load_daily_summaries_from_paths(
+        shared,
+        &paths::cowork_paths()?,
+        project_filter,
+        group_by_project,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsString, path::Path, sync::Mutex};
+
+    use ccusage_test_support::fs_fixture;
+
+    use super::*;
+    use crate::cli::{CostMode, SharedArgs};
+
+    static COWORK_CONFIG_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CoworkConfigDirGuard {
+        previous: Option<OsString>,
+    }
+
+    impl CoworkConfigDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = env::var_os("COWORK_CONFIG_DIR");
+            env::set_var("COWORK_CONFIG_DIR", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for CoworkConfigDirGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                env::set_var("COWORK_CONFIG_DIR", previous);
+            } else {
+                env::remove_var("COWORK_CONFIG_DIR");
+            }
+        }
+    }
+
+    #[test]
+    fn loads_cowork_daily_summaries_from_local_agent_sessions() {
+        let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        });
+        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let rows = load_daily_summaries(&shared, None, false).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].date.as_deref(), Some("2025-01-10"));
+        assert_eq!(rows[0].input_tokens, 100);
+        assert_eq!(rows[0].output_tokens, 25);
+        assert_eq!(rows[0].cache_creation_tokens, 10);
+        assert_eq!(rows[0].cache_read_tokens, 5);
+    }
+
+    #[test]
+    fn loads_cowork_entries_with_session_and_project_metadata() {
+        let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        });
+        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries(&shared, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_ref(), "project-a");
+        assert_eq!(entries[0].session_id.as_ref(), "session-a");
+        assert_eq!(entries[0].project_path.as_ref(), "project-a");
+    }
+}
+```
+
+- [ ] **Step 2: Run Cowork tests and verify failure**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage cowork -- --nocapture
+```
+
+Expected: FAIL until the module compiles with the shared Claude helper exports and progress label.
+
+- [ ] **Step 3: Add Cowork progress label**
+
+In `rust/crates/ccusage/src/progress.rs`, add:
+
+```rust
+Cowork,
+```
+
+to `UsageLoadAgent`, and add this match arm:
+
+```rust
+UsageLoadAgent::Cowork => "Cowork",
+```
+
+- [ ] **Step 4: Implement Cowork run function**
+
+Replace `cowork/mod.rs` top-level runtime with:
+
+```rust
+mod paths;
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use crate::{
+    cli::{AgentCommandArgs, AgentReportKind, SharedArgs, WeekDay},
+    print_json_or_jq, print_usage_table, sort_summaries, summarize_summaries_by_bucket,
+    totals_json, wants_json, BucketKind, Result, SessionAccumulator, UsageSummary,
+};
+
+#[cfg(test)]
+pub(crate) use paths::cowork_paths_from_root;
+
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+) -> Result<Vec<crate::LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Cowork, shared.json, || {
+        crate::adapter::claude::load_entries_from_paths(
+            shared,
+            &paths::cowork_paths()?,
+            project_filter,
+            "Cowork",
+        )
+    })
+}
+
+pub(crate) fn load_daily_summaries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Cowork, shared.json, || {
+        crate::adapter::claude::load_daily_summaries_from_paths(
+            shared,
+            &paths::cowork_paths()?,
+            project_filter,
+            group_by_project,
+        )
+    })
+}
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let mut rows = load_summaries(&args.shared, args.kind)?;
+    sort_summaries(&mut rows, &args.shared.order, |row| {
+        crate::adapter::opencode::summary_period(row)
+    });
+    if wants_json(&args.shared) {
+        return print_json_or_jq(report_from_rows(&rows, args.kind), args.shared.jq.as_deref());
+    }
+    print_usage_table(
+        "Cowork Token Usage Report",
+        crate::adapter::opencode::first_column(args.kind),
+        &rows,
+        &args.shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}
+
+fn load_summaries(shared: &SharedArgs, kind: AgentReportKind) -> Result<Vec<UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => {
+            let mut rows = load_daily_summaries(shared, None, false)?;
+            filter_daily_summaries_by_date(&mut rows, shared);
+            Ok(rows)
+        }
+        AgentReportKind::Monthly => {
+            let mut daily = load_daily_summaries(shared, None, false)?;
+            filter_daily_summaries_by_date(&mut daily, shared);
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Weekly => unreachable!("cowork parser does not expose weekly reports"),
+        AgentReportKind::Session => {
+            let entries = load_entries(shared, None)?;
+            let mut rows = summarize_sessions(&entries, shared.timezone.as_deref())?;
+            filter_session_summaries(&mut rows, shared);
+            Ok(rows)
+        }
+    }
+}
+
+fn summarize_sessions(
+    entries: &[crate::LoadedEntry],
+    timezone: Option<&str>,
+) -> Result<Vec<UsageSummary>> {
+    let mut groups = BTreeMap::<(String, String), SessionAccumulator>::new();
+    for entry in entries {
+        groups
+            .entry((entry.project_path.to_string(), entry.session_id.to_string()))
+            .or_default()
+            .add_entry(entry);
+    }
+    groups
+        .into_values()
+        .map(|group| group.into_summary(timezone))
+        .collect()
+}
+
+fn filter_daily_summaries_by_date(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
+    if shared.since.is_none() && shared.until.is_none() {
+        return;
+    }
+    rows.retain(|row| {
+        let date = row.date.as_deref().unwrap_or_default().replace('-', "");
+        shared.since.as_ref().is_none_or(|since| &date >= since)
+            && shared.until.as_ref().is_none_or(|until| &date <= until)
+    });
+}
+
+fn filter_session_summaries(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
+    if shared.since.is_some() || shared.until.is_some() {
+        rows.retain(|row| {
+            let date = row
+                .last_activity
+                .as_deref()
+                .unwrap_or_default()
+                .replace('-', "");
+            shared.since.as_ref().is_none_or(|since| &date >= since)
+                && shared.until.as_ref().is_none_or(|until| &date <= until)
+        });
+    }
+}
+
+fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| {
+            crate::adapter::opencode::agent_summary_json(
+                row,
+                kind,
+                kind == AgentReportKind::Session,
+            )
+        })
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+```
+
+- [ ] **Step 5: Dispatch Cowork from main**
+
+In `rust/crates/ccusage/src/main.rs`, add:
+
+```rust
+Some(Command::Cowork(args)) => adapter::cowork::run(args),
+```
+
+near other agent command dispatch arms.
+
+- [ ] **Step 6: Run Cowork runtime tests**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage cowork -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Cowork runtime adapter**
+
+Run:
+
+```bash
+git add rust/crates/ccusage/src/adapter/cowork rust/crates/ccusage/src/adapter/mod.rs rust/crates/ccusage/src/main.rs rust/crates/ccusage/src/progress.rs
+git diff --staged
+git commit -m "feat(cowork): add usage report adapter"
+```
+
+---
+
+### Task 5: Add Cowork to All-Agent Reports
+
+**Files:**
+- Modify: `rust/crates/ccusage/src/adapter/all/loader.rs`
+- Modify: `rust/crates/ccusage/src/adapter/all/tests.rs`
+
+- [ ] **Step 1: Add failing all-agent aggregation test**
+
+Add this unit test to `rust/crates/ccusage/src/adapter/all/tests.rs`:
+
+```rust
+#[test]
+fn aggregates_claude_and_cowork_as_separate_agents() {
+    let rows = aggregate_rows(
+        vec![
+            AllRow {
+                period: "2025-01-10".to_string(),
+                agent: "claude",
+                models_used: vec!["claude-opus-4-6".to_string()],
+                input_tokens: 100,
+                output_tokens: 10,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                total_tokens: 110,
+                total_cost: 0.01,
+                metadata: None,
+                metadata_agents: Some(vec!["claude"]),
+                agent_breakdowns: None,
+                model_breakdowns: Vec::new(),
+            },
+            AllRow {
+                period: "2025-01-10".to_string(),
+                agent: "cowork",
+                models_used: vec!["claude-opus-4-6".to_string()],
+                input_tokens: 200,
+                output_tokens: 20,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 0,
+                total_tokens: 220,
+                total_cost: 0.02,
+                metadata: None,
+                metadata_agents: Some(vec!["cowork"]),
+                agent_breakdowns: None,
+                model_breakdowns: Vec::new(),
+            },
+        ],
+        AgentReportKind::Daily,
+    );
+
+    assert_eq!(rows.len(), 1);
+    let breakdowns = rows[0].agent_breakdowns.as_ref().unwrap();
+    assert_eq!(breakdowns.len(), 2);
+    assert_eq!(breakdowns[0].agent, "claude");
+    assert_eq!(breakdowns[1].agent, "cowork");
+    assert_eq!(rows[0].metadata_agents.as_ref().unwrap(), &vec!["claude", "cowork"]);
+}
+```
+
+- [ ] **Step 2: Run all-agent tests**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::all -- --nocapture
+```
+
+Expected: existing tests pass; new aggregation test should pass already because aggregation is label-based. If it fails because ordering differs, sort expectation to match current `agent_breakdowns.sort_by(|a, b| a.agent.cmp(b.agent))`.
+
+- [ ] **Step 3: Wire Cowork into loader specs**
+
+In `rust/crates/ccusage/src/adapter/all/loader.rs`, add `cowork` to the adapter imports:
+
+```rust
+cowork,
+```
+
+Add a new `AgentLoadSpec` after Claude:
+
+```rust
+AgentLoadSpec {
+    index: 1,
+    agent: "cowork",
+    progress_agent: crate::progress::UsageLoadAgent::Cowork,
+    load: Box::new(|| load_cowork_rows(load_kind, &loader_shared)),
+},
+```
+
+Increment later `index` values by 1. Do not leave duplicate indexes.
+
+Add:
+
+```rust
+fn load_cowork_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
+    if kind == AgentReportKind::Session {
+        return load_session_capable_summary_agent_rows(
+            "cowork",
+            kind,
+            shared,
+            cowork::load_entries,
+            summarize_entries,
+        );
+    }
+
+    let mut summaries = cowork::load_daily_summaries(shared, None, false)?;
+    let detected = !summaries.is_empty();
+    filter_daily_summaries_by_date(&mut summaries, shared);
+    Ok(AgentRows {
+        rows: summary_rows("cowork", summaries),
+        detected,
+    })
+}
+```
+
+- [ ] **Step 4: Run all-agent tests again**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::all -- --nocapture
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit all-agent integration**
+
+Run:
+
+```bash
+git add rust/crates/ccusage/src/adapter/all/loader.rs rust/crates/ccusage/src/adapter/all/tests.rs
+git diff --staged
+git commit -m "feat(cowork): include source in all-agent reports"
+```
+
+---
+
+### Task 6: Add Source README and User-Facing Docs
+
+**Files:**
+- Create: `rust/crates/ccusage/src/adapter/cowork/README.md`
+- Modify: `README.md`
+- Modify: `apps/ccusage/README.md`
+- Modify: matching `docs/guide/` files found by search
+
+- [ ] **Step 1: Find docs that mention supported agents**
+
+Run:
+
+```bash
+rg -n "Claude Code|Codex|OpenCode|Amp|supported agents|agent sources|ccusage (codex|opencode|amp|all)" README.md apps/ccusage/README.md docs/guide
+```
+
+Expected: list of docs that need Cowork added.
+
+- [ ] **Step 2: Add Cowork adapter README**
+
+Create `rust/crates/ccusage/src/adapter/cowork/README.md`:
+
+```markdown
+# Cowork Adapter
+
+The Cowork adapter reads Claude Desktop local agent mode sessions as a separate
+`cowork` source.
+
+Default discovery on macOS:
+
+`~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/.claude/projects/**/*.jsonl`
+
+Cowork stores Claude-compatible usage JSONL records, so token parsing, model
+mapping, cost calculation, and deduplication are shared with the Claude adapter.
+
+Set `COWORK_CONFIG_DIR` to override discovery. The value is comma-separated and
+each entry may be:
+
+- a `local-agent-mode-sessions` directory;
+- a concrete `.claude` config directory;
+- a `projects` directory inside a `.claude` config directory.
+
+Supported reports:
+
+- `ccusage cowork`
+- `ccusage cowork daily`
+- `ccusage cowork monthly`
+- `ccusage cowork session`
+```
+
+- [ ] **Step 3: Update public docs**
+
+In each supported-agent list found in Step 1, add Cowork with wording matching the surrounding style:
+
+```markdown
+- Cowork (`ccusage cowork`) - Claude Desktop local agent mode usage
+```
+
+Where command examples are listed, add:
+
+```bash
+ccusage cowork daily
+ccusage cowork monthly
+ccusage cowork session
+```
+
+Do not add `ccusage cowork weekly`, blocks, or statusline examples.
+
+- [ ] **Step 4: Run docs-related checks that do not need network**
+
+Run:
+
+```bash
+pnpm run lint:oxfmt
+```
+
+Expected: PASS or formatting diffs reported. If formatting diffs are reported, run `pnpm run format` in Task 7.
+
+- [ ] **Step 5: Commit docs**
+
+Run:
+
+```bash
+git add rust/crates/ccusage/src/adapter/cowork/README.md README.md apps/ccusage/README.md docs/guide
+git diff --staged
+git commit -m "docs(cowork): document usage source"
+```
+
+---
+
+### Task 7: Final Verification and Cleanup
+
+**Files:**
+- No planned source edits unless verification exposes issues.
+
+- [ ] **Step 1: Run formatter**
+
+Run:
+
+```bash
+pnpm run format
+```
+
+Expected: completes successfully. If files change, inspect the diff.
+
+- [ ] **Step 2: Run targeted Rust tests**
+
+Run:
+
+```bash
+cargo test --manifest-path rust/Cargo.toml -p ccusage-cli cowork -- --nocapture
+cargo test --manifest-path rust/Cargo.toml -p ccusage cowork -- --nocapture
+cargo test --manifest-path rust/Cargo.toml -p ccusage adapter::all -- --nocapture
+cargo test --manifest-path rust/Cargo.toml -p ccusage claude -- --nocapture
+```
+
+Expected: all PASS.
+
+- [ ] **Step 3: Run repository-required checks**
+
+Run:
+
+```bash
+pnpm typecheck
+pnpm run test
+```
+
+Expected: all PASS.
+
+- [ ] **Step 4: Inspect final diff**
+
+Run:
+
+```bash
+git status --short
+git diff
+```
+
+Expected: only intended formatting or final cleanup changes remain.
+
+- [ ] **Step 5: Commit verification cleanup if needed**
+
+If formatting or cleanup changed files, run:
+
+```bash
+git add .
+git diff --staged
+git commit -m "chore(cowork): apply formatting"
+```
+
+If no files changed, do not create an empty commit.
+
+- [ ] **Step 6: Record final status**
+
+Run:
+
+```bash
+git log --oneline --decorate -5
+git status
+```
+
+Expected: branch `feat/cowork-usage-source` is clean and contains the Cowork commits.

--- a/docs/superpowers/specs/2026-06-01-cowork-usage-source-design.md
+++ b/docs/superpowers/specs/2026-06-01-cowork-usage-source-design.md
@@ -1,0 +1,159 @@
+# Cowork Usage Source Design
+
+Date: 2026-06-01
+
+## Problem
+
+Claude Desktop Cowork local agent sessions store Claude Code-compatible usage
+JSONL files under:
+
+`~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/.claude/projects/**/*.jsonl`
+
+The current `ccusage` Claude adapter reads normal Claude Code config
+directories such as `~/.claude` and `$XDG_CONFIG_HOME/claude`, but it does not
+discover Cowork local agent session directories. Users cannot view Cowork token
+usage separately from Claude Code usage.
+
+## Goal
+
+Add Cowork as a separate agent source. Users should be able to run commands such
+as:
+
+- `ccusage cowork`
+- `ccusage cowork daily`
+- `ccusage cowork monthly`
+- `ccusage cowork session`
+
+All-agent reports should include Cowork as its own `cowork` agent when Cowork
+usage files are present. Claude Code and Cowork usage must not be merged under
+the same agent label.
+
+## Non-Goals
+
+- Do not change Claude Code default discovery.
+- Do not estimate tokens from message text.
+- Do not add a standalone package such as `ccusage-cowork`.
+- Do not add Cowork blocks or statusline support.
+- Do not duplicate Claude parsing logic when a small shared helper can preserve
+  the same behavior.
+
+## Data Source
+
+The default Cowork root is the macOS Claude Desktop application support
+directory:
+
+`~/Library/Application Support/Claude/local-agent-mode-sessions`
+
+Within that root, each usable source is a nested Claude config directory:
+
+`<root>/<workspace-id>/<session-id>/local_<uuid>/.claude`
+
+The adapter should accept an override environment variable:
+
+`COWORK_CONFIG_DIR`
+
+The override should accept comma-separated paths. Each path may be either:
+
+- a `local-agent-mode-sessions` root to discover recursively;
+- a concrete `.claude` config directory;
+- a `projects` directory inside a `.claude` config directory.
+
+Invalid override paths should return a clear CLI error, matching the existing
+`CLAUDE_CONFIG_DIR` behavior.
+
+## Architecture
+
+Add a new Rust adapter under:
+
+`rust/crates/ccusage/src/adapter/cowork/`
+
+The adapter owns Cowork path discovery and command wiring, but it should reuse
+the Claude JSONL parsing, dedupe, cost calculation, daily summaries, session
+summaries, and project extraction semantics.
+
+To avoid copy-paste, refactor the Claude adapter so its loaders can accept an
+explicit list of Claude-compatible config directories:
+
+- keep `claude::load_entries(...)` and `claude::load_daily_summaries(...)` as
+  public Claude entry points using `claude_paths()`;
+- add internal helper entry points that receive `Vec<PathBuf>` or `&[PathBuf]`;
+- call those helpers from both `claude` and `cowork`.
+
+Cowork should use its own progress label and all-agent source label:
+
+- progress label: `Cowork`
+- all-agent JSON/table agent id: `cowork`
+
+## CLI Integration
+
+Add a `Cowork(AgentCommandArgs)` variant to `ccusage-cli`.
+
+Register `cowork` in the command parser using the standard agent reports:
+
+- `daily`
+- `monthly`
+- `session`
+
+Weekly support is excluded for the first patch because the standard Claude-like
+agent command set in this repository does not expose weekly reports for most
+agents.
+
+Wire `Command::Cowork(args)` in `rust/crates/ccusage/src/main.rs` to
+`adapter::cowork::run(args)`.
+
+## All-Agent Reports
+
+Add Cowork to `adapter/all/loader.rs` as a separate load spec. It should use the
+same summary-row path as Claude, but with agent id `cowork`.
+
+When both Claude Code and Cowork files exist, all-agent output should contain
+two separate agent breakdowns:
+
+- `claude`
+- `cowork`
+
+No dedupe should happen across agent boundaries. Identical message IDs in
+Claude Code and Cowork are separate product sources for reporting purposes.
+
+## Tests
+
+Follow TDD for implementation.
+
+Add tests covering:
+
+- Cowork path discovery from a `local-agent-mode-sessions` fixture root.
+- Normalization of direct `.claude` and `projects` override paths.
+- A Cowork daily report fixture that reuses Claude-compatible JSONL usage.
+- A Cowork session report fixture that preserves session and project metadata.
+- Parser coverage for `ccusage cowork`, `ccusage cowork daily`,
+  `ccusage cowork monthly`, and `ccusage cowork session`.
+- All-agent aggregation where Claude and Cowork fixtures appear as separate
+  agent rows.
+
+Add a skipped local-data smoke test if the existing test style supports
+developer-machine paths for schema drift checks.
+
+## Documentation Impact
+
+This is a user-facing source and command. Update supported-agent lists and
+command examples in:
+
+- root `README.md`;
+- `apps/ccusage/README.md`;
+- relevant docs guide pages and navigation if those pages list supported
+  agents or subcommands.
+
+Add a source-specific README under `rust/crates/ccusage/src/adapter/cowork/`
+describing the default path, `COWORK_CONFIG_DIR`, and the fact that Cowork uses
+Claude-compatible JSONL usage files.
+
+## Verification
+
+Before opening a PR, run the repository-required checks:
+
+- `pnpm run format`
+- `pnpm typecheck`
+- `pnpm run test`
+
+During implementation, run targeted Rust and CLI parser tests first, then the
+full repository checks after the patch is complete.

--- a/nix/git-hooks.nix
+++ b/nix/git-hooks.nix
@@ -30,7 +30,7 @@ in
           hooks = {
             renovate-config-validator = {
               enable = true;
-              entry = "${lib.getExe pkgs.renovate} --strict config-validator";
+              entry = "${lib.getExe' pkgs.renovate "renovate-config-validator"} --strict";
               files = "renovate\\.json5?$";
               pass_filenames = false;
               stages = [

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -94,6 +94,10 @@
 			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
+			},
+			{
+				"name": "cowork",
+				"description": "Show Cowork usage commands"
 			}
 		]
 	},
@@ -690,6 +694,43 @@
 			"path": ["qwen", "session"],
 			"description": "Show Qwen usage grouped by session",
 			"usage": "ccusage qwen session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["cowork"],
+			"description": "Usage reports for cowork.",
+			"usage": "ccusage cowork <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Cowork usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Cowork usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Cowork usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["cowork", "daily"],
+			"description": "Show Cowork usage grouped by date",
+			"usage": "ccusage cowork daily <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["cowork", "monthly"],
+			"description": "Show Cowork usage grouped by month",
+			"usage": "ccusage cowork monthly <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["cowork", "session"],
+			"description": "Show Cowork usage grouped by session",
+			"usage": "ccusage cowork session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -648,14 +648,10 @@ fn normalize_legacy_agent_command_args(args: &mut Vec<String>) {
     let Some((agent, report)) = command.split_once(':') else {
         return;
     };
-    if !legacy_agent_report_supported(agent, report) {
+    if !is_agent_command(agent) {
         return;
     }
     args.splice(0..1, [agent.to_string(), report.to_string()]);
-}
-
-fn legacy_agent_report_supported(agent: &str, report: &str) -> bool {
-    agent_report_supported(agent, report)
 }
 
 fn report_flag_alias_error(args: &[String]) -> Option<String> {
@@ -793,6 +789,7 @@ fn is_agent_command(command: &str) -> bool {
             | "copilot"
             | "gemini"
             | "kimi"
+            | "cowork"
             | "qwen"
             | "openclaw"
     )
@@ -807,7 +804,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "cowork" | "openclaw" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -830,6 +827,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "cowork" => "Cowork",
         "openclaw" => "OpenClaw",
         _ => unreachable!("agent is prevalidated"),
     }

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -263,6 +263,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Qwen,
         ),
+        "cowork" => parse_basic_agent_command(
+            parser,
+            shared,
+            "cowork",
+            STANDARD_AGENT_REPORTS,
+            Command::Cowork,
+        ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
@@ -629,6 +636,7 @@ fn is_command(arg: &str) -> bool {
             | "copilot"
             | "gemini"
             | "kimi"
+            | "cowork"
             | "qwen"
     )
 }

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -201,6 +201,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Gemini(args)) => agent_command_snapshot("gemini", args),
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
+        Some(Command::Cowork(args)) => agent_command_snapshot("cowork", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
     }
 }
@@ -860,6 +861,36 @@ fn parses_qwen_session_options() {
     };
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);
+}
+
+#[test]
+fn parses_cowork_default_command() {
+    let cli = parse(&["ccusage", "cowork"]);
+    let Some(Command::Cowork(args)) = cli.command else {
+        panic!("expected Cowork command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+}
+
+#[test]
+fn parses_cowork_report_commands() {
+    for (report, expected) in [
+        ("daily", AgentReportKind::Daily),
+        ("monthly", AgentReportKind::Monthly),
+        ("session", AgentReportKind::Session),
+    ] {
+        let cli = parse(&["ccusage", "cowork", report]);
+        let Some(Command::Cowork(args)) = cli.command else {
+            panic!("expected Cowork command for {report}");
+        };
+        assert_eq!(args.kind, expected);
+    }
+}
+
+#[test]
+fn rejects_unknown_cowork_report_command() {
+    let error = parse_error(&["ccusage", "cowork", "weekly"]);
+    assert_eq!(error, "Unknown cowork command 'weekly'");
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -767,6 +767,15 @@ fn parses_legacy_colon_agent_commands() {
 }
 
 #[test]
+fn parses_legacy_colon_cowork_command() {
+    let cli = parse(&["ccusage", "cowork:monthly"]);
+    let Some(Command::Cowork(args)) = cli.command else {
+        panic!("expected cowork command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Monthly);
+}
+
+#[test]
 fn rejects_report_flag_aliases_with_guidance() {
     let error = parse_error(&["ccusage", "--daily"]);
     assert_eq!(
@@ -790,6 +799,15 @@ fn rejects_unsupported_agent_reports_with_guidance() {
     assert_eq!(
         error,
         "The \"blocks\" report is only available for Claude Code usage.\nUse \"ccusage codex daily\" for Codex usage reports."
+    );
+}
+
+#[test]
+fn rejects_unsupported_legacy_colon_cowork_report_with_guidance() {
+    let error = parse_error(&["ccusage", "cowork:weekly"]);
+    assert_eq!(
+        error,
+        "The \"weekly\" report is not available for Cowork usage.\nUse \"ccusage cowork daily\" for Cowork usage reports."
     );
 }
 
@@ -888,9 +906,12 @@ fn parses_cowork_report_commands() {
 }
 
 #[test]
-fn rejects_unknown_cowork_report_command() {
+fn rejects_unsupported_cowork_report_with_guidance() {
     let error = parse_error(&["ccusage", "cowork", "weekly"]);
-    assert_eq!(error, "Unknown cowork command 'weekly'");
+    assert_eq!(
+        error,
+        "The \"weekly\" report is not available for Cowork usage.\nUse \"ccusage cowork daily\" for Cowork usage reports."
+    );
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Gemini(AgentCommandArgs),
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
+    Cowork(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
 }
 

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -4,8 +4,8 @@ use serde_json::{json, Value};
 
 use crate::{
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, claude, codebuff, codex, copilot, cowork, droid, gemini, goose, hermes, kilo, kimi,
+        openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float, summarize_by_key, summarize_summaries_by_bucket,
@@ -47,12 +47,18 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
             },
             AgentLoadSpec {
                 index: 1,
+                agent: "cowork",
+                progress_agent: crate::progress::UsageLoadAgent::Cowork,
+                load: Box::new(|| load_cowork_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 2,
                 agent: "codex",
                 progress_agent: crate::progress::UsageLoadAgent::Codex,
                 load: Box::new(|| load_codex_rows(load_kind, &loader_shared, &pricing)),
             },
             AgentLoadSpec {
-                index: 2,
+                index: 3,
                 agent: "opencode",
                 progress_agent: crate::progress::UsageLoadAgent::OpenCode,
                 load: Box::new(|| {
@@ -66,7 +72,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 3,
+                index: 4,
                 agent: "amp",
                 progress_agent: crate::progress::UsageLoadAgent::Amp,
                 load: Box::new(|| {
@@ -81,7 +87,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 4,
+                index: 5,
                 agent: "droid",
                 progress_agent: crate::progress::UsageLoadAgent::Droid,
                 load: Box::new(|| {
@@ -96,7 +102,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 5,
+                index: 6,
                 agent: "codebuff",
                 progress_agent: crate::progress::UsageLoadAgent::Codebuff,
                 load: Box::new(|| {
@@ -111,7 +117,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 6,
+                index: 7,
                 agent: "hermes",
                 progress_agent: crate::progress::UsageLoadAgent::Hermes,
                 load: Box::new(|| {
@@ -126,7 +132,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 7,
+                index: 8,
                 agent: "pi",
                 progress_agent: crate::progress::UsageLoadAgent::Pi,
                 load: Box::new(|| {
@@ -140,7 +146,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 8,
+                index: 9,
                 agent: "goose",
                 progress_agent: crate::progress::UsageLoadAgent::Goose,
                 load: Box::new(|| {
@@ -155,7 +161,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 9,
+                index: 10,
                 agent: "openclaw",
                 progress_agent: crate::progress::UsageLoadAgent::OpenClaw,
                 load: Box::new(|| {
@@ -169,7 +175,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 10,
+                index: 11,
                 agent: "kilo",
                 progress_agent: crate::progress::UsageLoadAgent::Kilo,
                 load: Box::new(|| {
@@ -184,7 +190,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 11,
+                index: 12,
                 agent: "copilot",
                 progress_agent: crate::progress::UsageLoadAgent::Copilot,
                 load: Box::new(|| {
@@ -199,7 +205,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 12,
+                index: 13,
                 agent: "gemini",
                 progress_agent: crate::progress::UsageLoadAgent::Gemini,
                 load: Box::new(|| {
@@ -214,7 +220,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 13,
+                index: 14,
                 agent: "kimi",
                 progress_agent: crate::progress::UsageLoadAgent::Kimi,
                 load: Box::new(|| {
@@ -229,7 +235,7 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 }),
             },
             AgentLoadSpec {
-                index: 14,
+                index: 15,
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
@@ -398,6 +404,26 @@ fn load_claude_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentR
     })
 }
 
+fn load_cowork_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
+    if kind == AgentReportKind::Session {
+        return load_session_capable_summary_agent_rows(
+            "cowork",
+            kind,
+            shared,
+            cowork::load_entries,
+            summarize_entries,
+        );
+    }
+
+    let mut summaries = cowork::load_daily_summaries(shared, None, false)?;
+    let detected = !summaries.is_empty();
+    filter_daily_summaries_by_date(&mut summaries, shared);
+    Ok(AgentRows {
+        rows: summary_rows("cowork", summaries),
+        detected,
+    })
+}
+
 fn filter_daily_summaries_by_date(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
     if shared.since.is_none() && shared.until.is_none() {
         return;
@@ -545,7 +571,7 @@ fn filter_session_summaries(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
     }
 }
 
-fn summary_rows(agent: &'static str, summaries: Vec<UsageSummary>) -> Vec<AllRow> {
+pub(super) fn summary_rows(agent: &'static str, summaries: Vec<UsageSummary>) -> Vec<AllRow> {
     summaries
         .into_iter()
         .filter_map(|summary| {
@@ -589,7 +615,7 @@ fn summary_metadata(agent: &'static str, summary: &UsageSummary) -> Option<Value
         if let Some(last_activity) = summary.last_activity.as_ref() {
             metadata.insert("lastActivity".to_string(), json!(last_activity));
         }
-        if agent == "pi" {
+        if matches!(agent, "pi" | "cowork") {
             if let Some(project_path) = summary.project_path.as_ref() {
                 metadata.insert("projectPath".to_string(), json!(project_path));
             }

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -9,7 +9,7 @@ use crate::{
     UsageSummary,
 };
 
-use super::types::AllRow;
+use super::types::{compare_agents, AllRow};
 
 pub(super) fn report_json(rows: &[AllRow], kind: AgentReportKind) -> Value {
     json!({
@@ -243,6 +243,8 @@ fn detected_agent_labels(rows: &[AllRow], detected_agents: &[&'static str]) -> S
     if agents.is_empty() {
         return "None".to_string();
     }
+    let mut agents = agents.into_iter().collect::<Vec<_>>();
+    agents.sort_by(|a, b| compare_agents(a, b));
     agents
         .into_iter()
         .map(agent_label)
@@ -413,6 +415,7 @@ fn agent_label(agent: &str) -> &str {
     match agent {
         "all" => "All",
         "claude" => "Claude",
+        "cowork" => "Cowork",
         "codex" => "Codex",
         "opencode" => "OpenCode",
         "amp" => "Amp",

--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -12,7 +12,7 @@ use serde_json::json;
 use super::*;
 use crate::{
     cli::{AgentReportKind, CodexSpeed},
-    Align, CodexGroup, CodexModelUsage, ModelBreakdown, PricingMap,
+    Align, CodexGroup, CodexModelUsage, ModelBreakdown, PricingMap, UsageSummary,
 };
 
 fn test_agent_rows(agent: &'static str) -> AgentRows {
@@ -129,6 +129,91 @@ fn aggregates_daily_agent_rows_by_period() {
     assert_eq!(breakdowns[0].agent, "claude");
     assert_eq!(breakdowns[0].period, "2026-01-02");
     assert_eq!(breakdowns[1].agent, "codex");
+}
+
+#[test]
+fn aggregates_claude_and_cowork_as_distinct_daily_agents() {
+    let rows = aggregate_rows(
+        vec![
+            AllRow {
+                period: "2026-01-02".to_string(),
+                agent: "claude",
+                models_used: vec!["claude-sonnet-4-20250514".to_string()],
+                input_tokens: 100,
+                output_tokens: 20,
+                cache_creation_tokens: 5,
+                cache_read_tokens: 10,
+                total_tokens: 135,
+                total_cost: 0.02,
+                metadata: None,
+                metadata_agents: Some(vec!["claude"]),
+                agent_breakdowns: None,
+                model_breakdowns: Vec::new(),
+            },
+            AllRow {
+                period: "2026-01-02".to_string(),
+                agent: "cowork",
+                models_used: vec!["claude-sonnet-4-20250514".to_string()],
+                input_tokens: 50,
+                output_tokens: 15,
+                cache_creation_tokens: 2,
+                cache_read_tokens: 3,
+                total_tokens: 70,
+                total_cost: 0.01,
+                metadata: None,
+                metadata_agents: Some(vec!["cowork"]),
+                agent_breakdowns: None,
+                model_breakdowns: Vec::new(),
+            },
+        ],
+        AgentReportKind::Daily,
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].metadata_agents, Some(vec!["claude", "cowork"]));
+    let breakdowns = rows[0].agent_breakdowns.as_ref().unwrap();
+    assert_eq!(breakdowns.len(), 2);
+    assert_eq!(breakdowns[0].agent, "claude");
+    assert_eq!(breakdowns[1].agent, "cowork");
+    assert_eq!(breakdowns[0].input_tokens, 100);
+    assert_eq!(breakdowns[1].input_tokens, 50);
+}
+
+#[test]
+fn includes_cowork_session_project_path_and_last_activity_metadata() {
+    let rows = super::loader::summary_rows(
+        "cowork",
+        vec![UsageSummary {
+            date: None,
+            month: None,
+            week: None,
+            session_id: Some("session-a".to_string()),
+            project_path: Some("/workspace/project-a".to_string()),
+            last_activity: Some("2026-01-02".to_string()),
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_creation_tokens: 10,
+            cache_read_tokens: 5,
+            extra_total_tokens: 0,
+            total_cost: 0.01,
+            credits: None,
+            message_count: None,
+            models_used: vec!["claude-sonnet-4-20250514".to_string()],
+            model_breakdowns: Vec::new(),
+            project: None,
+            versions: None,
+        }],
+    );
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].period, "session-a");
+    assert_eq!(
+        rows[0].metadata,
+        Some(json!({
+            "lastActivity": "2026-01-02",
+            "projectPath": "/workspace/project-a",
+        }))
+    );
 }
 
 #[test]

--- a/rust/crates/ccusage/src/adapter/all/tests.rs
+++ b/rust/crates/ccusage/src/adapter/all/tests.rs
@@ -152,6 +152,21 @@ fn aggregates_claude_and_cowork_as_distinct_daily_agents() {
             },
             AllRow {
                 period: "2026-01-02".to_string(),
+                agent: "codex",
+                models_used: vec!["gpt-5".to_string()],
+                input_tokens: 25,
+                output_tokens: 10,
+                cache_creation_tokens: 0,
+                cache_read_tokens: 4,
+                total_tokens: 39,
+                total_cost: 0.01,
+                metadata: None,
+                metadata_agents: Some(vec!["codex"]),
+                agent_breakdowns: None,
+                model_breakdowns: Vec::new(),
+            },
+            AllRow {
+                period: "2026-01-02".to_string(),
                 agent: "cowork",
                 models_used: vec!["claude-sonnet-4-20250514".to_string()],
                 input_tokens: 50,
@@ -170,13 +185,18 @@ fn aggregates_claude_and_cowork_as_distinct_daily_agents() {
     );
 
     assert_eq!(rows.len(), 1);
-    assert_eq!(rows[0].metadata_agents, Some(vec!["claude", "cowork"]));
+    assert_eq!(
+        rows[0].metadata_agents,
+        Some(vec!["claude", "cowork", "codex"])
+    );
     let breakdowns = rows[0].agent_breakdowns.as_ref().unwrap();
-    assert_eq!(breakdowns.len(), 2);
+    assert_eq!(breakdowns.len(), 3);
     assert_eq!(breakdowns[0].agent, "claude");
     assert_eq!(breakdowns[1].agent, "cowork");
+    assert_eq!(breakdowns[2].agent, "codex");
     assert_eq!(breakdowns[0].input_tokens, 100);
     assert_eq!(breakdowns[1].input_tokens, 50);
+    assert_eq!(breakdowns[2].input_tokens, 25);
 }
 
 #[test]
@@ -578,7 +598,17 @@ fn report_title_uses_detected_agents_even_when_filtered_rows_are_sparse() {
 
     assert_eq!(
         title,
-        "Coding (Agent) CLI Usage Report - Daily\nDetected: Amp, Claude, Codex, OpenCode, pi-agent"
+        "Coding (Agent) CLI Usage Report - Daily\nDetected: Claude, Codex, OpenCode, Amp, pi-agent"
+    );
+}
+
+#[test]
+fn all_report_title_uses_canonical_detected_agent_order_and_cowork_label() {
+    let title = all_report_title(AgentReportKind::Daily, &[], &["codex", "cowork", "claude"]);
+
+    assert_eq!(
+        title,
+        "Coding (Agent) CLI Usage Report - Daily\nDetected: Claude, Cowork, Codex"
     );
 }
 
@@ -626,6 +656,27 @@ fn all_table_rows_match_main_agent_breakdown_display() {
         ),
         vec!["", "- Codex", "- gpt-5", "100", "20", "$0.01"]
     );
+}
+
+#[test]
+fn all_table_row_uses_cowork_label() {
+    let row = AllRow {
+        period: "2026-01-02".to_string(),
+        agent: "cowork",
+        models_used: vec!["claude-sonnet-4-20250514".to_string()],
+        input_tokens: 100,
+        output_tokens: 20,
+        cache_creation_tokens: 0,
+        cache_read_tokens: 10,
+        total_tokens: 130,
+        total_cost: 0.01,
+        metadata: None,
+        metadata_agents: Some(vec!["cowork"]),
+        agent_breakdowns: None,
+        model_breakdowns: Vec::new(),
+    };
+
+    assert_eq!(all_table_row(&row, true, true)[1], "- Cowork");
 }
 
 #[test]

--- a/rust/crates/ccusage/src/adapter/all/types.rs
+++ b/rust/crates/ccusage/src/adapter/all/types.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::{cmp::Ordering, collections::BTreeSet};
 
 use serde_json::Value;
 
@@ -42,6 +42,24 @@ pub(super) struct LoadedAgentRows {
     pub(super) index: usize,
     pub(super) agent: &'static str,
     pub(super) agent_rows: AgentRows,
+}
+
+const AGENT_ORDER: &[&str] = &[
+    "claude", "cowork", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose",
+    "openclaw", "kilo", "copilot", "gemini", "kimi", "qwen",
+];
+
+pub(super) fn compare_agents(a: &str, b: &str) -> Ordering {
+    match (agent_order_index(a), agent_order_index(b)) {
+        (Some(a), Some(b)) => a.cmp(&b),
+        (Some(_), None) => Ordering::Less,
+        (None, Some(_)) => Ordering::Greater,
+        (None, None) => a.cmp(b),
+    }
+}
+
+fn agent_order_index(agent: &str) -> Option<usize> {
+    AGENT_ORDER.iter().position(|known| *known == agent)
 }
 
 #[derive(Default)]
@@ -91,9 +109,11 @@ impl AllAccumulator {
         for breakdown in &mut agent_breakdowns {
             breakdown.period = period.clone();
         }
-        agent_breakdowns.sort_by(|a, b| a.agent.cmp(b.agent));
+        agent_breakdowns.sort_by(|a, b| compare_agents(a.agent, b.agent));
         let mut model_breakdowns = aggregate_model_breakdowns(&agent_breakdowns);
         model_breakdowns.sort_by(|a, b| b.cost.total_cmp(&a.cost));
+        let mut metadata_agents = self.agents.into_iter().collect::<Vec<_>>();
+        metadata_agents.sort_by(|a, b| compare_agents(a, b));
         AllRow {
             period,
             agent: "all",
@@ -105,7 +125,7 @@ impl AllAccumulator {
             total_tokens: self.total_tokens,
             total_cost: self.total_cost,
             metadata: None,
-            metadata_agents: Some(self.agents.into_iter().collect()),
+            metadata_agents: Some(metadata_agents),
             agent_breakdowns: Some(agent_breakdowns),
             model_breakdowns,
         }

--- a/rust/crates/ccusage/src/adapter/claude/daily.rs
+++ b/rust/crates/ccusage/src/adapter/claude/daily.rs
@@ -21,17 +21,17 @@ use crate::{
 
 use super::{
     chunk_file_indexes_by_size, has_unsupported_null_field, is_semver_prefix,
-    paths::{claude_paths, extract_project, usage_files},
+    paths::{extract_project, usage_files},
     usage_dedupe_hash,
 };
 
-pub(super) fn load_daily_summaries_inner(
+pub(super) fn load_daily_summaries_from_paths(
     shared: &SharedArgs,
+    paths: &[PathBuf],
     project_filter: Option<&str>,
     group_by_project: bool,
 ) -> Result<Vec<UsageSummary>> {
-    let paths = claude_paths()?;
-    let files = usage_files(&paths, project_filter);
+    let files = usage_files(paths, project_filter);
     if files.is_empty() {
         return Ok(Vec::new());
     }

--- a/rust/crates/ccusage/src/adapter/claude/mod.rs
+++ b/rust/crates/ccusage/src/adapter/claude/mod.rs
@@ -23,6 +23,8 @@ use crate::{
     UsageSummary,
 };
 
+#[allow(unused_imports)]
+pub(crate) use paths::normalize_claude_config_path;
 #[cfg(test)]
 pub(crate) use paths::timestamp_from_line;
 pub(crate) use paths::{
@@ -35,7 +37,8 @@ pub(crate) fn load_entries(
     project_filter: Option<&str>,
 ) -> Result<Vec<LoadedEntry>> {
     progress::track_usage_load(progress::UsageLoadAgent::Claude, shared.json, || {
-        load_entries_inner(shared, project_filter)
+        let paths = claude_paths()?;
+        load_entries_from_paths(shared, &paths, project_filter, "Claude")
     })
 }
 
@@ -45,19 +48,39 @@ pub(crate) fn load_daily_summaries(
     group_by_project: bool,
 ) -> Result<Vec<UsageSummary>> {
     progress::track_usage_load(progress::UsageLoadAgent::Claude, shared.json, || {
-        daily::load_daily_summaries_inner(shared, project_filter, group_by_project)
+        let paths = claude_paths()?;
+        daily::load_daily_summaries_from_paths(shared, &paths, project_filter, group_by_project)
     })
+}
+
+pub(crate) fn load_daily_summaries_from_paths(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    daily::load_daily_summaries_from_paths(shared, paths, project_filter, group_by_project)
+}
+
+pub(crate) fn load_entries_from_paths(
+    shared: &SharedArgs,
+    paths: &[PathBuf],
+    project_filter: Option<&str>,
+    debug_label: &str,
+) -> Result<Vec<LoadedEntry>> {
+    load_entries_inner(shared, paths, project_filter, debug_label)
 }
 
 fn load_entries_inner(
     shared: &SharedArgs,
+    paths: &[PathBuf],
     project_filter: Option<&str>,
+    debug_label: &str,
 ) -> Result<Vec<LoadedEntry>> {
-    let paths = claude_paths()?;
     debug_log(
         shared,
         format!(
-            "Scanning Claude data directories: {}",
+            "Scanning {debug_label} data directories: {}",
             paths
                 .iter()
                 .map(|path| path.display().to_string())
@@ -65,7 +88,7 @@ fn load_entries_inner(
                 .join(", ")
         ),
     );
-    let files = usage_files(&paths, project_filter);
+    let files = usage_files(paths, project_filter);
     debug_log(shared, format!("Found {} JSONL usage files", files.len()));
     if files.is_empty() {
         return Ok(Vec::new());

--- a/rust/crates/ccusage/src/adapter/claude/paths.rs
+++ b/rust/crates/ccusage/src/adapter/claude/paths.rs
@@ -44,7 +44,7 @@ pub(crate) fn claude_paths() -> Result<Vec<PathBuf>> {
     Ok(paths)
 }
 
-fn normalize_claude_config_path(raw: &str) -> PathBuf {
+pub(crate) fn normalize_claude_config_path(raw: &str) -> PathBuf {
     let path = expand_home_path(raw);
     if path.file_name().is_some_and(|name| name == "projects") && path.is_dir() {
         return path.parent().map(Path::to_path_buf).unwrap_or(path);
@@ -52,7 +52,7 @@ fn normalize_claude_config_path(raw: &str) -> PathBuf {
     path
 }
 
-fn expand_home_path(raw: &str) -> PathBuf {
+pub(crate) fn expand_home_path(raw: &str) -> PathBuf {
     if raw == "~" {
         if let Some(home) = home::home_dir() {
             return home;

--- a/rust/crates/ccusage/src/adapter/cowork/README.md
+++ b/rust/crates/ccusage/src/adapter/cowork/README.md
@@ -1,0 +1,25 @@
+# Cowork Adapter
+
+The Cowork adapter reads Claude Desktop local agent mode sessions as a separate
+`cowork` source.
+
+Default discovery on macOS:
+
+`~/Library/Application Support/Claude/local-agent-mode-sessions/**/local_*/.claude/projects/**/*.jsonl`
+
+Cowork stores Claude-compatible usage JSONL records, so token parsing, model
+mapping, cost calculation, and deduplication are shared with the Claude adapter.
+
+Set `COWORK_CONFIG_DIR` to override discovery. The value is comma-separated and
+each entry may be:
+
+- a `local-agent-mode-sessions` directory;
+- a concrete `.claude` config directory;
+- a `projects` directory inside a `.claude` config directory.
+
+Supported reports:
+
+- `ccusage cowork`
+- `ccusage cowork daily`
+- `ccusage cowork monthly`
+- `ccusage cowork session`

--- a/rust/crates/ccusage/src/adapter/cowork/mod.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/mod.rs
@@ -175,9 +175,9 @@ mod tests {
     fn loads_cowork_daily_summaries_from_local_agent_sessions() {
         let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
-            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+            "local-agent-mode-sessions/workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
         });
-        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let _guard = CoworkConfigDirGuard::set(&fixture.path("local-agent-mode-sessions"));
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -198,9 +198,9 @@ mod tests {
     fn loads_cowork_entries_with_session_and_project_metadata() {
         let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
-            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+            "local-agent-mode-sessions/workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
         });
-        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let _guard = CoworkConfigDirGuard::set(&fixture.path("local-agent-mode-sessions"));
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),
@@ -219,9 +219,9 @@ mod tests {
     fn builds_cowork_session_report_with_session_metadata() {
         let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({
-            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+            "local-agent-mode-sessions/workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
         });
-        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let _guard = CoworkConfigDirGuard::set(&fixture.path("local-agent-mode-sessions"));
         let shared = SharedArgs {
             mode: CostMode::Display,
             timezone: Some("UTC".to_string()),

--- a/rust/crates/ccusage/src/adapter/cowork/mod.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/mod.rs
@@ -1,1 +1,243 @@
 mod paths;
+
+use std::collections::BTreeMap;
+
+use serde_json::{json, Value};
+
+use crate::{
+    adapter::claude,
+    cli::{AgentCommandArgs, AgentReportKind, SharedArgs, WeekDay},
+    filter_and_sort_summaries, print_json_or_jq, print_usage_table, progress, sort_summaries,
+    summarize_summaries_by_bucket, totals_json, wants_json, BucketKind, LoadedEntry, Result,
+    SessionAccumulator, UsageSummary,
+};
+
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+) -> Result<Vec<LoadedEntry>> {
+    progress::track_usage_load(progress::UsageLoadAgent::Cowork, shared.json, || {
+        claude::load_entries_from_paths(shared, &paths::cowork_paths()?, project_filter, "Cowork")
+    })
+}
+
+pub(crate) fn load_daily_summaries(
+    shared: &SharedArgs,
+    project_filter: Option<&str>,
+    group_by_project: bool,
+) -> Result<Vec<UsageSummary>> {
+    progress::track_usage_load(progress::UsageLoadAgent::Cowork, shared.json, || {
+        claude::load_daily_summaries_from_paths(
+            shared,
+            &paths::cowork_paths()?,
+            project_filter,
+            group_by_project,
+        )
+    })
+}
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let rows = match args.kind {
+        AgentReportKind::Daily => {
+            let mut rows = load_daily_summaries(&shared, None, false)?;
+            filter_and_sort_summaries(&mut rows, &shared, |row| {
+                row.date.as_deref().unwrap_or_default()
+            });
+            rows
+        }
+        AgentReportKind::Monthly => {
+            let mut daily = load_daily_summaries(&shared, None, false)?;
+            filter_and_sort_summaries(&mut daily, &shared, |row| {
+                row.date.as_deref().unwrap_or_default()
+            });
+            let mut monthly =
+                summarize_summaries_by_bucket(&daily, BucketKind::Monthly, WeekDay::Sunday);
+            sort_summaries(&mut monthly, &shared.order, |row| {
+                row.month.as_deref().unwrap_or_default()
+            });
+            monthly
+        }
+        AgentReportKind::Session => {
+            let entries = load_entries(&shared, None)?;
+            let mut rows = summarize_sessions(&entries, shared.timezone.as_deref())?;
+            filter_session_summaries(&mut rows, &shared);
+            sort_summaries(&mut rows, &shared.order, |row| {
+                super::opencode::summary_period(row)
+            });
+            rows
+        }
+        AgentReportKind::Weekly => unreachable!("Cowork weekly reports are not exposed by CLI"),
+    };
+
+    if wants_json(&shared) {
+        return print_json_or_jq(report_from_rows(&rows, args.kind), shared.jq.as_deref());
+    }
+
+    print_usage_table(
+        "Cowork Token Usage Report",
+        super::opencode::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}
+
+fn summarize_sessions(
+    entries: &[LoadedEntry],
+    timezone: Option<&str>,
+) -> Result<Vec<UsageSummary>> {
+    let mut groups = BTreeMap::<(String, String), SessionAccumulator>::new();
+    for entry in entries {
+        groups
+            .entry((entry.project_path.to_string(), entry.session_id.to_string()))
+            .or_default()
+            .add_entry(entry);
+    }
+    groups
+        .into_values()
+        .map(|group| group.into_summary(timezone))
+        .collect()
+}
+
+fn filter_session_summaries(rows: &mut Vec<UsageSummary>, shared: &SharedArgs) {
+    if shared.since.is_none() && shared.until.is_none() {
+        return;
+    }
+    rows.retain(|row| {
+        let date = row
+            .last_activity
+            .as_deref()
+            .unwrap_or_default()
+            .replace('-', "");
+        shared.since.as_ref().is_none_or(|since| &date >= since)
+            && shared.until.as_ref().is_none_or(|until| &date <= until)
+    });
+}
+
+fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| super::opencode::agent_summary_json(row, kind, kind == AgentReportKind::Session))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{env, ffi::OsString, path::Path, sync::Mutex};
+
+    use ccusage_test_support::fs_fixture;
+    use serde_json::json;
+
+    use super::*;
+    use crate::cli::{AgentReportKind, CostMode, SharedArgs};
+
+    static COWORK_CONFIG_DIR_LOCK: Mutex<()> = Mutex::new(());
+
+    struct CoworkConfigDirGuard {
+        previous: Option<OsString>,
+    }
+
+    impl CoworkConfigDirGuard {
+        fn set(path: &Path) -> Self {
+            let previous = env::var_os("COWORK_CONFIG_DIR");
+            env::set_var("COWORK_CONFIG_DIR", path);
+            Self { previous }
+        }
+    }
+
+    impl Drop for CoworkConfigDirGuard {
+        fn drop(&mut self) {
+            if let Some(previous) = self.previous.take() {
+                env::set_var("COWORK_CONFIG_DIR", previous);
+            } else {
+                env::remove_var("COWORK_CONFIG_DIR");
+            }
+        }
+    }
+
+    #[test]
+    fn loads_cowork_daily_summaries_from_local_agent_sessions() {
+        let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        });
+        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let rows = load_daily_summaries(&shared, None, false).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].date.as_deref(), Some("2025-01-10"));
+        assert_eq!(rows[0].input_tokens, 100);
+        assert_eq!(rows[0].output_tokens, 25);
+        assert_eq!(rows[0].cache_creation_tokens, 10);
+        assert_eq!(rows[0].cache_read_tokens, 5);
+    }
+
+    #[test]
+    fn loads_cowork_entries_with_session_and_project_metadata() {
+        let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        });
+        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries(&shared, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_ref(), "project-a");
+        assert_eq!(entries[0].session_id.as_ref(), "session-a");
+        assert_eq!(entries[0].project_path.as_ref(), "project-a");
+    }
+
+    #[test]
+    fn builds_cowork_session_report_with_session_metadata() {
+        let _lock = COWORK_CONFIG_DIR_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "workspace/session/local_111/.claude/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","version":"2.1.142","sessionId":"session-a","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+        });
+        let _guard = CoworkConfigDirGuard::set(fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries(&shared, None).unwrap();
+        let rows = summarize_sessions(&entries, shared.timezone.as_deref()).unwrap();
+        let report = report_from_rows(&rows, AgentReportKind::Session);
+
+        assert_eq!(report["sessions"][0]["sessionId"], "session-a");
+        assert_eq!(report["sessions"][0]["projectPath"], "project-a");
+        assert_eq!(report["sessions"][0]["lastActivity"], "2025-01-10");
+        assert_eq!(
+            report["sessions"][0]["modelsUsed"],
+            json!(["claude-opus-4-6"])
+        );
+    }
+}

--- a/rust/crates/ccusage/src/adapter/cowork/mod.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/mod.rs
@@ -1,0 +1,5 @@
+mod paths;
+
+#[cfg(test)]
+#[allow(unused_imports)]
+pub(crate) use paths::cowork_paths_from_root;

--- a/rust/crates/ccusage/src/adapter/cowork/mod.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/mod.rs
@@ -1,5 +1,1 @@
 mod paths;
-
-#[cfg(test)]
-#[allow(unused_imports)]
-pub(crate) use paths::cowork_paths_from_root;

--- a/rust/crates/ccusage/src/adapter/cowork/paths.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/paths.rs
@@ -28,6 +28,9 @@ fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {
             }
             continue;
         }
+        if !is_cowork_sessions_root(&path) {
+            continue;
+        }
         for discovered in cowork_paths_from_root(&path) {
             if seen.insert(discovered.clone()) {
                 paths.push(discovered);
@@ -41,6 +44,12 @@ fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {
     }
     paths.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
     Ok(paths)
+}
+
+fn is_cowork_sessions_root(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .is_some_and(|name| name == "local-agent-mode-sessions")
 }
 
 pub(crate) fn cowork_paths_from_root(root: &Path) -> Vec<PathBuf> {
@@ -129,14 +138,14 @@ mod tests {
     #[test]
     fn sorts_mixed_env_paths_globally() {
         let fixture = fs_fixture!({
-            "root/local_b/.claude/projects/project-b/session-b.jsonl": "",
-            "root/local_c/.claude/projects/project-c/session-c.jsonl": "",
+            "local-agent-mode-sessions/local_b/.claude/projects/project-b/session-b.jsonl": "",
+            "local-agent-mode-sessions/local_c/.claude/projects/project-c/session-c.jsonl": "",
             "a-direct/.claude/projects/project-a/session-a.jsonl": "",
         });
 
         let paths = super::cowork_paths_from_env(&format!(
             "{},{}",
-            fixture.path("root").display(),
+            fixture.path("local-agent-mode-sessions").display(),
             fixture.path("a-direct/.claude").display()
         ))
         .unwrap();
@@ -145,10 +154,23 @@ mod tests {
             paths,
             vec![
                 fixture.path("a-direct/.claude"),
-                fixture.path("root/local_b/.claude"),
-                fixture.path("root/local_c/.claude"),
+                fixture.path("local-agent-mode-sessions/local_b/.claude"),
+                fixture.path("local-agent-mode-sessions/local_c/.claude"),
             ]
         );
+    }
+
+    #[test]
+    fn rejects_arbitrary_env_roots_before_recursive_discovery() {
+        let fixture = fs_fixture!({
+            "home/local_111/.claude/projects/project-a/session-a.jsonl": "",
+        });
+
+        let error = super::cowork_paths_from_env(&fixture.path("home").display().to_string())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("No valid Cowork data directories found in COWORK_CONFIG_DIR"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/cowork/paths.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/paths.rs
@@ -2,16 +2,15 @@ use std::path::{Path, PathBuf};
 
 use crate::Result;
 
-#[allow(dead_code)]
 pub(crate) fn cowork_paths() -> Result<Vec<PathBuf>> {
     if let Ok(env_paths) = std::env::var("COWORK_CONFIG_DIR") {
         return cowork_paths_from_env(&env_paths);
     }
     let home =
         crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
-    Ok(cowork_paths_from_root(
-        &home.join("Library/Application Support/Claude/local-agent-mode-sessions"),
-    ))
+    Ok(cowork_paths_from_root(&home.join(
+        "Library/Application Support/Claude/local-agent-mode-sessions",
+    )))
 }
 
 fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {

--- a/rust/crates/ccusage/src/adapter/cowork/paths.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/paths.rs
@@ -1,0 +1,140 @@
+use std::path::{Path, PathBuf};
+
+use crate::Result;
+
+#[allow(dead_code)]
+pub(crate) fn cowork_paths() -> Result<Vec<PathBuf>> {
+    if let Ok(env_paths) = std::env::var("COWORK_CONFIG_DIR") {
+        return cowork_paths_from_env(&env_paths);
+    }
+    let home =
+        crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
+    Ok(cowork_paths_from_root(
+        &home.join("Library/Application Support/Claude/local-agent-mode-sessions"),
+    ))
+}
+
+fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = crate::fast::FxHashSet::default();
+    for raw in env_paths
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        let path = crate::adapter::claude::normalize_claude_config_path(raw);
+        if path.join("projects").is_dir() {
+            if seen.insert(path.clone()) {
+                paths.push(path);
+            }
+            continue;
+        }
+        for discovered in cowork_paths_from_root(&path) {
+            if seen.insert(discovered.clone()) {
+                paths.push(discovered);
+            }
+        }
+    }
+    if paths.is_empty() {
+        return Err(crate::cli_error(format!(
+            "No valid Cowork data directories found in COWORK_CONFIG_DIR. Expected each path to be a Cowork local-agent-mode-sessions directory, a .claude config directory containing 'projects/', or the 'projects/' directory itself: {env_paths}"
+        )));
+    }
+    Ok(paths)
+}
+
+pub(crate) fn cowork_paths_from_root(root: &Path) -> Vec<PathBuf> {
+    let mut paths = Vec::new();
+    collect_cowork_paths(root, &mut paths);
+    paths.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
+    paths
+}
+
+fn collect_cowork_paths(dir: &Path, paths: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if !file_type.is_dir() {
+            continue;
+        }
+        let path = entry.path();
+        if path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .is_some_and(|name| name.starts_with("local_"))
+        {
+            let config = path.join(".claude");
+            if config.join("projects").is_dir() {
+                paths.push(config);
+            }
+        }
+        collect_cowork_paths(&path, paths);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use ccusage_test_support::fs_fixture;
+
+    use super::cowork_paths_from_root;
+
+    #[test]
+    fn discovers_local_agent_mode_claude_config_dirs() {
+        let fixture = fs_fixture!({
+            "workspace-a/session-a/local_111/.claude/projects/project-a/session-a.jsonl": "",
+            "workspace-a/session-a/local_222/.claude/projects/project-b/session-b.jsonl": "",
+            "workspace-a/session-a/not-local/.claude/projects/project-c/session-c.jsonl": "",
+            "workspace-b/session-b/local_333/no-claude/projects/project-d/session-d.jsonl": "",
+        });
+
+        let paths = cowork_paths_from_root(fixture.root());
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("workspace-a/session-a/local_111/.claude"),
+                fixture.path("workspace-a/session-a/local_222/.claude"),
+            ]
+        );
+    }
+
+    #[test]
+    fn accepts_direct_claude_and_projects_env_paths() {
+        let fixture = fs_fixture!({
+            "direct/.claude/projects/project-a/session-a.jsonl": "",
+            "other/.claude/projects/project-b/session-b.jsonl": "",
+        });
+
+        let paths = super::cowork_paths_from_env(&format!(
+            "{},{}",
+            fixture.path("direct/.claude").display(),
+            fixture.path("other/.claude/projects").display()
+        ))
+        .unwrap();
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("direct/.claude"),
+                fixture.path("other/.claude"),
+            ]
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_cowork_env_paths() {
+        let fixture = fs_fixture!({
+            "empty": "",
+        });
+
+        let error = super::cowork_paths_from_env(&fixture.path("empty").display().to_string())
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("No valid Cowork data directories found in COWORK_CONFIG_DIR"));
+    }
+}

--- a/rust/crates/ccusage/src/adapter/cowork/paths.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/paths.rs
@@ -40,6 +40,7 @@ fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {
             "No valid Cowork data directories found in COWORK_CONFIG_DIR. Expected each path to be a Cowork local-agent-mode-sessions directory, a .claude config directory containing 'projects/', or the 'projects/' directory itself: {env_paths}"
         )));
     }
+    paths.sort_by_cached_key(|path| path.to_string_lossy().into_owned());
     Ok(paths)
 }
 
@@ -70,6 +71,7 @@ fn collect_cowork_paths(dir: &Path, paths: &mut Vec<PathBuf>) {
             let config = path.join(".claude");
             if config.join("projects").is_dir() {
                 paths.push(config);
+                continue;
             }
         }
         collect_cowork_paths(&path, paths);
@@ -123,6 +125,47 @@ mod tests {
                 fixture.path("other/.claude"),
             ]
         );
+    }
+
+    #[test]
+    fn sorts_mixed_env_paths_globally() {
+        let fixture = fs_fixture!({
+            "root/local_b/.claude/projects/project-b/session-b.jsonl": "",
+            "root/local_c/.claude/projects/project-c/session-c.jsonl": "",
+            "a-direct/.claude/projects/project-a/session-a.jsonl": "",
+        });
+
+        let paths = super::cowork_paths_from_env(&format!(
+            "{},{}",
+            fixture.path("root").display(),
+            fixture.path("a-direct/.claude").display()
+        ))
+        .unwrap();
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("a-direct/.claude"),
+                fixture.path("root/local_b/.claude"),
+                fixture.path("root/local_c/.claude"),
+            ]
+        );
+    }
+
+    #[test]
+    fn dedupes_equivalent_direct_claude_and_projects_env_paths() {
+        let fixture = fs_fixture!({
+            "direct/.claude/projects/project-a/session-a.jsonl": "",
+        });
+
+        let paths = super::cowork_paths_from_env(&format!(
+            "{},{}",
+            fixture.path("direct/.claude").display(),
+            fixture.path("direct/.claude/projects").display()
+        ))
+        .unwrap();
+
+        assert_eq!(paths, vec![fixture.path("direct/.claude")]);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/cowork/paths.rs
+++ b/rust/crates/ccusage/src/adapter/cowork/paths.rs
@@ -6,11 +6,28 @@ pub(crate) fn cowork_paths() -> Result<Vec<PathBuf>> {
     if let Ok(env_paths) = std::env::var("COWORK_CONFIG_DIR") {
         return cowork_paths_from_env(&env_paths);
     }
-    let home =
-        crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
-    Ok(cowork_paths_from_root(&home.join(
-        "Library/Application Support/Claude/local-agent-mode-sessions",
-    )))
+    Ok(cowork_paths_from_root(&default_sessions_root()?))
+}
+
+fn default_sessions_root() -> Result<PathBuf> {
+    #[cfg(target_os = "windows")]
+    {
+        let local_app_data = std::env::var("LOCALAPPDATA")
+            .map_err(|_| crate::cli_error("LOCALAPPDATA environment variable is not set"))?;
+        Ok(PathBuf::from(local_app_data)
+            .join("Packages")
+            .join("Claude_pzs8sxrjxfjjc")
+            .join("LocalCache")
+            .join("Roaming")
+            .join("Claude")
+            .join("local-agent-mode-sessions"))
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let home = crate::home::home_dir()
+            .ok_or_else(|| crate::cli_error("home directory is not set"))?;
+        Ok(home.join("Library/Application Support/Claude/local-agent-mode-sessions"))
+    }
 }
 
 fn cowork_paths_from_env(env_paths: &str) -> Result<Vec<PathBuf>> {

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -4,6 +4,7 @@ pub(crate) mod claude;
 pub(crate) mod codebuff;
 pub(crate) mod codex;
 pub(crate) mod copilot;
+pub(crate) mod cowork;
 pub(crate) mod droid;
 pub(crate) mod gemini;
 pub(crate) mod goose;

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -243,6 +243,7 @@ fn is_agent_command(command: &str) -> bool {
             | "pi"
             | "goose"
             | "kilo"
+            | "cowork"
             | "qwen"
             | "copilot"
             | "gemini"
@@ -755,6 +756,15 @@ mod tests {
         );
 
         assert_eq!(open_claw_path.as_deref(), Some("/tmp/openclaw"));
+    }
+
+    #[test]
+    fn detects_cowork_as_agent_config_namespace() {
+        let command = detect_config_command(&["cowork".to_string(), "session".to_string()]);
+
+        assert_eq!(command.raw, "cowork session");
+        assert_eq!(command.agent.as_deref(), Some("cowork"));
+        assert_eq!(command.report, "session");
     }
 
     fn context(value: Value, raw: &str, agent: Option<&str>, report: &str) -> ConfigContext {

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -34,6 +34,8 @@ pub(crate) struct CcusageConfig {
     pub(crate) pi: Option<PiConfig>,
     /// Goose configuration.
     pub(crate) goose: Option<GooseConfig>,
+    /// Cowork configuration.
+    pub(crate) cowork: Option<CoworkConfig>,
     /// OpenClaw configuration.
     pub(crate) openclaw: Option<OpenClawConfig>,
     /// Kilo configuration.
@@ -193,6 +195,21 @@ pub(crate) struct GooseConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct GooseCommandsConfig {
+    pub(crate) daily: Option<SharedOptions>,
+    pub(crate) monthly: Option<SharedOptions>,
+    pub(crate) session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CoworkConfig {
+    pub(crate) defaults: Option<SharedOptions>,
+    pub(crate) commands: Option<CoworkCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct CoworkCommandsConfig {
     pub(crate) daily: Option<SharedOptions>,
     pub(crate) monthly: Option<SharedOptions>,
     pub(crate) session: Option<SharedOptions>,
@@ -1005,6 +1022,7 @@ mod tests {
         assert!(schema_property(&schema, &["codebuff", "defaults", "speed"]).is_none());
         assert!(schema_property(&schema, &["pi", "defaults", "piPath"]).is_some());
         assert!(schema_property(&schema, &["goose", "defaults", "piPath"]).is_none());
+        assert!(schema_property(&schema, &["cowork", "defaults", "speed"]).is_none());
         assert!(schema_property(&schema, &["openclaw", "defaults", "openClawPath"]).is_some());
         assert!(schema_property(&schema, &["kilo", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["gemini", "defaults", "openClawPath"]).is_none());
@@ -1042,9 +1060,9 @@ mod tests {
             &schema,
             "ccusage-config",
             &[
-                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "cowork",
+                "defaults", "droid", "gemini", "goose", "hermes", "kilo", "kimi", "opencode",
+                "openclaw", "pi", "qwen",
             ],
         );
         assert!(
@@ -1134,6 +1152,13 @@ mod tests {
             "goose": {
                 "commands": {
                     "daily": {
+                        "json": true
+                    }
+                }
+            },
+            "cowork": {
+                "commands": {
+                    "session": {
                         "json": true
                     }
                 }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -143,7 +143,7 @@ fn main() -> Result<()> {
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
-        Some(Command::Cowork(_args)) => Err(cli_error("cowork runtime is not implemented yet")),
+        Some(Command::Cowork(args)) => adapter::cowork::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         None => {
             let args = AgentCommandArgs {

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -143,6 +143,7 @@ fn main() -> Result<()> {
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
+        Some(Command::Cowork(_args)) => Err(cli_error("cowork runtime is not implemented yet")),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         None => {
             let args = AgentCommandArgs {

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -384,6 +384,39 @@ mod tests {
     }
 
     #[test]
+    fn loads_claude_compatible_entries_from_explicit_config_paths() {
+        let fixture = fs_fixture!({
+            "config-a/projects/project-a/session-a.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_a","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"requestId":"req_a","costUSD":0.01}"#,
+            "config-b/projects/project-b/session-b.jsonl": r#"{"timestamp":"2025-01-11T10:00:00.000Z","message":{"id":"msg_b","model":"claude-sonnet-4-20250514","usage":{"input_tokens":20,"output_tokens":30,"cache_creation_input_tokens":4,"cache_read_input_tokens":2}},"requestId":"req_b","costUSD":0.04}"#,
+        });
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = adapter::claude::load_entries_from_paths(
+            &shared,
+            &[fixture.path("config-a"), fixture.path("config-b")],
+            None,
+            "Test",
+        )
+        .unwrap();
+        let daily = adapter::claude::load_daily_summaries_from_paths(
+            &shared,
+            &[fixture.path("config-a"), fixture.path("config-b")],
+            None,
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(daily.len(), 2);
+        assert_eq!(entries[0].project.as_ref(), "project-a");
+        assert_eq!(entries[1].project.as_ref(), "project-b");
+    }
+
+    #[test]
     fn loads_daily_summaries_like_loaded_entry_aggregation() {
         let _guard = CLAUDE_CONFIG_DIR_LOCK.lock().unwrap();
         let fixture = fs_fixture!({

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -406,7 +406,7 @@ mod tests {
             &shared,
             &[fixture.path("config-a"), fixture.path("config-b")],
             None,
-            false,
+            true,
         )
         .unwrap();
 
@@ -414,6 +414,8 @@ mod tests {
         assert_eq!(daily.len(), 2);
         assert_eq!(entries[0].project.as_ref(), "project-a");
         assert_eq!(entries[1].project.as_ref(), "project-b");
+        assert_eq!(daily[0].project.as_deref(), Some("project-a"));
+        assert_eq!(daily[1].project.as_deref(), Some("project-b"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -29,6 +29,7 @@ pub(crate) enum UsageLoadAgent {
     Copilot,
     Gemini,
     Kimi,
+    Cowork,
     OpenClaw,
 }
 
@@ -59,6 +60,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Copilot => "GitHub Copilot CLI",
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
+        UsageLoadAgent::Cowork => "Cowork",
         UsageLoadAgent::OpenClaw => "OpenClaw",
     }
 }

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -778,6 +778,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "codex",
     "commands",
     "copilot",
+    "cowork",
     "defaults",
     "droid",
     "gemini",


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the `feat/cowork-usage-source` branch (originally PR #1199, closed) to make `ccusage cowork` fully functional, including on Windows.

### Fix 1: Missing `cli-commands.json` entries

The cowork subcommands (`daily`, `monthly`, `session`) were absent from `cli-commands.json`, which is used to generate the CLI help text and command dispatch. This caused:

```
Unknown command 'cowork'
```

even though the Rust parser already handled them correctly.

### Fix 2: Windows default path support

`paths.rs` only hardcoded the macOS path as the default:

```
~/Library/Application Support/Claude/local-agent-mode-sessions
```

On Windows, Claude Desktop (Microsoft Store edition) stores Cowork sessions at:

```
%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions
```

Added `#[cfg(target_os = "windows")]` / `#[cfg(not(target_os = "windows"))]` branching so the correct default is selected per platform. `COWORK_CONFIG_DIR` continues to override on all platforms.

## Relation to #1199 / #1200

This branch is based on `feat/cowork-usage-source` (the branch from the auto-closed PR #1199) and adds the two fixes above. Closes #1200.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1372"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784969807&installation_id=139163553&pr_number=1372&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1372&signature=93a980338fdae6c579f5ec7343d7453af2f7df1df21caeecb980d1812b7e45e6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `ccusage cowork` fully functional across platforms by adding the missing CLI entries and selecting the correct default Cowork session path on Windows. Cowork `daily`, `monthly`, and `session` now work on macOS, Linux, and Windows; `COWORK_CONFIG_DIR` still overrides.

- **Bug Fixes**
  - Added `cowork` subcommand entries to `rust/crates/ccusage-cli/src/cli-commands.json` so help/dispatch matches the Rust parser (supports `daily`, `monthly`, `session`).
  - Implemented OS-specific default discovery for Cowork sessions:
    - Windows: `%LOCALAPPDATA%\Packages\Claude_pzs8sxrjxfjjc\LocalCache\Roaming\Claude\local-agent-mode-sessions`
    - Non-Windows keeps existing default; `COWORK_CONFIG_DIR` overrides everywhere.

<sup>Written for commit 2046391efdacbecbc411ca8f861b7c862e2412fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1372?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

