### PR TITLE
feat(codex): add project filtering and instances

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -148,6 +148,9 @@ bunx ccusage daily --timezone UTC  # Use UTC timezone
 bunx ccusage claude daily --instances  # Group Claude Code by project/instance
 bunx ccusage claude daily --project myproject  # Filter to specific Claude project
 bunx ccusage claude daily --instances --project myproject --json  # Combined usage
+bunx ccusage codex daily --instances  # Group Codex by project/instance
+bunx ccusage codex daily --project myproject  # Filter to specific Codex project
+bunx ccusage codex daily --instances --project myproject --json  # Combined usage
 
 # Compact mode for screenshots/sharing
 bunx ccusage --compact  # Force compact table mode
@@ -176,7 +179,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 🔄 **Cache Token Support**: Tracks and displays cache creation and cache read tokens separately
 - 🌐 **Offline Mode**: Use pre-cached pricing data without network connectivity with `--offline`
 - 🧩 **Custom Pricing Overrides**: Override token pricing per raw model name in `ccusage.json` without rebuilding
-- 🏗️ **Claude Instance Support**: Group Claude Code usage by project with `--instances` and filter by specific projects
+- 🏗️ **Project Filtering**: Group Claude Code or Codex usage by project with `--instances` and filter by specific projects with `--project`
 - 🌍 **Timezone Support**: Configure timezone for date grouping with `--timezone` option
 - ⚙️ **Configuration Files**: Set defaults with JSON configuration files, complete with IDE autocomplete and validation
 

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -2709,6 +2709,16 @@
 											"markdownDescription": "Disable parallel file processing.",
 											"type": "boolean"
 										},
+										"instances": {
+											"description": "Show usage breakdown by Codex project instance.",
+											"markdownDescription": "Show usage breakdown by Codex project instance.",
+											"type": "boolean"
+										},
+										"project": {
+											"description": "Filter to a Codex project name or path.",
+											"markdownDescription": "Filter to a Codex project name or path.",
+											"type": "string"
+										},
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
@@ -2868,6 +2878,16 @@
 											"markdownDescription": "Disable parallel file processing.",
 											"type": "boolean"
 										},
+										"instances": {
+											"description": "Show usage breakdown by Codex project instance.",
+											"markdownDescription": "Show usage breakdown by Codex project instance.",
+											"type": "boolean"
+										},
+										"project": {
+											"description": "Filter to a Codex project name or path.",
+											"markdownDescription": "Filter to a Codex project name or path.",
+											"type": "string"
+										},
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
@@ -3026,6 +3046,16 @@
 											"description": "Disable parallel file processing.",
 											"markdownDescription": "Disable parallel file processing.",
 											"type": "boolean"
