### PR TITLE
feat(devin): add Devin usage adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 
 # generated local agent skills
 .claude/skills
+
+# local ccusage config (personal pricing overrides, etc.)
+.ccusage/

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -73,6 +73,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | pi-agent           | `ccusage pi daily`       |
 | Goose              | `ccusage goose daily`    |
 | OpenClaw           | `ccusage openclaw daily` |
+| Devin              | `ccusage devin daily`    |
 | Kilo               | `ccusage kilo daily`     |
 | Kimi               | `ccusage kimi daily`     |
 | Qwen               | `ccusage qwen daily`     |
@@ -80,6 +81,8 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Gemini CLI         | `ccusage gemini daily`   |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
+
+> **Devin note:** Devin writes ATIF transcripts after every turn to `~/.local/share/devin/cli/transcripts/` (macOS/Linux) or `%APPDATA%\devin\cli\transcripts\` (Windows). `ccusage` reads those files automatically. `ccusage` does not invoke the Devin CLI.
 
 ## Installation
 
@@ -127,6 +130,8 @@ bunx ccusage codebuff daily
 bunx ccusage hermes daily
 bunx ccusage goose daily
 bunx ccusage openclaw daily
+bunx ccusage devin daily
+bunx ccusage devin daily --devin-path /path/to/devin/cli
 bunx ccusage kilo daily
 bunx ccusage kimi daily
 bunx ccusage qwen daily
@@ -159,7 +164,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -4993,6 +4993,805 @@
 					},
 					"type": "object"
 				},
+				"devin": {
+					"additionalProperties": false,
+					"description": "Devin configuration.",
+					"markdownDescription": "Devin configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"devinPath": {
+											"description": "Path or comma-separated paths to Devin CLI data directories.",
+											"markdownDescription": "Path or comma-separated paths to Devin CLI data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"weekly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"devinPath": {
+											"description": "Path or comma-separated paths to Devin CLI data directories.",
+											"markdownDescription": "Path or comma-separated paths to Devin CLI data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"devinPath": {
+											"description": "Path or comma-separated paths to Devin CLI data directories.",
+											"markdownDescription": "Path or comma-separated paths to Devin CLI data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"devinPath": {
+											"description": "Path or comma-separated paths to Devin CLI data directories.",
+											"markdownDescription": "Path or comma-separated paths to Devin CLI data directories.",
+											"type": "string"
+										},
+										"order": {
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"devinPath": {
+									"description": "Path or comma-separated paths to Devin CLI data directories.",
+									"markdownDescription": "Path or comma-separated paths to Devin CLI data directories.",
+									"type": "string"
+								},
+								"order": {
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"droid": {
 					"additionalProperties": false,
 					"description": "Droid configuration.",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Devin', link: '/guide/devin/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -25,7 +25,7 @@ ccusage daily --all
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -1,6 +1,6 @@
 # Claude Code Data Source
 
-ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 
@@ -75,7 +75,7 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
-For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
+For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -4,7 +4,7 @@
 
 > ⚠️ Codex log support is experimental while the Codex CLI log format continues to evolve.
 
-ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
 ## Focused Views
 

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -180,7 +180,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `devin`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
 
 ```json
 {
@@ -230,6 +230,11 @@ Use data source namespaces to set defaults and report overrides. Supported names
 			"openClawPath": "/path/to/openclaw,/archive/openclaw"
 		}
 	},