+										},
+										"instances": {
+											"description": "Show usage breakdown by Codex project instance.",
+											"markdownDescription": "Show usage breakdown by Codex project instance.",
+											"type": "boolean"
+										},
+										"project": {
+											"description": "Filter to a Codex project name or path.",
+											"markdownDescription": "Filter to a Codex project name or path.",
+											"type": "string"
 										},
 										"speed": {
 											"default": "auto",
@@ -3188,6 +3218,16 @@
 									"description": "Disable parallel file processing.",
 									"markdownDescription": "Disable parallel file processing.",
 									"type": "boolean"
+								},
+								"instances": {
+									"description": "Show usage breakdown by Codex project instance.",
+									"markdownDescription": "Show usage breakdown by Codex project instance.",
+									"type": "boolean"
+								},
+								"project": {
+									"description": "Filter to a Codex project name or path.",
+									"markdownDescription": "Filter to a Codex project name or path.",
+									"type": "string"
 								},
 								"speed": {
 									"default": "auto",

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -17,9 +17,15 @@ ccusage codex monthly
 
 # Codex sessions
 ccusage codex session
+
+# Filter to one Codex project
+ccusage codex daily --project ccusage
+
+# Break down Codex usage by project
+ccusage codex daily --instances
 ```
 
-Most users can start with unified reports such as `ccusage daily`. Add the `codex` namespace only when you want to focus the same report shape on Codex usage or pass Codex-specific options such as `--speed`.
+Most users can start with unified reports such as `ccusage daily`. Add the `codex` namespace only when you want to focus the same report shape on Codex usage or pass Codex-specific options such as `--speed`, `--project`, or `--instances`.
 
 ## Data Source
 
@@ -37,7 +43,11 @@ CODEX_HOME="$HOME/.codex,$HOME/.codex-work,$HOME/codex-exec-logs" ccusage codex 
 | `ccusage codex monthly` | Aggregate usage by month     | [Monthly Usage](/guide/monthly-reports) |
 | `ccusage codex session` | Group usage by Codex session | [Session Usage](/guide/session-reports) |
 
-These views support `--json`, `--compact`, `--offline`, and `--speed auto|standard|fast`.
+These views support `--json`, `--compact`, `--offline`, `--instances`, `--project`, and `--speed auto|standard|fast`.
+
+`--project` matches the Codex `cwd` recorded in `session_meta` or `turn_context` log entries. Pass either the full project path or the final directory name, for example `--project C:\Users\alice\Projects\ccusage` or `--project ccusage`.
+
+`--instances` groups Codex daily, monthly, and session reports by that same recorded project path. In JSON mode, the default flat report shape is preserved unless `--instances` is passed; with `--instances`, output contains a `projects` object plus overall `totals`.
 
 ## Monthly Example
 
@@ -46,6 +56,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 ## What Gets Calculated
 
 - **Token deltas** – Each `event_msg` with `payload.type === "token_count"` reports cumulative totals. The CLI subtracts the previous totals to recover per-turn token usage (input, cached input, output, reasoning, total).
+- **Project filtering and grouping** – Codex sessions record the workspace path as `cwd`. `--project` filters daily, monthly, and session views to matching workspace paths or final directory names. `--instances` groups those views by project path.
 - **Per-model grouping** – The `turn_context` metadata specifies the active model. We aggregate tokens per day/month and per model. Sessions lacking model metadata (seen in early September 2025 builds) are skipped.
 - **Pricing** – Rates come from LiteLLM's pricing dataset via the shared `LiteLLMPricingFetcher`. Codex's internal review label is resolved to the newest known model for the log date before pricing is calculated.
 - **Speed pricing** – `--speed auto` is the default. It reads `config.toml` from each `CODEX_HOME` root and applies fast pricing when any Codex config has `service_tier = "priority"` or legacy `service_tier = "fast"` configured. Fast mode uses the model-specific LiteLLM multiplier when available and otherwise falls back to 2x pricing. Pass `--speed fast` or `--speed standard` to override config-based detection.

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -181,6 +181,15 @@
 			"choices": ["auto", "standard", "fast"]
 		},
 		{
+			"flags": "-i, --instances",
+			"description": "Show usage breakdown by Codex project instance",
+			"default": "false"
+		},
+		{
+			"flags": "-p, --project <project>",
+			"description": "Filter to a Codex project name or path"
+		},
+		{
 			"flags": "--compact",
 			"description": "Force compact table layout for narrow terminals",
 			"default": "false"

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -284,6 +284,8 @@ fn parse_all_command(
     Ok(Command::All(AgentCommandArgs {
         shared,
         kind,
+        instances: false,
+        project: None,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -317,6 +319,8 @@ fn parse_top_level_session_command(
     Ok(Command::All(AgentCommandArgs {
         shared: args.shared,
         kind: AgentReportKind::Session,
+        instances: false,
+        project: None,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,
@@ -458,12 +462,22 @@ fn parse_codex_command(
 ) -> Result<Command, String> {
     let kind = parse_agent_report_kind(parser, "codex", STANDARD_AGENT_REPORTS)?;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, None);
+    let mut instances = false;
+    let mut project = None;
+    config.apply_agent_args(
+        &mut codex_speed,
+        Some(&mut instances),
+        Some(&mut project),
+        None,
+        None,
+    );
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
         }
         match parser.next_flag()?.as_str() {
+            "-i" | "--instances" => instances = true,
+            "-p" | "--project" => project = Some(parser.value_for("--project")?),
             "--speed" => codex_speed = parse_codex_speed(&parser.value_for("--speed")?)?,
             flag => return Err(format!("Unknown codex option '{flag}'")),
         }
@@ -471,6 +485,8 @@ fn parse_codex_command(
     Ok(Command::Codex(AgentCommandArgs {
         shared,
         kind,
+        instances,
+        project,
         pi_path: None,
         open_claw_path: None,
         codex_speed,
@@ -485,7 +501,7 @@ fn parse_pi_command(
     let kind = parse_agent_report_kind(parser, "pi", STANDARD_AGENT_REPORTS)?;
     let mut pi_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, Some(&mut pi_path), None);
+    config.apply_agent_args(&mut codex_speed, None, None, Some(&mut pi_path), None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -498,6 +514,8 @@ fn parse_pi_command(
     Ok(Command::Pi(AgentCommandArgs {
         shared,
         kind,
+        instances: false,
+        project: None,
         pi_path,
         open_claw_path: None,
         codex_speed,
@@ -512,7 +530,13 @@ fn parse_openclaw_command(
     let kind = parse_agent_report_kind(parser, "openclaw", STANDARD_AGENT_REPORTS)?;
     let mut open_claw_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, Some(&mut open_claw_path));
+    config.apply_agent_args(
+        &mut codex_speed,
+        None,
+        None,
+        None,
+        Some(&mut open_claw_path),
+    );
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -525,6 +549,8 @@ fn parse_openclaw_command(
     Ok(Command::OpenClaw(AgentCommandArgs {
         shared,
         kind,
+        instances: false,
+        project: None,
         pi_path: None,
         open_claw_path,
         codex_speed,
@@ -553,6 +579,8 @@ fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommand
     AgentCommandArgs {
         shared,
         kind,
+        instances: false,
+        project: None,
         pi_path: None,
         open_claw_path: None,
         codex_speed: CodexSpeed::Auto,

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__codex_daily_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__codex_daily_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ccusage-cli/src/tests.rs
+assertion_line: 483
 expression: "help_text_for_args(&[\"ccusage\".to_string(), \"codex\".to_string(),\n\"daily\".to_string(),])"
 ---
 Show Codex token usage grouped by day
@@ -15,6 +16,8 @@ OPTIONS:
   -O, --offline                        Use cached pricing data instead of fetching from LiteLLM (default: false)
   --no-offline                         Negatable of -O, --offline
   --speed [speed]                      Cost speed tier: auto reads Codex config.toml service_tier; use standard or fast to override (default: auto, choices: auto | standard | fast)
+  -i, --instances                      Show usage breakdown by Codex project instance (default: false)
+  -p, --project <project>              Filter to a Codex project name or path
   --compact                            Force compact table layout for narrow terminals (default: false)
   --no-cost                            Hide cost information in table and JSON output (default: false)
   --color                              Enable colored output. FORCE_COLOR=1 has the same effect. (default: auto)

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
+assertion_line: 623
 expression: cases
 ---
 [
@@ -33,9 +34,11 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "instances": false,
         "kind": "Daily",
         "openClawPath": null,
         "piPath": null,
+        "project": null,
         "shared": {
           "breakdown": true,
           "color": true,
@@ -179,9 +182,11 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Fast",
+        "instances": true,
         "kind": "Monthly",
         "openClawPath": null,
         "piPath": null,
+        "project": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -229,9 +234,11 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "instances": false,
         "kind": "Weekly",
         "openClawPath": null,
         "piPath": null,
+        "project": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -279,9 +286,11 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "instances": false,
         "kind": "Session",
         "openClawPath": null,
         "piPath": "/tmp/pi-sessions",
+        "project": null,
         "shared": {
           "breakdown": false,
           "color": false,
@@ -329,9 +338,11 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "instances": false,
         "kind": "Session",
         "openClawPath": "/tmp/openclaw",
         "piPath": null,
+        "project": null,
         "shared": {
           "breakdown": false,
           "color": false,

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -41,6 +41,8 @@ struct TestConfig {
     statusline_cost_source: Option<CostSource>,
     statusline_refresh_interval: Option<u64>,
     codex_speed: Option<CodexSpeed>,
+    codex_instances: Option<bool>,
+    codex_project: Option<&'static str>,
     pi_path: Option<&'static str>,
     open_claw_path: Option<&'static str>,
 }
@@ -97,11 +99,19 @@ impl CliConfig for TestConfig {
     fn apply_agent_args(
         &self,
         codex_speed: &mut CodexSpeed,
+        instances: Option<&mut bool>,
+        project: Option<&mut Option<String>>,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
     ) {
         if let Some(speed) = self.codex_speed {
             *codex_speed = speed;
+        }
+        if let (Some(value), Some(instances)) = (self.codex_instances, instances) {
+            *instances = value;
+        }
+        if let (Some(value), Some(project)) = (self.codex_project, project) {
+            *project = Some(value.to_string());
         }
         if let (Some(path), Some(pi_path)) = (self.pi_path, pi_path) {
             *pi_path = Some(path.to_string());
@@ -210,6 +220,8 @@ fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
         "type": agent,
         "shared": shared_snapshot(&args.shared),
         "kind": format!("{:?}", args.kind),
+        "instances": args.instances,
+        "project": args.project,
         "piPath": args.pi_path,
         "openClawPath": args.open_claw_path,
         "codexSpeed": format!("{:?}", args.codex_speed),
@@ -267,6 +279,20 @@ fn applies_agent_namespace_config_to_codex_speed() {
         panic!("expected codex command");
     };
     assert_eq!(args.codex_speed, CodexSpeed::Fast);
+}
+
+#[test]
+fn applies_agent_namespace_config_to_codex_instances() {
+    let config = TestConfig {
+        codex_instances: Some(true),
+        ..TestConfig::default()
+    };
+
+    let cli = parse_with_config(&["ccusage", "codex", "daily"], &config);
+    let Some(Command::Codex(args)) = cli.command else {
+        panic!("expected codex command");
+    };
+    assert!(args.instances);
 }
 
 #[test]
@@ -534,6 +560,7 @@ fn snapshots_representative_cli_parse_shapes() {
                 "codex",
                 "monthly",
                 "--speed=fast",
+                "--instances",
             ])),
         }),
         json!({
@@ -753,6 +780,24 @@ fn parses_codex_speed_option() {
         panic!("expected codex command");
     };
     assert_eq!(args.codex_speed, CodexSpeed::Fast);
+}
+
+#[test]
+fn parses_codex_project_option() {
+    let cli = parse(&["ccusage", "codex", "daily", "--project", "ccusage"]);
+    let Some(Command::Codex(args)) = cli.command else {
+        panic!("expected codex command");
+    };
+    assert_eq!(args.project.as_deref(), Some("ccusage"));
+}
+
+#[test]
+fn parses_codex_instances_option() {
+    let cli = parse(&["ccusage", "codex", "daily", "--instances"]);
+    let Some(Command::Codex(args)) = cli.command else {
+        panic!("expected codex command");
+    };
+    assert!(args.instances);
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -120,6 +120,8 @@ pub struct StatuslineArgs {
 pub struct AgentCommandArgs {
     pub shared: SharedArgs,
     pub kind: AgentReportKind,
+    pub instances: bool,
+    pub project: Option<String>,
     pub pi_path: Option<String>,
     pub open_claw_path: Option<String>,
     pub codex_speed: CodexSpeed,
@@ -244,6 +246,8 @@ pub trait CliConfig {
     fn apply_agent_args(
         &self,
         _codex_speed: &mut CodexSpeed,
+        _instances: Option<&mut bool>,
+        _project: Option<&mut Option<String>>,
         _pi_path: Option<&mut Option<String>>,
         _open_claw_path: Option<&mut Option<String>>,
     ) {

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -425,7 +425,7 @@ fn load_codex_rows(
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
     if shared.since.is_none() && shared.until.is_none() {
-        let groups = codex::load_groups(shared, kind)?;
+        let groups = codex::load_groups(shared, kind, false, None)?;
         let detected = !groups.is_empty();
         let speed = codex::resolve_codex_speed(CodexSpeed::Auto);
         return Ok(AgentRows {
@@ -440,7 +440,7 @@ fn load_codex_rows(
     let mut events = codex::load_codex_events(shared)?;
     let detected = !events.is_empty();
     codex::filter_events_by_date(&mut events, shared)?;
-    let groups = codex::aggregate_events(&events, kind, shared.timezone.as_deref())?;
+    let groups = codex::aggregate_events(&events, kind, shared.timezone.as_deref(), false)?;
     let speed = codex::resolve_codex_speed(CodexSpeed::Auto);
     Ok(AgentRows {
         rows: groups

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -21,6 +21,8 @@ use super::{parser, paths};
 type CodexEventKey = (
     u64,
     usize,
+    u64,
+    usize,
     crate::TimestampMs,
     u64,
     usize,
@@ -31,6 +33,7 @@ type CodexEventKey = (
     u64,
 );
 type CodexDedupeShards = [Mutex<FxHashSet<CodexEventKey>>];
+pub(super) const PROJECT_GROUP_SEPARATOR: char = '\u{1f}';
 
 struct CodexAggregation {
     groups: BTreeMap<String, CodexGroup>,
@@ -40,25 +43,43 @@ struct CodexAggregation {
 pub(crate) fn load_groups(
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let sources = paths::codex_usage_sources()?;
     if sources.len() == 1 && !wants_json(shared) {
-        return load_groups_from_directory(&sources[0].dir, shared, kind);
+        return load_groups_from_directory(
+            &sources[0].dir,
+            shared,
+            kind,
+            group_projects,
+            project_filter,
+        );
     }
-    load_groups_from_sources(&sources, shared, kind)
+    load_groups_from_sources(&sources, shared, kind, group_projects, project_filter)
 }
 
 fn load_groups_from_sources(
     sources: &[paths::CodexUsageSource],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
     for group in paths::collect_deduped_codex_usage_files(sources) {
         merge_groups(
             &mut groups,
-            aggregate_files_with_dedupe(&group.dir, &group.files, shared, kind, &seen)?,
+            aggregate_files_with_dedupe(
+                &group.dir,
+                &group.files,
+                shared,
+                kind,
+                group_projects,
+                project_filter,
+                &seen,
+            )?,
         );
     }
     Ok(groups)
@@ -68,13 +89,30 @@ pub(super) fn load_groups_from_directory(
     sessions_dir: &Path,
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let files = paths::collect_codex_usage_files(sessions_dir);
     if shared.single_thread {
-        return aggregate_files_local(sessions_dir, &files, shared, kind);
+        return aggregate_files_local(
+            sessions_dir,
+            &files,
+            shared,
+            kind,
+            group_projects,
+            project_filter,
+        );
     }
     let seen = create_dedupe_shards();
-    aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen)
+    aggregate_files_parallel(
+        sessions_dir,
+        &files,
+        shared,
+        kind,
+        group_projects,
+        project_filter,
+        &seen,
+    )
 }
 
 fn aggregate_files_with_dedupe(
@@ -82,12 +120,30 @@ fn aggregate_files_with_dedupe(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
     seen: &CodexDedupeShards,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     if shared.single_thread {
-        return aggregate_files(sessions_dir, files, shared, kind, seen);
+        return aggregate_files(
+            sessions_dir,
+            files,
+            shared,
+            kind,
+            group_projects,
+            project_filter,
+            seen,
+        );
     }
-    aggregate_files_parallel(sessions_dir, files, shared, kind, seen)
+    aggregate_files_parallel(
+        sessions_dir,
+        files,
+        shared,
+        kind,
+        group_projects,
+        project_filter,
+        seen,
+    )
 }
 
 fn aggregate_files(
@@ -95,6 +151,8 @@ fn aggregate_files(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
     seen: &CodexDedupeShards,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
@@ -106,6 +164,8 @@ fn aggregate_files(
             kind,
             timezone.as_ref(),
             shared,
+            group_projects,
+            project_filter,
             seen,
             &mut groups,
         )?;
@@ -118,6 +178,8 @@ fn aggregate_files_parallel(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
     seen: &CodexDedupeShards,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let worker_count = thread::available_parallelism()
@@ -125,7 +187,15 @@ fn aggregate_files_parallel(
         .unwrap_or(1)
         .min(files.len());
     if worker_count <= 1 {
-        return aggregate_files(sessions_dir, files, shared, kind, seen);
+        return aggregate_files(
+            sessions_dir,
+            files,
+            shared,
+            kind,
+            group_projects,
+            project_filter,
+            seen,
+        );
     }
 
     let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
@@ -143,6 +213,8 @@ fn aggregate_files_parallel(
                         kind,
                         timezone.as_ref(),
                         shared,
+                        group_projects,
+                        project_filter,
                         seen,
                         &mut groups,
                     )?;
@@ -170,11 +242,22 @@ fn aggregate_file(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    group_projects: bool,
+    project_filter: Option<&str>,
     seen: &CodexDedupeShards,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
     parser::visit_codex_session_file(sessions_dir, file, |event| {
-        add_event_to_groups(&event, kind, timezone, shared, seen, groups)
+        add_event_to_groups(
+            &event,
+            kind,
+            timezone,
+            shared,
+            group_projects,
+            project_filter,
+            seen,
+            groups,
+        )
     })
 }
 
@@ -183,8 +266,18 @@ fn aggregate_files_local(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    Ok(aggregate_files_local_with_seen(sessions_dir, files, shared, kind)?.groups)
+    Ok(aggregate_files_local_with_seen(
+        sessions_dir,
+        files,
+        shared,
+        kind,
+        group_projects,
+        project_filter,
+    )?
+    .groups)
 }
 
 fn aggregate_files_local_with_seen(
@@ -192,6 +285,8 @@ fn aggregate_files_local_with_seen(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    group_projects: bool,
+    project_filter: Option<&str>,
 ) -> Result<CodexAggregation> {
     let mut aggregation = CodexAggregation {
         groups: BTreeMap::new(),
@@ -205,6 +300,8 @@ fn aggregate_files_local_with_seen(
             kind,
             timezone.as_ref(),
             shared,
+            group_projects,
+            project_filter,
             &mut aggregation,
         )?;
     }
@@ -217,10 +314,20 @@ fn aggregate_file_local(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    group_projects: bool,
+    project_filter: Option<&str>,
     aggregation: &mut CodexAggregation,
 ) -> Result<()> {
     parser::visit_codex_session_file(sessions_dir, file, |event| {
-        add_event_to_groups_local(&event, kind, timezone, shared, aggregation)
+        add_event_to_groups_local(
+            &event,
+            kind,
+            timezone,
+            shared,
+            group_projects,
+            project_filter,
+            aggregation,
+        )
     })
 }
 
@@ -229,9 +336,14 @@ fn add_event_to_groups(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    group_projects: bool,
+    project_filter: Option<&str>,
     seen: &CodexDedupeShards,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
+    if !codex_event_matches_project(event, project_filter) {
+        return Ok(());
+    }
     let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
         return Ok(());
     };
@@ -248,6 +360,7 @@ fn add_event_to_groups(
         kind,
         timezone,
         shared,
+        group_projects,
         groups,
     )
 }
@@ -257,8 +370,13 @@ fn add_event_to_groups_local(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    group_projects: bool,
+    project_filter: Option<&str>,
     aggregation: &mut CodexAggregation,
 ) -> Result<()> {
+    if !codex_event_matches_project(event, project_filter) {
+        return Ok(());
+    }
     let Some(model) = event.model.as_deref().filter(|model| !model.is_empty()) else {
         return Ok(());
     };
@@ -278,6 +396,7 @@ fn add_event_to_groups_local(
         kind,
         timezone,
         shared,
+        group_projects,
         &mut aggregation.groups,
     )
 }
@@ -289,6 +408,7 @@ fn add_deduped_event_to_groups(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    group_projects: bool,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
     let date = format_date_tz(timestamp, timezone);
@@ -306,9 +426,30 @@ fn add_deduped_event_to_groups(
         AgentReportKind::Monthly => date[..7].to_string(),
         AgentReportKind::Session => event.session_id.clone(),
     };
-    let group = groups.entry(period).or_default();
+    let project_path = event
+        .project_path
+        .as_deref()
+        .filter(|project| !project.trim().is_empty());
+    let key = codex_group_key(&period, project_path, group_projects);
+    let group = groups.entry(key).or_default();
+    if group_projects && group.project_path.is_none() {
+        group.project_path = Some(project_path.unwrap_or("unknown").to_string());
+    }
     accumulate_codex_event_into_group(group, event, model);
     Ok(())
+}
+
+fn codex_group_key(period: &str, project_path: Option<&str>, group_projects: bool) -> String {
+    if group_projects {
+        format!(
+            "{}{}{}",
+            project_path.unwrap_or("unknown"),
+            PROJECT_GROUP_SEPARATOR,
+            period
+        )
+    } else {
+        period.to_string()
+    }
 }
 
 fn accumulate_codex_event_into_group(
@@ -372,9 +513,16 @@ fn codex_event_key(
     } else {
         (0, 0)
     };
+    let (project_hash, project_len) = event
+        .project_path
+        .as_deref()
+        .map(|project| (hash_text(project), project.len()))
+        .unwrap_or((0, 0));
     (
         session_hash,
         session_len,
+        project_hash,
+        project_len,
         timestamp,
         hash_text(model),
         model.len(),
@@ -392,10 +540,43 @@ fn hash_text(value: &str) -> u64 {
     hasher.finish()
 }
 
+fn codex_event_matches_project(event: &CodexTokenUsageEvent, project_filter: Option<&str>) -> bool {
+    let Some(filter) = project_filter.filter(|filter| !filter.trim().is_empty()) else {
+        return true;
+    };
+    let Some(project_path) = event.project_path.as_deref() else {
+        return false;
+    };
+    codex_project_matches(project_path, filter)
+}
+
+fn codex_project_matches(project_path: &str, filter: &str) -> bool {
+    let project = normalize_project_path(project_path);
+    let filter = normalize_project_path(filter);
+    if project == filter {
+        return true;
+    }
+    project
+        .rsplit('/')
+        .next()
+        .is_some_and(|name| name == filter.as_str())
+}
+
+fn normalize_project_path(value: &str) -> String {
+    value
+        .trim()
+        .replace('\\', "/")
+        .trim_end_matches('/')
+        .to_string()
+}
+
 fn merge_groups(target: &mut BTreeMap<String, CodexGroup>, source: BTreeMap<String, CodexGroup>) {
     for (period, group) in source {
         let target_group = target.entry(period).or_default();
         target_group.input_tokens += group.input_tokens;
+        if target_group.project_path.is_none() {
+            target_group.project_path = group.project_path;
+        }
         target_group.cached_input_tokens += group.cached_input_tokens;
         target_group.output_tokens += group.output_tokens;
         target_group.reasoning_output_tokens += group.reasoning_output_tokens;
@@ -424,6 +605,7 @@ pub(crate) fn aggregate_events(
     events: &[CodexTokenUsageEvent],
     kind: AgentReportKind,
     timezone: Option<&str>,
+    group_projects: bool,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
     let timezone = parse_tz(timezone).or_else(|| Some(JiffTimeZone::system()));
@@ -441,7 +623,15 @@ pub(crate) fn aggregate_events(
             AgentReportKind::Monthly => date[..7].to_string(),
             AgentReportKind::Session => event.session_id.clone(),
         };
-        let group = groups.entry(period).or_insert_with(CodexGroup::default);
+        let project_path = event
+            .project_path
+            .as_deref()
+            .filter(|project| !project.trim().is_empty());
+        let key = codex_group_key(&period, project_path, group_projects);
+        let group = groups.entry(key).or_insert_with(CodexGroup::default);
+        if group_projects && group.project_path.is_none() {
+            group.project_path = Some(project_path.unwrap_or("unknown").to_string());
+        }
         let model = crate::model_aliases::resolve_model_name(model);
         accumulate_codex_event_into_group(group, event, model.as_ref());
     }
@@ -518,6 +708,8 @@ mod tests {
                 &fixture.path("sessions"),
                 &shared,
                 AgentReportKind::Daily,
+                false,
+                None,
             )
             .unwrap();
 
@@ -585,6 +777,8 @@ mod tests {
                 &fixture.path("sessions"),
                 &shared,
                 AgentReportKind::Daily,
+                false,
+                None,
             )
             .unwrap();
 
@@ -630,6 +824,8 @@ mod tests {
                 &fixture.path("sessions"),
                 &shared,
                 AgentReportKind::Session,
+                false,
+                None,
             )
             .unwrap();
 
@@ -637,6 +833,137 @@ mod tests {
             assert_eq!(groups["root"].input_tokens, 1_000);
             assert_eq!(groups["goal"].input_tokens, 1_000);
         }
+    }
+
+    #[test]
+    fn filters_codex_usage_by_project_path_or_name() {
+        let session = |cwd: &str, input_tokens: u64| {
+            [
+                json!({
+                    "timestamp": "2026-05-29T08:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "session",
+                        "cwd": cwd,
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-29T08:00:01.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "cwd": cwd,
+                        "model": "gpt-5.2",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-29T08:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": input_tokens,
+                                "cached_input_tokens": 0,
+                                "output_tokens": 10,
+                                "total_tokens": input_tokens + 10,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n")
+        };
+        let fixture = fs_fixture!({
+            "sessions/api.jsonl": session("/workspace/api", 100),
+            "sessions/web.jsonl": session("/workspace/web", 200),
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let groups = load_groups_from_directory(
+            &fixture.path("sessions"),
+            &shared,
+            AgentReportKind::Daily,
+            false,
+            Some("api"),
+        )
+        .unwrap();
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups["2026-05-29"].input_tokens, 100);
+    }
+
+    #[test]
+    fn groups_codex_usage_by_project_when_instances_enabled() {
+        let session = |cwd: &str, input_tokens: u64| {
+            [
+                json!({
+                    "timestamp": "2026-05-29T08:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "session",
+                        "cwd": cwd,
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-05-29T08:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "model": "gpt-5.2",
+                            "last_token_usage": {
+                                "input_tokens": input_tokens,
+                                "cached_input_tokens": 0,
+                                "output_tokens": 10,
+                                "total_tokens": input_tokens + 10,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n")
+        };
+        let fixture = fs_fixture!({
+            "sessions/api.jsonl": session("/workspace/api", 100),
+            "sessions/web.jsonl": session("/workspace/web", 200),
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let groups = load_groups_from_directory(
+            &fixture.path("sessions"),
+            &shared,
+            AgentReportKind::Daily,
+            true,
+            None,
+        )
+        .unwrap();
+
+        assert_eq!(groups.len(), 2);
+        assert_eq!(
+            groups["/workspace/api\u{1f}2026-05-29"]
+                .project_path
+                .as_deref(),
+            Some("/workspace/api")
+        );
+        assert_eq!(groups["/workspace/api\u{1f}2026-05-29"].input_tokens, 100);
+        assert_eq!(
+            groups["/workspace/web\u{1f}2026-05-29"]
+                .project_path
+                .as_deref(),
+            Some("/workspace/web")
+        );
+        assert_eq!(groups["/workspace/web\u{1f}2026-05-29"].input_tokens, 200);
     }
 
     #[test]
@@ -746,7 +1073,8 @@ mod tests {
                 ),
             ];
             let groups =
-                load_groups_from_sources(&sources, &shared, AgentReportKind::Daily).unwrap();
+                load_groups_from_sources(&sources, &shared, AgentReportKind::Daily, false, None)
+                    .unwrap();
 
             assert_eq!(groups.len(), 2);
             assert_eq!(groups["2026-05-12"].input_tokens, 111);

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -128,6 +128,7 @@ fn dedupe_codex_events(events: &mut Vec<CodexTokenUsageEvent>) {
         seen.insert((
             CompactString::new(&event.timestamp),
             event.model.as_deref().map(CompactString::new),
+            event.project_path.as_deref().map(CompactString::new),
             event.input_tokens,
             event.cached_input_tokens,
             event.output_tokens,
@@ -149,6 +150,7 @@ mod tests {
     fn codex_event(session_id: &str) -> CodexTokenUsageEvent {
         CodexTokenUsageEvent {
             session_id: session_id.to_string(),
+            project_path: None,
             timestamp: "2026-01-02T00:00:00.000Z".to_string(),
             model: Some("gpt-5".to_string()),
             input_tokens: 100,
@@ -311,6 +313,53 @@ mod tests {
         assert_eq!(events[2].output_tokens, 4);
         assert_eq!(events[2].reasoning_output_tokens, 1);
         assert_eq!(events[2].total_tokens, 14);
+    }
+
+    #[test]
+    fn loads_codex_project_path_from_session_metadata() {
+        let fixture = fs_fixture!({
+            "session.jsonl": [
+                json!({
+                    "timestamp": "2026-01-02T00:00:00.000Z",
+                    "type": "session_meta",
+                    "payload": {
+                        "id": "session",
+                        "cwd": "/workspace/api",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-01-02T00:00:01.000Z",
+                    "type": "turn_context",
+                    "payload": {
+                        "model": "gpt-5",
+                    },
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-01-02T00:00:02.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 100,
+                                "cached_input_tokens": 10,
+                                "output_tokens": 50,
+                                "total_tokens": 150,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].project_path.as_deref(), Some("/workspace/api"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -36,13 +36,13 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         log_level() != Some(0),
         shared.pricing_overrides.iter(),
     );
-    let groups = load_groups(&shared, args.kind)?;
+    let groups = load_groups(&shared, args.kind, args.instances, args.project.as_deref())?;
     let speed = resolve_codex_speed(args.codex_speed);
     if wants_json(&shared) {
-        let output = report_from_groups(&groups, args.kind, &pricing, speed);
+        let output = report_from_groups(&groups, args.kind, &pricing, speed, args.instances);
         return print_json_or_jq(output, shared.jq.as_deref(), shared.no_cost);
     }
-    print_table_from_groups(&groups, args.kind, &pricing, speed, &shared)
+    print_table_from_groups(&groups, args.kind, &pricing, speed, &shared, args.instances)
 }
 
 #[cfg(test)]
@@ -53,8 +53,20 @@ pub(crate) fn report_json(
     pricing: &PricingMap,
     speed: CodexSpeed,
 ) -> Result<Value> {
-    let groups = aggregate_events(events, kind, timezone)?;
-    Ok(report_from_groups(&groups, kind, pricing, speed))
+    let groups = aggregate_events(events, kind, timezone, false)?;
+    Ok(report_from_groups(&groups, kind, pricing, speed, false))
+}
+
+#[cfg(test)]
+pub(crate) fn report_json_with_instances(
+    events: &[CodexTokenUsageEvent],
+    kind: AgentReportKind,
+    timezone: Option<&str>,
+    pricing: &PricingMap,
+    speed: CodexSpeed,
+) -> Result<Value> {
+    let groups = aggregate_events(events, kind, timezone, true)?;
+    Ok(report_from_groups(&groups, kind, pricing, speed, true))
 }
 
 #[cfg(test)]
@@ -84,7 +96,8 @@ mod tests {
         };
 
         let groups =
-            load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily).unwrap();
+            load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily, false, None)
+                .unwrap();
 
         assert_eq!(groups.len(), 1);
         let group = groups.get("2026-01-03").unwrap();
@@ -109,7 +122,8 @@ mod tests {
         };
 
         let groups =
-            load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily).unwrap();
+            load_groups_from_directory(&sessions_dir, &shared, AgentReportKind::Daily, false, None)
+                .unwrap();
 
         assert_eq!(groups.len(), 1);
         let group = groups.get("2026-01-02").unwrap();
@@ -125,6 +139,7 @@ mod tests {
         let report = report_json(
             &[CodexTokenUsageEvent {
                 session_id: "session-1".to_string(),
+                project_path: None,
                 timestamp: "2026-01-02T00:00:00.000Z".to_string(),
                 model: Some("gpt-5".to_string()),
                 input_tokens: 100,
@@ -168,6 +183,7 @@ mod tests {
             &[
                 CodexTokenUsageEvent {
                     session_id: "session-1".to_string(),
+                    project_path: None,
                     timestamp: "2026-01-02T00:00:00.000Z".to_string(),
                     model: Some("private-codex-alpha".to_string()),
                     input_tokens: 100,
@@ -179,6 +195,7 @@ mod tests {
                 },
                 CodexTokenUsageEvent {
                     session_id: "session-1".to_string(),
+                    project_path: None,
                     timestamp: "2026-01-02T00:00:01.000Z".to_string(),
                     model: Some("private-codex-beta".to_string()),
                     input_tokens: 50,
@@ -315,6 +332,7 @@ mod tests {
         let events = vec![
             CodexTokenUsageEvent {
                 session_id: "/workspace/api/session-a.jsonl".to_string(),
+                project_path: Some("/workspace/api".to_string()),
                 timestamp: "2026-01-02T00:00:00.000Z".to_string(),
                 model: Some("gpt-5.3-codex".to_string()),
                 input_tokens: 140,
@@ -326,6 +344,7 @@ mod tests {
             },
             CodexTokenUsageEvent {
                 session_id: "/workspace/api/session-a.jsonl".to_string(),
+                project_path: Some("/workspace/api".to_string()),
                 timestamp: "2026-01-02T00:05:00.000Z".to_string(),
                 model: Some("gpt-5.3-codex".to_string()),
                 input_tokens: 70,
@@ -337,6 +356,7 @@ mod tests {
             },
             CodexTokenUsageEvent {
                 session_id: "/workspace/web/session-b.jsonl".to_string(),
+                project_path: Some("/workspace/web".to_string()),
                 timestamp: "2026-01-05T23:59:59.000Z".to_string(),
                 model: Some("gpt-5-mini".to_string()),
                 input_tokens: 10,
@@ -348,6 +368,7 @@ mod tests {
             },
             CodexTokenUsageEvent {
                 session_id: "ignored-missing-model".to_string(),
+                project_path: None,
                 timestamp: "2026-01-06T00:00:00.000Z".to_string(),
                 model: None,
                 input_tokens: 999,
@@ -390,6 +411,14 @@ mod tests {
                 Some("UTC"),
                 &pricing,
                 CodexSpeed::Fast,
+            )
+            .unwrap(),
+            "dailyInstances": report_json_with_instances(
+                &events,
+                AgentReportKind::Daily,
+                Some("UTC"),
+                &pricing,
+                CodexSpeed::Standard,
             )
             .unwrap(),
         }));

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -19,6 +19,8 @@ use super::types::{
 
 static EVENT_MSG_TYPE_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""type":"event_msg""#));
+static SESSION_META_TYPE_FINDER: LazyLock<Finder<'static>> =
+    LazyLock::new(|| Finder::new(br#""type":"session_meta""#));
 static TURN_CONTEXT_TYPE_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""type":"turn_context""#));
 static TOKEN_COUNT_TYPE_FINDER: LazyLock<Finder<'static>> =
@@ -151,6 +153,7 @@ pub(super) fn visit_codex_session_file(
     let mut previous_totals: Option<CodexRawUsage> = None;
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
+    let mut current_project_path: Option<String> = None;
     let fallback_timestamp = file_modified_timestamp(path);
     let mut skip_replay = replay_second.is_some();
 
@@ -205,6 +208,7 @@ pub(super) fn visit_codex_session_file(
                     &mut previous_totals,
                     &mut current_model,
                     &mut current_model_is_fallback,
+                    &mut current_project_path,
                     &mut visit,
                 )?;
             }
@@ -216,6 +220,7 @@ pub(super) fn visit_codex_session_file(
                         &fallback_timestamp,
                         &mut current_model,
                         &mut current_model_is_fallback,
+                        &mut current_project_path,
                         &mut visit,
                     )?;
                 } else {
@@ -225,6 +230,7 @@ pub(super) fn visit_codex_session_file(
                         &fallback_timestamp,
                         &mut current_model,
                         &mut current_model_is_fallback,
+                        &mut current_project_path,
                         &mut visit,
                     )?;
                 };
@@ -241,9 +247,18 @@ fn visit_codex_session_entry(
     previous_totals: &mut Option<CodexRawUsage>,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
+    current_project_path: &mut Option<String>,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
     let entry_type = value.entry_type.as_deref();
+    if matches!(entry_type, Some("session_meta" | "turn_context")) {
+        if let Some(project_path) = value.payload.as_ref().and_then(codex_project_from_payload) {
+            *current_project_path = Some(project_path);
+        }
+    }
+    if entry_type == Some("session_meta") {
+        return Ok(());
+    }
     if entry_type == Some("turn_context") {
         if let Some(model) = value.payload.as_ref().and_then(codex_model_from_payload) {
             *current_model = Some(model);
@@ -297,6 +312,7 @@ fn visit_codex_session_entry(
 
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
+        project_path: current_project_path.clone(),
         timestamp,
         model,
         input_tokens: raw_usage.input_tokens,
@@ -314,6 +330,7 @@ fn add_codex_exec_event(
     fallback_timestamp: &str,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
+    current_project_path: &mut Option<String>,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
     let Some(raw_usage) = normalize_headless_codex_usage(value) else {
@@ -332,6 +349,7 @@ fn add_codex_exec_event(
         timestamps,
         current_model,
         current_model_is_fallback,
+        current_project_path,
         visit,
     )
 }
@@ -342,6 +360,7 @@ fn add_codex_exec_event_from_value(
     fallback_timestamp: &str,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
+    current_project_path: &mut Option<String>,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
     let Ok(value) = serde_json::from_slice::<Value>(line) else {
@@ -364,6 +383,7 @@ fn add_codex_exec_event_from_value(
         timestamps,
         current_model,
         current_model_is_fallback,
+        current_project_path,
         visit,
     )
 }
@@ -375,6 +395,7 @@ fn visit_codex_exec_usage_event(
     timestamps: CodexExecTimestamps,
     current_model: &mut Option<String>,
     current_model_is_fallback: &mut bool,
+    current_project_path: &mut Option<String>,
     visit: &mut impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
     let (model, is_fallback_model) = resolve_codex_usage_model(
@@ -385,6 +406,7 @@ fn visit_codex_exec_usage_event(
     );
     visit(CodexTokenUsageEvent {
         session_id: session_id.to_string(),
+        project_path: current_project_path.clone(),
         timestamp: timestamps.event,
         model,
         input_tokens: raw_usage.input_tokens,
@@ -397,6 +419,9 @@ fn visit_codex_exec_usage_event(
 }
 
 fn codex_line_usage_kind(line: &[u8]) -> Option<CodexLineKind> {
+    if SESSION_META_TYPE_FINDER.find(line).is_some() {
+        return Some(CodexLineKind::Session);
+    }
     let has_event_msg = EVENT_MSG_TYPE_FINDER.find(line).is_some();
     let has_token_count = has_event_msg && TOKEN_COUNT_TYPE_FINDER.find(line).is_some();
     if TURN_CONTEXT_TYPE_FINDER.find(line).is_some() || has_token_count {
@@ -443,7 +468,7 @@ fn codex_line_type_flags(line: &[u8]) -> (bool, bool, bool) {
         has_turn_context |= json_string_value_matches(line, cursor, b"turn_context");
         has_event_msg |= json_string_value_matches(line, cursor, b"event_msg");
         has_token_count |= json_string_value_matches(line, cursor, b"token_count");
-        if has_turn_context || (has_event_msg && has_token_count) {
+        if has_turn_context || has_event_msg && has_token_count {
             return (has_turn_context, has_event_msg, has_token_count);
         }
         start = cursor.saturating_add(1);
@@ -592,6 +617,10 @@ fn codex_model_from_payload(value: &CodexPayload<'_>) -> Option<String> {
         value.model_name.as_ref(),
         value.metadata.as_ref(),
     )
+}
+
+fn codex_project_from_payload(value: &CodexPayload<'_>) -> Option<String> {
+    non_empty_cow_string(value.cwd.as_ref())
 }
 
 fn codex_model_from_info(value: &CodexInfo<'_>) -> Option<String> {

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -15,7 +15,11 @@ pub(super) fn report_from_groups(
     kind: AgentReportKind,
     pricing: &PricingMap,
     speed: CodexSpeed,
+    group_projects: bool,
 ) -> Value {
+    if group_projects {
+        return project_report_from_groups(groups, kind, pricing, speed);
+    }
     let rows = groups
         .iter()
         .map(|(period, group)| group_json(period, group, kind, pricing, speed))
@@ -24,6 +28,32 @@ pub(super) fn report_from_groups(
     json!({
         rows_key(kind): rows,
         "totals": totals,
+    })
+}
+
+fn project_report_from_groups(
+    groups: &BTreeMap<String, CodexGroup>,
+    kind: AgentReportKind,
+    pricing: &PricingMap,
+    speed: CodexSpeed,
+) -> Value {
+    let mut projects = BTreeMap::<String, Vec<Value>>::new();
+    for (period, group) in groups {
+        let project = group
+            .project_path
+            .clone()
+            .unwrap_or_else(|| "unknown".to_string());
+        projects.entry(project).or_default().push(group_json(
+            display_period(period, group),
+            group,
+            kind,
+            pricing,
+            speed,
+        ));
+    }
+    json!({
+        "projects": projects,
+        "totals": totals_json(groups.values(), pricing, speed),
     })
 }
 
@@ -70,6 +100,9 @@ fn group_json(
         "costUSD": json_float(cost),
         "models": models,
     });
+    if let Some(project_path) = &group.project_path {
+        row["project"] = json!(project_path);
+    }
     if kind == AgentReportKind::Session {
         row["lastActivity"] = json!(group.last_activity);
         let separator = period.rfind('/');
@@ -203,6 +236,7 @@ pub(super) fn print_table_from_groups(
     pricing: &PricingMap,
     speed: CodexSpeed,
     shared: &SharedArgs,
+    group_projects: bool,
 ) -> Result<()> {
     if groups.is_empty() {
         eprintln!("No Codex usage data found.");
@@ -259,7 +293,18 @@ pub(super) fn print_table_from_groups(
     let mut total_reasoning = 0;
     let mut total_tokens = 0;
     let mut total_cost = 0.0;
+    let mut current_project: Option<&str> = None;
     for (label, group) in groups {
+        if group_projects {
+            let project = group.project_path.as_deref().unwrap_or("unknown");
+            if current_project != Some(project) {
+                if current_project.is_some() {
+                    table.separator();
+                }
+                table.push(project_header_row(table.column_count(), project, shared));
+                current_project = Some(project);
+            }
+        }
         let input_tokens = non_cached_input_tokens(group.input_tokens, group.cached_input_tokens);
         let cost = calculate_group_cost(group, pricing, speed);
         total_input += input_tokens;
@@ -269,8 +314,9 @@ pub(super) fn print_table_from_groups(
         total_tokens += group.total_tokens;
         total_cost += cost;
         let models = format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
+        let label = display_period(label, group).to_string();
         let mut row = vec![
-            label.clone(),
+            label,
             models,
             format_number(input_tokens),
             format_number(group.output_tokens),
@@ -306,4 +352,21 @@ pub(super) fn print_table_from_groups(
         shared.offline,
     );
     Ok(())
+}
+
+fn display_period<'a>(label: &'a str, group: &'a CodexGroup) -> &'a str {
+    if group.project_path.is_some()
+        && let Some((_, period)) = label.split_once(super::aggregate::PROJECT_GROUP_SEPARATOR)
+    {
+        return period;
+    }
+    label
+}
+
+fn project_header_row(columns: usize, project: &str, shared: &SharedArgs) -> Vec<String> {
+    let mut row = vec![String::new(); columns];
+    if let Some(first) = row.first_mut() {
+        *first = color(shared, format!("Project: {project}"), Color::Blue);
+    }
+    row
 }

--- a/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
+++ b/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
@@ -1,6 +1,7 @@
 ---
 source: crates/ccusage/src/adapter/codex/mod.rs
-expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, AgentReportKind::Daily, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"weekly\":\n    report_json(&events, AgentReportKind::Weekly, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"monthly\":\n    report_json(&events, AgentReportKind::Monthly, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"sessionFast\":\n    report_json(&events, AgentReportKind::Session, Some(\"UTC\"), &pricing,\n    CodexSpeed::Fast,).unwrap(),\n})"
+assertion_line: 383
+expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, AgentReportKind::Daily, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"weekly\":\n    report_json(&events, AgentReportKind::Weekly, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"monthly\":\n    report_json(&events, AgentReportKind::Monthly, Some(\"UTC\"), &pricing,\n    CodexSpeed::Standard,).unwrap(), \"sessionFast\":\n    report_json(&events, AgentReportKind::Session, Some(\"UTC\"), &pricing,\n    CodexSpeed::Fast,).unwrap(), \"dailyInstances\":\n    report_json_with_instances(&events, AgentReportKind::Daily, Some(\"UTC\"),\n    &pricing, CodexSpeed::Standard,).unwrap(),\n})"
 ---
 {
   "daily": {
@@ -48,6 +49,67 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "totalTokens": 12
       }
     ],
+    "totals": {
+      "cacheCreationTokens": 0,
+      "cacheReadTokens": 110,
+      "costUSD": 0.00041075,
+      "inputTokens": 110,
+      "outputTokens": 17,
+      "reasoningOutputTokens": 2,
+      "totalTokens": 239
+    }
+  },
+  "dailyInstances": {
+    "projects": {
+      "/workspace/api": [
+        {
+          "cacheCreationTokens": 0,
+          "cacheReadTokens": 110,
+          "costUSD": 0.00040425,
+          "date": "2026-01-02",
+          "inputTokens": 100,
+          "models": {
+            "gpt-5.3-codex": {
+              "cacheCreationTokens": 0,
+              "cacheReadTokens": 110,
+              "inputTokens": 100,
+              "isFallback": true,
+              "outputTokens": 15,
+              "reasoningOutputTokens": 2,
+              "totalTokens": 227
+            }
+          },
+          "outputTokens": 15,
+          "project": "/workspace/api",
+          "reasoningOutputTokens": 2,
+          "totalTokens": 227
+        }
+      ],
+      "/workspace/web": [
+        {
+          "cacheCreationTokens": 0,
+          "cacheReadTokens": 0,
+          "costUSD": 0.0000065,
+          "date": "2026-01-05",
+          "inputTokens": 10,
+          "models": {
+            "gpt-5-mini": {
+              "cacheCreationTokens": 0,
+              "cacheReadTokens": 0,
+              "inputTokens": 10,
+              "isFallback": false,
+              "outputTokens": 2,
+              "reasoningOutputTokens": 0,
+              "totalTokens": 12
+            }
+          },
+          "outputTokens": 2,
+          "project": "/workspace/web",
+          "reasoningOutputTokens": 0,
+          "totalTokens": 12
+        }
+      ]
+    },
     "totals": {
       "cacheCreationTokens": 0,
       "cacheReadTokens": 110,

--- a/rust/crates/ccusage/src/adapter/codex/types.rs
+++ b/rust/crates/ccusage/src/adapter/codex/types.rs
@@ -69,6 +69,8 @@ pub(super) enum CodexTimestamp<'a> {
 pub(super) struct CodexPayload<'a> {
     #[serde(rename = "type", borrow, default)]
     pub(super) payload_type: Option<Cow<'a, str>>,
+    #[serde(borrow, default)]
+    pub(super) cwd: Option<Cow<'a, str>>,
     #[serde(
         borrow,
         default,

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -356,12 +356,24 @@ pub(crate) fn apply_config_to_statusline_args(args: &mut StatuslineArgs, config:
 
 pub(crate) fn apply_config_to_agent_args(
     codex_speed: &mut CodexSpeed,
+    mut instances: Option<&mut bool>,
+    mut project: Option<&mut Option<String>>,
     mut pi_path: Option<&mut Option<String>>,
     mut open_claw_path: Option<&mut Option<String>>,
     config: &ConfigContext,
 ) {
     for options in config.option_maps() {
         let codex_options = CodexOptions::from_map(options);
+        if let Some(instances) = instances.as_deref_mut()
+            && let Some(value) = codex_options.instances
+        {
+            *instances = value;
+        }
+        if let Some(project) = project.as_deref_mut()
+            && let Some(value) = codex_options.project
+        {
+            *project = Some(value);
+        }
         if let Some(speed) = codex_options.speed {
             *codex_speed = speed.into();
         }
@@ -402,10 +414,19 @@ impl crate::cli::CliConfig for ConfigContext {
     fn apply_agent_args(
         &self,
         codex_speed: &mut CodexSpeed,
+        instances: Option<&mut bool>,
+        project: Option<&mut Option<String>>,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
     ) {
-        apply_config_to_agent_args(codex_speed, pi_path, open_claw_path, self);
+        apply_config_to_agent_args(
+            codex_speed,
+            instances,
+            project,
+            pi_path,
+            open_claw_path,
+            self,
+        );
     }
 }
 
@@ -776,14 +797,20 @@ mod tests {
         assert_eq!(weekly.start_of_week, WeekDay::Monday);
 
         let mut speed = CodexSpeed::Auto;
+        let mut instances = false;
+        let mut project = None;
         apply_config_to_agent_args(
             &mut speed,
+            Some(&mut instances),
+            Some(&mut project),
             None,
             None,
             &context(
                 json!({
                     "codex": {
                         "defaults": {
+                            "instances": true,
+                            "project": "ccusage",
                             "speed": "fast"
                         }
                     }
@@ -795,11 +822,15 @@ mod tests {
         );
 
         assert_eq!(speed, CodexSpeed::Fast);
+        assert!(instances);
+        assert_eq!(project.as_deref(), Some("ccusage"));
 
         let mut speed = CodexSpeed::Auto;
         let mut pi_path = None;
         apply_config_to_agent_args(
             &mut speed,
+            None,
+            None,
             Some(&mut pi_path),
             None,
             &context(
@@ -822,6 +853,8 @@ mod tests {
         let mut open_claw_path = None;
         apply_config_to_agent_args(
             &mut speed,
+            None,
+            None,
             None,
             Some(&mut open_claw_path),
             &context(

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -447,6 +447,10 @@ pub(crate) struct StatuslineSpecificOptions {
 pub(crate) struct CodexOptions {
     #[serde(flatten)]
     pub(crate) shared: SharedOptions,
+    /// Show usage breakdown by Codex project instance.
+    pub(crate) instances: Option<bool>,
+    /// Filter to a Codex project name or path.
+    pub(crate) project: Option<String>,
     /// Codex speed normalization strategy.
     pub(crate) speed: Option<ConfigCodexSpeed>,
 }
@@ -615,6 +619,8 @@ impl CodexOptions {
     pub(crate) fn from_map(map: &Map<String, Value>) -> Self {
         Self {
             shared: SharedOptions::from_map(map),
+            instances: bool_option(map, "instances"),
+            project: string_option(map, "project"),
             speed: enum_option(map, "speed"),
         }
     }
@@ -1040,7 +1046,7 @@ mod tests {
         assert_schema_properties(
             &schema,
             &["codex", "defaults"],
-            &with_keys(&shared, &["speed"]),
+            &with_keys(&shared, &["instances", "project", "speed"]),
         );
         assert_schema_properties(
             &schema,
@@ -1059,6 +1065,7 @@ mod tests {
         let schema = generated_schema();
 
         assert!(schema_property(&schema, &["codex", "defaults", "speed"]).is_some());
+        assert!(schema_property(&schema, &["codex", "defaults", "project"]).is_some());
         assert!(schema_property(&schema, &["opencode", "defaults", "speed"]).is_none());
         assert!(schema_property(&schema, &["amp", "defaults", "speed"]).is_none());
         assert!(schema_property(&schema, &["droid", "defaults", "speed"]).is_none());
@@ -1151,6 +1158,7 @@ mod tests {
             "codex": {
                 "commands": {
                     "monthly": {
+                        "project": "ccusage",
                         "speed": "standard",
                         "since": "20260101"
                     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -150,6 +150,8 @@ fn main() -> Result<()> {
             let args = AgentCommandArgs {
                 shared: cli.shared,
                 kind: AgentReportKind::Daily,
+                instances: false,
+                project: None,
                 pi_path: None,
                 open_claw_path: None,
                 codex_speed: cli::CodexSpeed::Auto,
@@ -529,6 +531,7 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         let events = vec![CodexTokenUsageEvent {
             session_id: "codex-session".to_string(),
+            project_path: None,
             timestamp: "2026-01-02T00:00:01.000Z".to_string(),
             model: Some("gpt-5".to_string()),
             input_tokens: 100,
@@ -570,6 +573,7 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         let events = vec![CodexTokenUsageEvent {
             session_id: "codex-session".to_string(),
+            project_path: None,
             timestamp: "2026-01-02T00:00:01.000Z".to_string(),
             model: Some("gpt-5.3-codex".to_string()),
             input_tokens: 120,
@@ -607,6 +611,7 @@ mod tests {
         );
         let events = vec![CodexTokenUsageEvent {
             session_id: "codex-session".to_string(),
+            project_path: None,
             timestamp: "2026-01-02T00:00:01.000Z".to_string(),
             model: Some("gpt-test".to_string()),
             input_tokens: 10,
@@ -643,6 +648,7 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         let events = vec![CodexTokenUsageEvent {
             session_id: "codex-session".to_string(),
+            project_path: None,
             timestamp: "2026-03-18T00:00:01.000Z".to_string(),
             model: Some("gpt-5.4".to_string()),
             input_tokens: 100,

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
+assertion_line: 1359
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -136,6 +136,11 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
         "minimum": 0.0,
         "type": "integer"
       },
+      "instances": {
+        "description": "Show usage breakdown by Codex project instance.",
+        "markdownDescription": "Show usage breakdown by Codex project instance.",
+        "type": "boolean"
+      },
       "jq": {
         "description": "jq filter to apply to JSON output.",
         "markdownDescription": "jq filter to apply to JSON output.",
@@ -236,6 +241,11 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
         "description": "Runtime pricing overrides keyed by raw model name.",
         "markdownDescription": "Runtime pricing overrides keyed by raw model name.",
         "type": "object"
+      },
+      "project": {
+        "description": "Filter to a Codex project name or path.",
+        "markdownDescription": "Filter to a Codex project name or path.",
+        "type": "string"
       },
       "since": {
         "description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",

--- a/rust/crates/ccusage/src/types.rs
+++ b/rust/crates/ccusage/src/types.rs
@@ -140,6 +140,7 @@ pub(crate) struct CodexRawUsage {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CodexTokenUsageEvent {
     pub(crate) session_id: String,
+    pub(crate) project_path: Option<String>,
     pub(crate) timestamp: String,
     pub(crate) model: Option<String>,
     pub(crate) input_tokens: u64,
@@ -162,6 +163,7 @@ pub(crate) struct CodexModelUsage {
 
 #[derive(Debug, Clone, Default)]
 pub(crate) struct CodexGroup {
+    pub(crate) project_path: Option<String>,
     pub(crate) input_tokens: u64,
     pub(crate) cached_input_tokens: u64,
     pub(crate) output_tokens: u64,


### PR DESCRIPTION
This is a port of #925 to the Rust codebase.

- Add Codex `--project` filtering by project path or basename, similar to existing Claude support.
- Add Codex `--instances` grouping for daily, weekly, monthly, and session reports, similar to existing Claude support.
- Update CLI help, config schema, docs, README examples, and snapshots.

I've tested this with my local Codex logs and it seems to work well. For example:

```sh
~/Projects/ccusage/rust ⟫ cargo run -p ccusage --bin ccusage -- codex daily --project ccusage
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.29s
     Running `target\debug\ccusage.exe codex daily --project ccusage`

╭────────────────────────────────────────────╮
│                                            │
│      Codex Token Usage Report - Daily      │
│                                            │
╰────────────────────────────────────────────╯

┌────────────┬───────────────┬────────────┬───────────┬────────────┬─────────────┬───────────────┬─────────────┐
│ Date       │ Models        │      Input │    Output │  Reasoning │  Cache Read │  Total Tokens │  Cost (USD) │
├────────────┼───────────────┼────────────┼───────────┼────────────┼─────────────┼───────────────┼─────────────┤
│ 2026-06-25 │ - gpt-5.5     │    516,140 │    27,180 │      6,139 │  13,780,096 │    14,323,416 │      $10.29 │
├────────────┼───────────────┼────────────┼───────────┼────────────┼─────────────┼───────────────┼─────────────┤
│ 2026-06-26 │ - gpt-5.5     │    671,601 │    39,040 │     10,269 │  12,472,320 │    13,182,961 │      $10.77 │
├────────────┼───────────────┼────────────┼───────────┼────────────┼─────────────┼───────────────┼─────────────┤
│ Total      │               │  1,187,741 │    66,220 │     16,408 │  26,252,416 │    27,506,377 │      $21.05 │
└────────────┴───────────────┴────────────┴───────────┴────────────┴─────────────┴───────────────┴─────────────┘
```

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1376"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785051270&installation_id=139163553&pr_number=1376&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1376&signature=7c663778da31ff32e64f374530d268e3c204c5e6ad9a037ef02469976db99d00"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds project filtering and per-project “instances” grouping to Codex daily/weekly/monthly/session reports, matching the existing Claude behavior. This makes it easy to focus on a single workspace or see usage split by each project.

- **New Features**
  - CLI: `--project <path-or-name>` to filter Codex reports by project path or basename.
  - CLI: `--instances` to group Codex reports by project instance.
  - Config: new `codex.defaults.instances` and `codex.defaults.project` (with command-level overrides) in the JSON schema.
  - Parser/Aggregation: reads project path from `cwd` in `session_meta`/`turn_context`; dedupe/grouping updated to include project.
  - Docs/Help: updated README, guide, CLI help, and snapshots.

- **Migration**
  - No breaking changes. JSON shape only changes when `--instances` is used (adds `projects` and `totals`). Adjust scripts if they rely on the flat JSON layout with instances.

<sup>Written for commit 59bee2d845fe394dfcd1167d54dd4e4b2b94aa22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1376?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project-based filtering and grouping for Codex usage reports.
  * Expanded Codex report views with `--instances` and `--project` options, including JSON and table outputs.

* **Documentation**
  * Updated the README and guide with new examples and clarified Codex reporting options.

* **Bug Fixes**
  * Codex usage data now preserves project context, improving report accuracy and duplicate handling across projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->