+	"devin": {
+		"defaults": {
+			"devinPath": "/path/to/devin/cli,/archive/devin/cli"
+		}
+	},
 	"kilo": {
 		"defaults": {
 			"offline": true
@@ -267,6 +272,7 @@ ccusage droid daily
 ccusage codebuff daily
 ccusage pi daily
 ccusage openclaw daily
+ccusage devin daily
 ccusage kilo daily
 ccusage kimi daily
 ccusage qwen daily

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -109,7 +109,7 @@ For individual developers working on multiple projects:
 
 ### Multiple Sources
 
-Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
+Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
 
 ```json
 // ~/.config/claude/ccusage.json

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -18,6 +18,7 @@ ccusage codex daily
 ccusage opencode daily
 ccusage amp daily
 ccusage pi daily
+ccusage devin daily
 ccusage qwen daily
 ```
 

--- a/docs/guide/devin/index.md
+++ b/docs/guide/devin/index.md
@@ -1,0 +1,166 @@
+# Devin Data Source
+
+ccusage can read Devin CLI ATIF trajectory transcripts as one of its supported local data sources. Devin records per-step token usage, model selection, and committed credit cost in transcript JSON files.
+
+## What is Devin?
+
+Devin is an AI software engineer CLI from Cognition. Devin writes ATIF (Agent Trajectory Interchange Format) trajectory files after every turn, which include per-step token usage and cost data. ccusage reads these ATIF transcripts and aggregates them alongside its other supported sources.
+
+## Focused Views
+
+```bash
+# Recommended
+bunx ccusage devin --help
+
+# Alternative package runners
+npx ccusage@latest devin --help
+pnpm dlx ccusage devin --help
+```
+
+## Data Source
+
+Devin writes an ATIF transcript after every turn to its CLI data directory. The CLI scans these directories for Devin transcript files:
+
+| Source | Default paths                                                | Override                        |
+| ------ | ------------------------------------------------------------ | -------------------------------- |
+| Devin  | `~/.local/share/devin/cli/transcripts/` (Linux/macOS)         | `DEVIN_DATA_DIR` or `--devin-path` |
+| Devin  | `%APPDATA%\devin\cli\transcripts\` (Windows)                 | `DEVIN_DATA_DIR` or `--devin-path` |
+
+ccusage also reads `${DEVIN_DATA_DIR}/sessions.db` when it exists to enrich transcripts with the working directory, model fallback, and session timestamps. Transcript filenames are used as session IDs when a session ID is not present in the transcript itself.
+
+Both `DEVIN_DATA_DIR` and `--devin-path` can point to one data directory or a comma-separated list of data directories.
+
+## Report Views
+
+```bash
+# Show daily Devin usage
+ccusage devin daily
+
+# Show weekly Devin usage
+ccusage devin weekly
+
+# Show monthly Devin usage
+ccusage devin monthly
+
+# Show session-based Devin usage
+ccusage devin session
+
+# JSON output for automation
+ccusage devin daily --json
+
+# Custom Devin data directory
+ccusage devin daily --devin-path /path/to/devin/cli
+
+# Multiple Devin data directories
+ccusage devin daily --devin-path /path/to/devin/cli,/archive/devin/cli
+
+# Filter by date range
+ccusage devin daily --since 2026-05-01 --until 2026-05-16
+```
+
+## Cost Calculation
+
+Devin transcripts can include a per-step `committed_credit_cost` value (USD). When present, ccusage uses this embedded cost directly. When no embedded cost is available, ccusage falls back to calculating cost from the reported token counts and model name using the embedded LiteLLM pricing snapshot. Model names are resolved from the step metadata in this order: `step.metadata.generation_model`, `step.extra.generation_model`, `step.model_name`, `transcript.agent.model_name`, `sessions.model`.
+
+## Environment Variables
+
+| Variable         | Description                                                           |
+| ---------------- | --------------------------------------------------------------------- |
+| `DEVIN_DATA_DIR` | Custom path, or comma-separated paths, to Devin CLI data directories  |
+| `LOG_LEVEL`      | Adjust logging verbosity (0 silent ... 5 trace)                      |
+
+## Daily View
+
+This view shows daily usage from Devin.
+
+```bash
+# Recommended (fastest)
+bunx ccusage devin daily
+
+# Using npx
+npx ccusage@latest devin daily
+```
+
+### Options
+
+| Flag            | Short | Description                                                       |
+| --------------- | ----- | ----------------------------------------------------------------- |
+| `--since`       |       | Start date filter (YYYY-MM-DD or YYYYMMDD)                        |
+| `--until`       |       | End date filter (YYYY-MM-DD or YYYYMMDD)                          |
+| `--timezone`    | `-z`  | Override timezone for date grouping                               |
+| `--json`        | `-j`  | Emit structured JSON instead of a table                           |
+| `--compact`     |       | Force compact table layout for narrow terminals                   |
+| `--devin-path`  |       | Custom path, or comma-separated paths, to Devin data directories  |
+
+### JSON Output
+
+Use `--json` for automation and scripting:
+
+```bash
+ccusage devin daily --json
+```
+
+Returns structured data:
+
+<!-- eslint-skip -->
+
+```json
+{
+	"daily": [
+		{
+			"date": "2026-05-16",
+			"inputTokens": 1860,
+			"outputTokens": 95,
+			"cacheCreationTokens": 500,
+			"cacheReadTokens": 109928,
+			"totalTokens": 112383,
+			"totalCost": 0.03,
+			"modelsUsed": ["claude-sonnet-4-20250514"]
+		}
+	],
+	"totals": {
+		"inputTokens": 1860,
+		"outputTokens": 95,
+		"cacheCreationTokens": 500,
+		"cacheReadTokens": 109928,
+		"totalTokens": 112383,
+		"totalCost": 0.03
+	}
+}
+```
+
+## Weekly View
+
+This view shows usage grouped by week from Devin.
+
+```bash
+ccusage devin weekly
+ccusage devin weekly --json
+ccusage devin weekly --since 2026-01-01 --until 2026-03-31
+```
+
+## Monthly View
+
+This view shows monthly usage from Devin.
+
+```bash
+ccusage devin monthly
+ccusage devin monthly --json
+ccusage devin monthly --since 2026-01-01 --until 2026-03-31
+```
+
+## Session View
+
+This view shows usage grouped by individual Devin sessions. Session IDs come from the transcript `session_id` field or from the transcript filename stem when `session_id` is absent.
+
+```bash
+ccusage devin session
+ccusage devin session --json
+ccusage devin session --since 2026-05-09
+```
+
+## Related
+
+- [All sources report](/guide/all-reports) - Combine Devin with every other supported source in one view
+- [Environment variables](/guide/environment-variables) - Full list of path overrides for all sources
+- [Configuration files](/guide/config-files) - Persist `devinPath` and other options in `ccusage.json`

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -18,6 +18,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `PI_AGENT_DIR`                    | pi-agent     | `~/.pi/agent/sessions`             |
 | `GOOSE_PATH_ROOT`                 | Goose        | Standard Goose data roots          |
 | `OPENCLAW_DIR`                    | OpenClaw     | `~/.openclaw`                      |
+| `DEVIN_DATA_DIR`                  | Devin        | `~/.local/share/devin/cli`         |
 | `KILO_DATA_DIR`                   | Kilo         | `~/.local/share/kilo`              |
 | `KIMI_DATA_DIR`                   | Kimi         | `~/.kimi`                          |
 | `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                          |
@@ -36,6 +37,7 @@ export HERMES_HOME="/path/to/hermes,/archive/hermes"
 export PI_AGENT_DIR="/path/to/pi/sessions,/archive/pi/sessions"
 export GOOSE_PATH_ROOT="/path/to/goose,/archive/goose"
 export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
+export DEVIN_DATA_DIR="/path/to/devin/cli,/archive/devin/cli"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
@@ -210,7 +212,7 @@ To see which environment variables are being used:
 
 ```bash
 # Show all environment variables
-env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
+env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|DEVIN|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
 
 # Debug mode shows environment variable usage
 LOG_LEVEL=4 ccusage daily --debug

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -174,6 +174,7 @@ If ccusage shows no data, check:
    - Kilo: `${KILO_DATA_DIR:-~/.local/share/kilo}`
    - Kimi: `${KIMI_DATA_DIR:-~/.kimi}`
    - OpenClaw: `${OPENCLAW_DIR:-~/.openclaw}` (also scans `~/.clawdbot`, `~/.moltbot`, `~/.moldbot`)
+   - Devin: `${DEVIN_DATA_DIR:-~/.local/share/devin/cli}`
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
 
@@ -192,6 +193,7 @@ export HERMES_HOME="/path/to/hermes"
 export PI_AGENT_DIR="/path/to/pi/sessions"
 export GOOSE_PATH_ROOT="/path/to/goose"
 export OPENCLAW_DIR="/path/to/openclaw"
+export DEVIN_DATA_DIR="/path/to/devin/cli"
 export KILO_DATA_DIR="/path/to/kilo"
 export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
@@ -210,6 +212,7 @@ export HERMES_HOME="/path/to/hermes,/archive/hermes"
 export PI_AGENT_DIR="/path/to/pi/sessions,/archive/pi/sessions"
 export GOOSE_PATH_ROOT="/path/to/goose,/archive/goose"
 export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
+export DEVIN_DATA_DIR="/path/to/devin/cli,/archive/devin/cli"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -84,6 +84,7 @@ ccusage reads from local coding CLI data directories:
 | pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`         |
 | Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`  |
 | OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
+| Devin        | `devin`    | `${DEVIN_DATA_DIR:-~/.local/share/devin/cli}`   |
 | Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
 | Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
 | Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
@@ -93,7 +94,9 @@ ccusage reads from local coding CLI data directories:
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+> **Devin note:** Devin writes ATIF transcripts after every turn to `~/.local/share/devin/cli/transcripts/` (macOS/Linux) or `%APPDATA%\devin\cli\transcripts\` (Windows). `ccusage` reads those files automatically. `ccusage` does not invoke the Devin CLI.
+
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI and Grok CLI.
 
 ## Report Shape
 
@@ -119,6 +122,7 @@ ccusage hermes daily
 ccusage pi monthly
 ccusage goose daily
 ccusage openclaw daily
+ccusage devin daily
 ccusage kilo daily
 ccusage kimi daily
 ccusage qwen daily

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -35,10 +35,12 @@ Grok CLI was investigated, but its local SQLite data did not contain usable toke
 Estimating tokens from message text would ignore provider-side context, hidden prompts, tool-call payloads, cached input, and tokenizer differences, so ccusage does not do that.
 :::
 
-::: details Why is Devin CLI not supported?
-Devin CLI usage information appears to live in Devin's cloud service rather than in a local usage log that ccusage can read. The locally available data did not provide direct access to historical token usage or costs.
+::: details Was Devin CLI investigated before it was supported?
+Yes. Devin CLI was investigated and found to write ATIF (Agent Trajectory Interchange Format) trajectory files after every turn. These files include per-step token usage, model identifiers, and committed credit costs — everything ccusage needs to produce accurate reports.
 
-ccusage is a local, read-only analyzer. It does not scrape private cloud services or depend on undocumented authenticated APIs for user usage history. If Devin adds a local export with timestamps, sessions, models, and token counts, support can be revisited.
+ccusage reads these transcripts from `~/.local/share/devin/cli/transcripts/` (Linux/macOS) or `%APPDATA%\devin\cli\transcripts\` (Windows), and enriches them with `sessions.db` when present.
+
+See the [Devin guide](/guide/devin/) for usage examples.
 :::
 
 ## Can These Be Added Later?

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: ccusage
   text: Coding (Agent) CLI Usage Analysis
-  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
+  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
   image:
     src: /logo.svg
     alt: ccusage logo
@@ -27,7 +27,7 @@ features:
     link: /guide/getting-started
   - icon: 📁
     title: Local Data Sources
-    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
+    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Devin, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
     link: /guide/
   - icon: 💰
     title: Cost Analysis

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -6,7 +6,8 @@
 		"claude_session_options": ["shared_claude_options", "session_options"],
 		"claude_weekly_options": ["shared_claude_options", "weekly_options"],
 		"openclaw_combined_options": ["agent_options", "openclaw_options"],
-		"pi_combined_options": ["agent_options", "pi_options"]
+		"pi_combined_options": ["agent_options", "pi_options"],
+		"devin_combined_options": ["agent_options", "devin_options"]
 	},
 	"root": {
 		"usage": ["ccusage [daily] <OPTIONS>", "ccusage <COMMANDS>"],
@@ -94,6 +95,10 @@
 			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
+			},
+			{
+				"name": "devin",
+				"description": "Show Devin usage commands"
 			}
 		]
 	},
@@ -728,6 +733,53 @@
 			"description": "Show OpenClaw usage grouped by session",
 			"usage": "ccusage openclaw session <OPTIONS>",
 			"options": "openclaw_combined_options"
+		},
+		{
+			"path": ["devin"],
+			"description": "Usage reports for devin.",
+			"usage": "ccusage devin <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Devin usage grouped by date"
+				},
+				{
+					"name": "weekly",
+					"description": "Show Devin usage grouped by week"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Devin usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Devin usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["devin", "daily"],
+			"description": "Show Devin usage grouped by date",
+			"usage": "ccusage devin daily <OPTIONS>",
+			"options": "devin_combined_options"
+		},
+		{
+			"path": ["devin", "weekly"],
+			"description": "Show Devin usage grouped by week",
+			"usage": "ccusage devin weekly <OPTIONS>",
+			"options": "devin_combined_options"
+		},
+		{
+			"path": ["devin", "monthly"],
+			"description": "Show Devin usage grouped by month",
+			"usage": "ccusage devin monthly <OPTIONS>",
+			"options": "devin_combined_options"
+		},
+		{
+			"path": ["devin", "session"],
+			"description": "Show Devin usage grouped by session",
+			"usage": "ccusage devin session <OPTIONS>",
+			"options": "devin_combined_options"
 		}
 	]
 }

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -235,6 +235,12 @@
 			"description": "Path or comma-separated paths to pi-agent sessions directories"
 		}
 	],
+	"devin_options": [
+		{
+			"flags": "--devin-path <devin-path>",
+			"description": "Path or comma-separated paths to Devin CLI data directories"
+		}
+	],
 	"openclaw_options": [
 		{
 			"flags": "--open-claw-path <open-claw-path>",

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -264,6 +264,7 @@ fn parse_command(
             Command::Qwen,
         ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
+        "devin" => parse_devin_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -286,6 +287,7 @@ fn parse_all_command(
         kind,
         pi_path: None,
         open_claw_path: None,
+        devin_path: None,
         codex_speed: CodexSpeed::Auto,
     }))
 }
@@ -319,6 +321,7 @@ fn parse_top_level_session_command(
         kind: AgentReportKind::Session,
         pi_path: None,
         open_claw_path: None,
+        devin_path: None,
         codex_speed: CodexSpeed::Auto,
     }))
 }
@@ -458,7 +461,7 @@ fn parse_codex_command(
 ) -> Result<Command, String> {
     let kind = parse_agent_report_kind(parser, "codex", STANDARD_AGENT_REPORTS)?;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, None);
+    config.apply_agent_args(&mut codex_speed, None, None, None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -473,6 +476,7 @@ fn parse_codex_command(
         kind,
         pi_path: None,
         open_claw_path: None,
+        devin_path: None,
         codex_speed,
     }))
 }
@@ -485,7 +489,7 @@ fn parse_pi_command(
     let kind = parse_agent_report_kind(parser, "pi", STANDARD_AGENT_REPORTS)?;
     let mut pi_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, Some(&mut pi_path), None);
+    config.apply_agent_args(&mut codex_speed, Some(&mut pi_path), None, None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -500,6 +504,7 @@ fn parse_pi_command(
         kind,
         pi_path,
         open_claw_path: None,
+        devin_path: None,
         codex_speed,
     }))
 }
@@ -512,7 +517,7 @@ fn parse_openclaw_command(
     let kind = parse_agent_report_kind(parser, "openclaw", STANDARD_AGENT_REPORTS)?;
     let mut open_claw_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, Some(&mut open_claw_path));
+    config.apply_agent_args(&mut codex_speed, None, Some(&mut open_claw_path), None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -527,6 +532,35 @@ fn parse_openclaw_command(
         kind,
         pi_path: None,
         open_claw_path,
+        devin_path: None,
+        codex_speed,
+    }))
+}
+
+fn parse_devin_command(
+    parser: &mut ArgParser,
+    mut shared: SharedArgs,
+    config: &dyn CliConfig,
+) -> Result<Command, String> {
+    let kind = parse_agent_report_kind(parser, "devin", OPENCODE_AGENT_REPORTS)?;
+    let mut devin_path = None;
+    let mut codex_speed = CodexSpeed::Auto;
+    config.apply_agent_args(&mut codex_speed, None, None, Some(&mut devin_path));
+    while parser.peek().is_some() {
+        if parse_shared_arg_for_command(parser, &mut shared)? {
+            continue;
+        }
+        match parser.next_flag()?.as_str() {
+            "--devin-path" => devin_path = Some(parser.value_for("--devin-path")?),
+            flag => return Err(format!("Unknown devin option '{flag}'")),
+        }
+    }
+    Ok(Command::Devin(AgentCommandArgs {
+        shared,
+        kind,
+        pi_path: None,
+        open_claw_path: None,
+        devin_path,
         codex_speed,
     }))
 }
@@ -555,6 +589,7 @@ fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommand
         kind,
         pi_path: None,
         open_claw_path: None,
+        devin_path: None,
         codex_speed: CodexSpeed::Auto,
     }
 }
@@ -631,6 +666,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "devin"
     )
 }
 
@@ -767,6 +803,7 @@ fn option_takes_value(arg: &str) -> bool {
             | "--speed"
             | "--pi-path"
             | "--open-claw-path"
+            | "--devin-path"
     )
 }
 
@@ -788,6 +825,7 @@ fn is_agent_command(command: &str) -> bool {
             | "kimi"
             | "qwen"
             | "openclaw"
+            | "devin"
     )
 }
 
@@ -799,6 +837,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         ),
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
+        "devin" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
         | "gemini" | "kimi" | "qwen" | "openclaw" => {
             matches!(report, "daily" | "monthly" | "session")
@@ -824,6 +863,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
+        "devin" => "Devin",
         _ => unreachable!("agent is prevalidated"),
     }
 }

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/ccusage-cli/src/tests.rs
+assertion_line: 459
 expression: help_text()
 ---
 USAGE:
@@ -28,6 +29,7 @@ COMMANDS:
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
+  devin                      Show Devin usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -51,6 +53,7 @@ For more info, run any command with the `--help` flag:
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help
+  ccusage devin --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
+assertion_line: 603
 expression: cases
 ---
 [
@@ -33,6 +34,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "devinPath": null,
         "kind": "Daily",
         "openClawPath": null,
         "piPath": null,
@@ -179,6 +181,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Fast",
+        "devinPath": null,
         "kind": "Monthly",
         "openClawPath": null,
         "piPath": null,
@@ -229,6 +232,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "devinPath": null,
         "kind": "Weekly",
         "openClawPath": null,
         "piPath": null,
@@ -279,6 +283,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "devinPath": null,
         "kind": "Session",
         "openClawPath": null,
         "piPath": "/tmp/pi-sessions",
@@ -329,6 +334,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "devinPath": null,
         "kind": "Session",
         "openClawPath": "/tmp/openclaw",
         "piPath": null,
@@ -352,6 +358,57 @@ expression: cases
           "until": null
         },
         "type": "openclaw"
+      },
+      "shared": {
+        "breakdown": false,
+        "color": false,
+        "compact": false,
+        "config": null,
+        "debug": false,
+        "debugSamples": 5,
+        "jq": null,
+        "json": false,
+        "mode": "Auto",
+        "noColor": false,
+        "noOffline": false,
+        "offline": false,
+        "order": "Asc",
+        "since": null,
+        "singleThread": false,
+        "timezone": null,
+        "until": null
+      }
+    }
+  },
+  {
+    "case": "devin weekly",
+    "cli": {
+      "command": {
+        "codexSpeed": "Auto",
+        "devinPath": null,
+        "kind": "Weekly",
+        "openClawPath": null,
+        "piPath": null,
+        "shared": {
+          "breakdown": false,
+          "color": false,
+          "compact": false,
+          "config": null,
+          "debug": false,
+          "debugSamples": 5,
+          "jq": null,
+          "json": true,
+          "mode": "Auto",
+          "noColor": false,
+          "noOffline": false,
+          "offline": false,
+          "order": "Asc",
+          "since": null,
+          "singleThread": false,
+          "timezone": null,
+          "until": null
+        },
+        "type": "devin"
       },
       "shared": {
         "breakdown": false,

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -43,6 +43,7 @@ struct TestConfig {
     codex_speed: Option<CodexSpeed>,
     pi_path: Option<&'static str>,
     open_claw_path: Option<&'static str>,
+    devin_path: Option<&'static str>,
 }
 
 impl CliConfig for TestConfig {
@@ -99,6 +100,7 @@ impl CliConfig for TestConfig {
         codex_speed: &mut CodexSpeed,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
+        devin_path: Option<&mut Option<String>>,
     ) {
         if let Some(speed) = self.codex_speed {
             *codex_speed = speed;
@@ -108,6 +110,9 @@ impl CliConfig for TestConfig {
         }
         if let (Some(path), Some(open_claw_path)) = (self.open_claw_path, open_claw_path) {
             *open_claw_path = Some(path.to_string());
+        }
+        if let (Some(path), Some(devin_path)) = (self.devin_path, devin_path) {
+            *devin_path = Some(path.to_string());
         }
     }
 }
@@ -202,6 +207,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Devin(args)) => agent_command_snapshot("devin", args),
     }
 }
 
@@ -212,6 +218,7 @@ fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
         "kind": format!("{:?}", args.kind),
         "piPath": args.pi_path,
         "openClawPath": args.open_claw_path,
+        "devinPath": args.devin_path,
         "codexSpeed": format!("{:?}", args.codex_speed),
     })
 }
@@ -358,7 +365,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "devin",
     ];
 
     for agent in agents {
@@ -558,6 +565,10 @@ fn snapshots_representative_cli_parse_shapes() {
                 "session",
                 "--open-claw-path=/tmp/openclaw",
             ])),
+        }),
+        json!({
+            "case": "devin weekly",
+            "cli": cli_snapshot(parse(&["ccusage", "devin", "weekly", "--json"])),
         }),
         json!({
             "case": "blocks active recent",
@@ -946,4 +957,32 @@ fn parses_openclaw_session_options() {
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);
     assert_eq!(args.open_claw_path.as_deref(), Some("/tmp/openclaw"));
+}
+
+#[test]
+fn parses_devin_session_options() {
+    let cli = parse(&[
+        "ccusage",
+        "devin",
+        "session",
+        "--json",
+        "--devin-path",
+        "/tmp/devin",
+    ]);
+    let Some(Command::Devin(args)) = cli.command else {
+        panic!("expected devin command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
+    assert_eq!(args.devin_path.as_deref(), Some("/tmp/devin"));
+}
+
+#[test]
+fn parses_devin_weekly_options() {
+    let cli = parse(&["ccusage", "devin", "weekly", "--json"]);
+    let Some(Command::Devin(args)) = cli.command else {
+        panic!("expected devin command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Weekly);
+    assert!(args.shared.json);
 }

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -30,6 +30,7 @@ pub enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+    Devin(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -122,6 +123,7 @@ pub struct AgentCommandArgs {
     pub kind: AgentReportKind,
     pub pi_path: Option<String>,
     pub open_claw_path: Option<String>,
+    pub devin_path: Option<String>,
     pub codex_speed: CodexSpeed,
 }
 
@@ -246,6 +248,7 @@ pub trait CliConfig {
         _codex_speed: &mut CodexSpeed,
         _pi_path: Option<&mut Option<String>>,
         _open_claw_path: Option<&mut Option<String>>,
+        _devin_path: Option<&mut Option<String>>,
     ) {
     }
 }

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use crate::{
     CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result, SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, claude, codebuff, codex, copilot, devin, droid, gemini, goose, hermes, kilo, kimi,
+        openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -237,6 +237,21 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 15,
+                agent: "devin",
+                progress_agent: crate::progress::UsageLoadAgent::Devin,
+                load: Box::new(|| {
+                    load_session_capable_summary_agent_rows(
+                        "devin",
+                        load_kind,
+                        &loader_shared,
+                        &pricing,
+                        devin::load_entries,
+                        devin::summarize_entries,
+                    )
+                }),
             },
         ],
         &mut progress,

--- a/rust/crates/ccusage/src/adapter/devin/README.md
+++ b/rust/crates/ccusage/src/adapter/devin/README.md
@@ -1,0 +1,33 @@
+# Devin Source
+
+Data source:
+
+```text
+${DEVIN_DATA_DIR:-~/.local/share/devin/cli}
+${DEVIN_DATA_DIR:-%APPDATA%\devin\cli}
+```
+
+Transcript JSON files are the primary source:
+
+```text
+${DEVIN_DATA_DIR}/transcripts/*.json
+```
+
+The adapter also reads `sessions.db` for enrichment: project path, model
+fallback, timestamp fallback, and hidden-session filtering.
+
+Transcripts follow the ATIF trajectory schema with Devin-specific extensions.
+Token counts are read from `step.metrics` (ATIF v1.7) and fall back to
+`step.metadata.metrics` (legacy Devin). Per-step cost is read from
+`step.metadata.committed_credit_cost` (USD) when available; otherwise cost is
+calculated from tokens using the embedded LiteLLM pricing snapshot.
+
+Commands:
+
+```sh
+ccusage devin daily
+ccusage devin monthly
+ccusage devin session
+ccusage devin daily --json
+ccusage devin daily --devin-path /path/to/devin/cli
+```

--- a/rust/crates/ccusage/src/adapter/devin/loader.rs
+++ b/rust/crates/ccusage/src/adapter/devin/loader.rs
@@ -1,0 +1,96 @@
+use std::collections::{HashMap, HashSet};
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
+
+use super::{parser, paths};
+
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    custom_path: Option<&str>,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Devin, shared.json, || {
+        load_entries_inner(shared, custom_path, pricing)
+    })
+}
+
+fn load_entries_inner(
+    shared: &SharedArgs,
+    custom_path: Option<&str>,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for data_dir in paths::paths(custom_path)? {
+        let session_info = load_session_info_for_directory(&data_dir);
+        let transcripts_dir = data_dir.join("transcripts");
+        let mut files = Vec::new();
+        crate::collect_files_with_extension(&transcripts_dir, "json", &mut files);
+        let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+            let session_id = session_id_from_path(file);
+            let info = session_info.get(&session_id);
+            parser::read_transcript_file(file, tz.as_ref(), shared.mode, pricing, info)
+                .unwrap_or_else(|error| {
+                    debug_log(
+                        shared,
+                        format!(
+                            "Failed to read Devin transcript file {}: {error}",
+                            file.display()
+                        ),
+                    );
+                    Vec::new()
+                })
+        });
+        for file_entries in loaded {
+            for entry in file_entries {
+                let id = entry_id(&entry);
+                if seen.insert(id) {
+                    entries.push(entry);
+                }
+            }
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_session_info_for_directory(
+    data_dir: &std::path::Path,
+) -> HashMap<String, super::parser::SessionInfo> {
+    let db_path = data_dir.join("sessions.db");
+    if !db_path.is_file() {
+        return HashMap::new();
+    }
+    parser::load_session_info(&db_path).into_iter().collect()
+}
+
+fn session_id_from_path(path: &std::path::Path) -> String {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+pub(super) fn entry_id(entry: &LoadedEntry) -> String {
+    [
+        "devin",
+        entry.project.as_ref(),
+        entry.session_id.as_ref(),
+        entry.data.timestamp.as_str(),
+        entry.model.as_deref().unwrap_or_default(),
+        &entry.data.message.usage.input_tokens.to_string(),
+        &entry.data.message.usage.output_tokens.to_string(),
+        &entry
+            .data
+            .message
+            .usage
+            .cache_creation_input_tokens
+            .to_string(),
+        &entry.data.message.usage.cache_read_input_tokens.to_string(),
+        &entry.cost.to_string(),
+    ]
+    .join(":")
+}

--- a/rust/crates/ccusage/src/adapter/devin/mod.rs
+++ b/rust/crates/ccusage/src/adapter/devin/mod.rs
@@ -1,0 +1,42 @@
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
+};
+
+pub(crate) use loader::load_entries;
+pub(crate) use report::{report_from_rows, summarize_entries};
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let pricing = crate::PricingMap::load_with_overrides(
+        args.shared.offline,
+        crate::log_level() != Some(0),
+        args.shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&args.shared, args.devin_path.as_deref(), Some(&pricing))?;
+    filter_loaded_entries_by_date(&mut entries, &args.shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &args.shared.order, |row| {
+        super::opencode::summary_period(row)
+    });
+    if wants_json(&args.shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            args.shared.jq.as_deref(),
+            args.shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Devin Token Usage Report",
+        super::opencode::first_column(args.kind),
+        &rows,
+        &args.shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/crates/ccusage/src/adapter/devin/parser.rs
+++ b/rust/crates/ccusage/src/adapter/devin/parser.rs
@@ -1,0 +1,465 @@
+use std::{collections::BTreeMap, fs, path::Path, str::FromStr, sync::Arc};
+
+use jiff::{Timestamp as JiffTimestamp, tz::TimeZone as JiffTimeZone};
+use serde::Deserialize;
+
+use super::super::jsonl;
+use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, missing_pricing_model_for_usage,
+    total_usage_tokens,
+};
+
+/// A Devin transcript JSON file following the ATIF trajectory schema with
+/// Devin-specific `metadata`/`extra` extensions.
+#[derive(Debug, Default, Deserialize)]
+struct DevinTranscript {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    session_id: Option<String>,
+    agent: Option<DevinAgent>,
+    #[serde(default)]
+    steps: Vec<DevinStep>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinAgent {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model_name: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinStep {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    timestamp: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model_name: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    step_id: Option<String>,
+    metrics: Option<DevinMetrics>,
+    metadata: Option<DevinStepMetadata>,
+    extra: Option<DevinStepExtra>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinMetrics {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    prompt_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    completion_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cached_tokens: u64,
+    extra: Option<DevinMetricsExtra>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinMetricsExtra {
+    #[serde(
+        rename = "cache_creation_input_tokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    cache_creation_input_tokens: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinStepMetadata {
+    #[serde(default)]
+    is_user_input: bool,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    generation_model: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    created_at: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    committed_credit_cost: Option<f64>,
+    metrics: Option<DevinLegacyMetrics>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    request_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinLegacyMetrics {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_creation_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_read_tokens: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct DevinStepExtra {
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    committed_credit_cost: Option<f64>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    generation_model: Option<String>,
+}
+
+pub(crate) fn read_transcript_file(
+    path: &Path,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+    session_info: Option<&SessionInfo>,
+) -> Result<Vec<LoadedEntry>> {
+    let content = fs::read(path)?;
+    let transcript: DevinTranscript = serde_json::from_slice(&content)?;
+
+    let session_id = transcript
+        .session_id
+        .clone()
+        .or_else(|| session_info.map(|info| info.id.clone()))
+        .unwrap_or_else(|| session_id_from_path(path));
+    let fallback_model = transcript
+        .agent
+        .as_ref()
+        .and_then(|agent| agent.model_name.clone());
+    let project_path = session_info
+        .and_then(|info| info.working_directory.as_deref())
+        .unwrap_or("devin");
+    let project_name = project_name_from_path(project_path);
+
+    let mut entries = Vec::new();
+    for step in transcript.steps {
+        if skip_step(&step) {
+            continue;
+        }
+        let Some(usage) = step_usage(&step) else {
+            continue;
+        };
+        if total_usage_tokens(usage) == 0 {
+            continue;
+        }
+        let Some(timestamp_text) = step_timestamp(&step, session_info) else {
+            continue;
+        };
+        let Some(timestamp) = parse_iso_timestamp(&timestamp_text) else {
+            continue;
+        };
+        let model = step_model(&step, &fallback_model, session_info);
+        let cost_usd = step_credit_cost(&step);
+        let cost = calculate_cost_for_usage(model.as_deref(), usage, cost_usd, mode, pricing);
+        let missing_pricing_model =
+            missing_pricing_model_for_usage(model.as_deref(), usage, cost_usd, mode, pricing);
+        let data = UsageEntry {
+            session_id: Some(session_id.clone()),
+            timestamp: timestamp_text.clone(),
+            version: None,
+            message: UsageMessage {
+                usage,
+                model: model.clone(),
+                id: step.request_id().or_else(|| step.step_id.clone()),
+            },
+            cost_usd,
+            request_id: step.request_id(),
+            is_api_error_message: None,
+            is_sidechain: None,
+        };
+        entries.push(LoadedEntry {
+            date: format_date_tz(timestamp, tz),
+            timestamp,
+            project: Arc::from(project_name.as_str()),
+            session_id: Arc::from(session_id.as_str()),
+            project_path: Arc::from(project_path),
+            cost,
+            extra_total_tokens: 0,
+            credits: None,
+            message_count: None,
+            model,
+            data,
+            usage_limit_reset_time: None,
+            missing_pricing_model,
+        });
+    }
+    Ok(entries)
+}
+
+fn skip_step(step: &DevinStep) -> bool {
+    step.metadata
+        .as_ref()
+        .is_some_and(|metadata| metadata.is_user_input)
+}
+
+fn step_usage(step: &DevinStep) -> Option<TokenUsageRaw> {
+    if let Some(metrics) = step.metrics.as_ref() {
+        let cache_creation = metrics
+            .extra
+            .as_ref()
+            .map_or(0, |extra| extra.cache_creation_input_tokens);
+        return Some(TokenUsageRaw {
+            input_tokens: metrics.prompt_tokens,
+            output_tokens: metrics.completion_tokens,
+            cache_creation_input_tokens: cache_creation,
+            cache_read_input_tokens: metrics.cached_tokens,
+            speed: None,
+            cache_creation: None,
+        });
+    }
+    if let Some(metrics) = step
+        .metadata
+        .as_ref()
+        .and_then(|metadata| metadata.metrics.as_ref())
+    {
+        return Some(TokenUsageRaw {
+            input_tokens: metrics.input_tokens,
+            output_tokens: metrics.output_tokens,
+            cache_creation_input_tokens: metrics.cache_creation_tokens,
+            cache_read_input_tokens: metrics.cache_read_tokens,
+            speed: None,
+            cache_creation: None,
+        });
+    }
+    None
+}
+
+fn step_timestamp(step: &DevinStep, session_info: Option<&SessionInfo>) -> Option<String> {
+    step.metadata
+        .as_ref()
+        .and_then(|metadata| metadata.created_at.as_deref())
+        .or(step.timestamp.as_deref())
+        .map(|value| value.to_string())
+        .or_else(|| {
+            session_info.and_then(|info| info.last_activity_at.as_deref().map(String::from))
+        })
+        .or_else(|| session_info.and_then(|info| info.created_at.as_deref().map(String::from)))
+}
+
+fn step_model(
+    step: &DevinStep,
+    fallback_model: &Option<String>,
+    session_info: Option<&SessionInfo>,
+) -> Option<String> {
+    step.metadata
+        .as_ref()
+        .and_then(|metadata| metadata.generation_model.as_deref())
+        .or(step
+            .extra
+            .as_ref()
+            .and_then(|extra| extra.generation_model.as_deref()))
+        .or(step.model_name.as_deref())
+        .or(fallback_model.as_deref())
+        .or(session_info.and_then(|info| info.model.as_deref()))
+        .map(|model| model.to_string())
+}
+
+fn step_credit_cost(step: &DevinStep) -> Option<f64> {
+    step.metadata
+        .as_ref()
+        .and_then(|metadata| metadata.committed_credit_cost)
+        .or(step
+            .extra
+            .as_ref()
+            .and_then(|extra| extra.committed_credit_cost))
+}
+
+fn parse_iso_timestamp(value: &str) -> Option<TimestampMs> {
+    JiffTimestamp::from_str(value)
+        .ok()
+        .map(|timestamp| TimestampMs::from_millis(timestamp.as_millisecond()))
+}
+
+fn session_id_from_path(path: &Path) -> String {
+    path.file_stem()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+fn project_name_from_path(path: &str) -> String {
+    Path::new(path)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+impl DevinStep {
+    fn request_id(&self) -> Option<String> {
+        self.metadata
+            .as_ref()
+            .and_then(|metadata| metadata.request_id.clone())
+    }
+}
+
+/// Enrichment data from Devin CLI `sessions.db` for a single transcript.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct SessionInfo {
+    pub(crate) id: String,
+    pub(crate) working_directory: Option<String>,
+    pub(crate) model: Option<String>,
+    pub(crate) created_at: Option<String>,
+    pub(crate) last_activity_at: Option<String>,
+}
+
+/// Load enrichment data from the Devin `sessions.db` SQLite database, if it
+/// exists. Missing or unreadable databases return an empty map.
+pub(crate) fn load_session_info(db_path: &Path) -> BTreeMap<String, SessionInfo> {
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        return BTreeMap::new();
+    };
+    let Ok(mut statement) = connection.prepare(
+        "SELECT id, working_directory, model, created_at, last_activity_at FROM sessions WHERE hidden = 0 OR hidden IS NULL",
+    ) else {
+        return BTreeMap::new();
+    };
+    let mut info = BTreeMap::new();
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                let Ok(id) = statement.read::<String, _>(0) else {
+                    continue;
+                };
+                let working_directory = read_optional_string(&statement, 1);
+                let model = read_optional_string(&statement, 2);
+                let created_at = read_optional_timestamp(&statement, 3);
+                let last_activity_at = read_optional_timestamp(&statement, 4);
+                info.insert(
+                    id.clone(),
+                    SessionInfo {
+                        id,
+                        working_directory,
+                        model,
+                        created_at,
+                        last_activity_at,
+                    },
+                );
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => break,
+        }
+    }
+    info
+}
+
+fn read_optional_string(statement: &sqlite::Statement, index: usize) -> Option<String> {
+    statement
+        .read::<String, _>(index)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+}
+
+fn read_optional_timestamp(statement: &sqlite::Statement, index: usize) -> Option<String> {
+    let value = statement.read::<sqlite::Value, _>(index).ok()?;
+    match value {
+        sqlite::Value::Integer(num) => Some(format_sqlite_timestamp(num)),
+        sqlite::Value::String(text) => Some(text),
+        _ => None,
+    }
+}
+
+fn format_sqlite_timestamp(num: i64) -> String {
+    let millis = if num < 10_000_000_000 {
+        num * 1_000
+    } else {
+        num
+    };
+    crate::format_rfc3339_millis(crate::TimestampMs::from_millis(millis))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn parses_atif_v1_7_metrics_and_credit_cost() {
+        let fixture = fs_fixture!({
+            "transcripts/session-a.json": r#"{
+                "schema_version": "ATIF-v1.7",
+                "session_id": "session-a",
+                "agent": { "model_name": "claude-sonnet-4" },
+                "steps": [
+                    {
+                        "step_id": "1",
+                        "timestamp": "2026-01-02T00:00:00.000Z",
+                        "source": "agent",
+                        "metrics": {
+                            "prompt_tokens": 100,
+                            "completion_tokens": 50,
+                            "cached_tokens": 25,
+                            "extra": { "cache_creation_input_tokens": 10 }
+                        },
+                        "metadata": { "generation_model": "claude-sonnet-4-20250514", "committed_credit_cost": 0.05 }
+                    }
+                ]
+            }"#,
+        });
+        let file = fixture.path("transcripts/session-a.json");
+
+        let entries = read_transcript_file(&file, None, CostMode::Auto, None, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 50);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 25);
+        assert_eq!(
+            entries[0].data.message.usage.cache_creation_input_tokens,
+            10
+        );
+        assert_eq!(entries[0].cost, 0.05);
+        assert_eq!(
+            entries[0].model.as_deref(),
+            Some("claude-sonnet-4-20250514")
+        );
+    }
+
+    #[test]
+    fn falls_back_to_legacy_metadata_metrics() {
+        let fixture = fs_fixture!({
+            "transcripts/session-b.json": r#"{
+                "session_id": "session-b",
+                "steps": [
+                    {
+                        "step_id": "1",
+                        "timestamp": "2026-01-02T00:00:00Z",
+                        "metadata": {
+                            "is_user_input": false,
+                            "metrics": { "input_tokens": 10, "output_tokens": 20, "cache_creation_tokens": 5, "cache_read_tokens": 3 },
+                            "generation_model": "swe"
+                        }
+                    }
+                ]
+            }"#,
+        });
+        let file = fixture.path("transcripts/session-b.json");
+
+        let entries = read_transcript_file(&file, None, CostMode::Auto, None, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 20);
+        assert_eq!(entries[0].data.message.usage.cache_creation_input_tokens, 5);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 3);
+        assert_eq!(entries[0].model.as_deref(), Some("swe"));
+    }
+
+    #[test]
+    fn skips_user_input_steps() {
+        let fixture = fs_fixture!({
+            "transcripts/session-c.json": r#"{
+                "session_id": "session-c",
+                "steps": [
+                    {
+                        "step_id": "1",
+                        "timestamp": "2026-01-02T00:00:00Z",
+                        "metadata": { "is_user_input": true, "metrics": { "input_tokens": 999, "output_tokens": 999 } }
+                    },
+                    {
+                        "step_id": "2",
+                        "timestamp": "2026-01-02T00:00:01Z",
+                        "metadata": { "is_user_input": false, "metrics": { "input_tokens": 1, "output_tokens": 2 } }
+                    }
+                ]
+            }"#,
+        });
+        let file = fixture.path("transcripts/session-c.json");
+
+        let entries = read_transcript_file(&file, None, CostMode::Auto, None, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 1);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/devin/paths.rs
+++ b/rust/crates/ccusage/src/adapter/devin/paths.rs
@@ -1,0 +1,44 @@
+use std::{collections::HashSet, env, path::PathBuf};
+
+use crate::Result;
+
+const DEVIN_DATA_DIR_ENV: &str = "DEVIN_DATA_DIR";
+
+pub(super) fn paths(custom_path: Option<&str>) -> Result<Vec<PathBuf>> {
+    if let Some(custom_path) = custom_path.filter(|path| !path.trim().is_empty()) {
+        return Ok(existing_path_list(custom_path));
+    }
+    if let Ok(env_paths) = env::var(DEVIN_DATA_DIR_ENV)
+        && !env_paths.trim().is_empty()
+    {
+        return Ok(existing_path_list(&env_paths));
+    }
+
+    if let Some(data_dir) = default_data_dir() {
+        return Ok(data_dir.is_dir().then_some(data_dir).into_iter().collect());
+    }
+
+    Ok(Vec::new())
+}
+
+fn default_data_dir() -> Option<PathBuf> {
+    if let Some(app_data) = env::var_os("APPDATA").and_then(|path| {
+        let path = PathBuf::from(path);
+        (!path.as_os_str().is_empty()).then_some(path)
+    }) {
+        return Some(app_data.join("devin").join("cli"));
+    }
+
+    let home = crate::home::home_dir()?;
+    Some(home.join(".local").join("share").join("devin").join("cli"))
+}
+
+fn existing_path_list(raw: &str) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    raw.split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .filter(|path| path.is_dir() && seen.insert(path.clone()))
+        .collect()
+}

--- a/rust/crates/ccusage/src/adapter/devin/report.rs
+++ b/rust/crates/ccusage/src/adapter/devin/report.rs
@@ -1,0 +1,76 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator, cli::AgentReportKind, cli::WeekDay,
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| {
+            super::super::opencode::agent_summary_json(row, kind, kind == AgentReportKind::Session)
+        })
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_by_key(
+                entries,
+                |entry| entry.date.clone(),
+                |date| (date.to_string(), None),
+            )?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(|group| group.into_summary())
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod claude;
 pub(crate) mod codebuff;
 pub(crate) mod codex;
 pub(crate) mod copilot;
+pub(crate) mod devin;
 pub(crate) mod droid;
 pub(crate) mod gemini;
 pub(crate) mod goose;

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -14,8 +14,8 @@ use crate::{
     config_schema::{
         BlocksSpecificOptions, CodexOptions, ConfigCodexSpeed, ConfigCostMode, ConfigCostSource,
         ConfigPricingOverride, ConfigSortOrder, ConfigVisualBurnRate, ConfigWeekDay,
-        DailySpecificOptions, OpenClawOptions, PiOptions, SharedOptions, StatuslineSpecificOptions,
-        WeeklySpecificOptions,
+        DailySpecificOptions, DevinOptions, OpenClawOptions, PiOptions, SharedOptions,
+        StatuslineSpecificOptions, WeeklySpecificOptions,
     },
 };
 
@@ -358,6 +358,7 @@ pub(crate) fn apply_config_to_agent_args(
     codex_speed: &mut CodexSpeed,
     mut pi_path: Option<&mut Option<String>>,
     mut open_claw_path: Option<&mut Option<String>>,
+    mut devin_path: Option<&mut Option<String>>,
     config: &ConfigContext,
 ) {
     for options in config.option_maps() {
@@ -374,6 +375,11 @@ pub(crate) fn apply_config_to_agent_args(
             && let Some(path) = OpenClawOptions::from_map(options).open_claw_path
         {
             *open_claw_path = Some(path);
+        }
+        if let Some(devin_path) = devin_path.as_deref_mut()
+            && let Some(path) = DevinOptions::from_map(options).devin_path
+        {
+            *devin_path = Some(path);
         }
     }
 }
@@ -404,8 +410,9 @@ impl crate::cli::CliConfig for ConfigContext {
         codex_speed: &mut CodexSpeed,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
+        devin_path: Option<&mut Option<String>>,
     ) {
-        apply_config_to_agent_args(codex_speed, pi_path, open_claw_path, self);
+        apply_config_to_agent_args(codex_speed, pi_path, open_claw_path, devin_path, self);
     }
 }
 
@@ -780,6 +787,7 @@ mod tests {
             &mut speed,
             None,
             None,
+            None,
             &context(
                 json!({
                     "codex": {
@@ -801,6 +809,7 @@ mod tests {
         apply_config_to_agent_args(
             &mut speed,
             Some(&mut pi_path),
+            None,
             None,
             &context(
                 json!({
@@ -824,6 +833,7 @@ mod tests {
             &mut speed,
             None,
             Some(&mut open_claw_path),
+            None,
             &context(
                 json!({
                     "openclaw": {
@@ -839,6 +849,29 @@ mod tests {
         );
 
         assert_eq!(open_claw_path.as_deref(), Some("/tmp/openclaw"));
+
+        let mut speed = CodexSpeed::Auto;
+        let mut devin_path = None;
+        apply_config_to_agent_args(
+            &mut speed,
+            None,
+            None,
+            Some(&mut devin_path),
+            &context(
+                json!({
+                    "devin": {
+                        "defaults": {
+                            "devinPath": "/tmp/devin"
+                        }
+                    }
+                }),
+                "devin daily",
+                Some("devin"),
+                "daily",
+            ),
+        );
+
+        assert_eq!(devin_path.as_deref(), Some("/tmp/devin"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -48,6 +48,8 @@ pub(crate) struct CcusageConfig {
     pub(crate) kimi: Option<KimiConfig>,
     /// Qwen configuration.
     pub(crate) qwen: Option<QwenConfig>,
+    /// Devin configuration.
+    pub(crate) devin: Option<DevinConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -292,6 +294,22 @@ pub(crate) struct QwenCommandsConfig {
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
+pub(crate) struct DevinConfig {
+    pub(crate) defaults: Option<DevinOptions>,
+    pub(crate) commands: Option<DevinCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DevinCommandsConfig {
+    pub(crate) daily: Option<DevinOptions>,
+    pub(crate) weekly: Option<DevinOptions>,
+    pub(crate) monthly: Option<DevinOptions>,
+    pub(crate) session: Option<DevinOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
 pub(crate) struct SharedOptions {
     /// Filter from date (YYYY-MM-DD or YYYYMMDD).
     pub(crate) since: Option<String>,
@@ -469,6 +487,15 @@ pub(crate) struct OpenClawOptions {
     pub(crate) open_claw_path: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DevinOptions {
+    #[serde(flatten)]
+    pub(crate) shared: SharedOptions,
+    /// Path or comma-separated paths to Devin CLI data directories.
+    pub(crate) devin_path: Option<String>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ConfigCostMode {
@@ -634,6 +661,15 @@ impl OpenClawOptions {
         Self {
             shared: SharedOptions::from_map(map),
             open_claw_path: string_option(map, "openClawPath"),
+        }
+    }
+}
+
+impl DevinOptions {
+    pub(crate) fn from_map(map: &Map<String, Value>) -> Self {
+        Self {
+            shared: SharedOptions::from_map(map),
+            devin_path: string_option(map, "devinPath"),
         }
     }
 }
@@ -1103,8 +1139,8 @@ mod tests {
             "ccusage-config",
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "devin", "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi",
+                "qwen", "droid",
             ],
         );
         assert!(

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -146,12 +146,14 @@ fn main() -> Result<()> {
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
+        Some(Command::Devin(args)) => adapter::devin::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
                 kind: AgentReportKind::Daily,
                 pi_path: None,
                 open_claw_path: None,
+                devin_path: None,
                 codex_speed: cli::CodexSpeed::Auto,
             };
             adapter::all::run(args)

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -30,6 +30,7 @@ pub(crate) enum UsageLoadAgent {
     Gemini,
     Kimi,
     OpenClaw,
+    Devin,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
         UsageLoadAgent::OpenClaw => "OpenClaw",
+        UsageLoadAgent::Devin => "Devin",
     }
 }
 

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
+assertion_line: 1386
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -1131,6 +1131,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "commands",
     "copilot",
     "defaults",
+    "devin",
     "droid",
     "gemini",
     "goose",


### PR DESCRIPTION
## Try This PR

```sh
bunx -p https://pkg.pr.new/ccusage/ccusage@1398 ccusage devin daily --help
```

## Summary

- Add a Rust-based Devin usage adapter that reads ATIF trajectory transcripts from the Devin CLI
- Discover Devin data under `DEVIN_DATA_DIR` or the default OS paths (`~/.local/share/devin/cli`, `%APPDATA%\devin\cli`)
- Parse ATIF v1.7 step metrics and fall back to legacy `metadata.metrics`
- Read `sessions.db` for project path, model fallback, timestamps, and hidden-session filtering
- Wire `ccusage devin daily|weekly|monthly|session` into the CLI, config schema, and all-source loader
- Support `--devin-path` and `devinPath` config for custom or multiple data directories
- Add fixture-backed tests for path discovery, loader behavior, parser fallbacks, and report aggregation
- Update docs and README with Devin commands and environment variables

## Sample Output

`ccusage.exe devin --breakdown`

```text
╭────────────────────────────────────────────╮
│                                            │
│          Devin Token Usage Report          │
│                                            │
╰────────────────────────────────────────────╯

┌────────────────────┬─────────────────┬──────────────┬───────────┬───────────────┬──────────────┬───────────────┬─────────────┐
│ Date               │ Models          │        Input │    Output │  Cache Create │   Cache Read │  Total Tokens │  Cost (USD) │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│ 2026-07-03         │ - MODEL_SWE_1_5 │   36,465,810 │   208,431 │       899,796 │   34,568,626 │    72,142,663 │      $82.68 │
│                    │ - kimi-k2-7     │              │           │               │              │               │             │
│                    │ - sonnet-4-6    │              │           │               │              │               │             │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ sonnet-4-6    │                 │   17,771,016 │    58,698 │       899,796 │   16,870,885 │    35,600,395 │      $62.63 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ kimi-k2-7     │                 │   16,638,545 │   144,310 │             0 │   15,711,565 │    32,494,420 │      $19.37 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ MODEL_SWE_1_5 │                 │    2,056,249 │     5,423 │             0 │    1,986,176 │     4,047,848 │       $0.68 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│ 2026-07-04         │ - MODEL_SWE_1_5 │   49,979,590 │   298,606 │       679,773 │   47,594,963 │    98,552,932 │      $86.94 │
│                    │ - kimi-k2-7     │              │           │               │              │               │             │
│                    │ - sonnet-4-6    │              │           │               │              │               │             │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ sonnet-4-6    │                 │   12,793,742 │    51,021 │       679,773 │   12,113,719 │    25,638,255 │      $45.33 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ kimi-k2-7     │                 │   35,411,195 │   240,018 │             0 │   33,759,132 │    69,410,345 │      $41.01 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ MODEL_SWE_1_5 │                 │    1,774,653 │     7,567 │             0 │    1,722,112 │     3,504,332 │       $0.60 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│ 2026-07-05         │ - kimi-k2-7     │   28,400,772 │    63,183 │        19,863 │   27,597,549 │    56,081,367 │      $32.77 │
│                    │ - sonnet-4-6    │              │           │               │              │               │             │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ kimi-k2-7     │                 │   28,303,324 │   62,519 │             0 │   27,519,971 │    55,885,814 │      $32.37 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│   └─ sonnet-4-6    │                 │       97,448 │       664 │        19,863 │       77,578 │       195,553 │       $0.40 │
├────────────────────┼─────────────────┼──────────────┼───────────┼───────────────┼──────────────┼───────────────┼─────────────┤
│ Total              │                 │  114,846,172 │   570,220 │     1,599,432 │  109,761,138 │   226,776,962 │     $202.39 │
└────────────────────┴─────────────────┴──────────────┴───────────┴───────────────┴──────────────┴───────────────┴─────────────┘
```

## Validation

- cargo check --workspace
- cargo test --workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Devin as a supported local usage source, with daily, weekly, monthly, and session report views.
  * Added support for configuring Devin data directories via environment variable and CLI/config options (including custom paths and multi-directory inputs).
  * Included Devin in unified local source views and added corresponding CLI commands and help.
* **Documentation**
  * Added a dedicated Devin guide and expanded existing configuration, environment variable, and troubleshooting docs with examples and supported commands.
  * Updated tables and wording across the guide to reflect Devin support and how transcripts are sourced locally.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->