### PR TITLE
docs: add Burnbar to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -7,6 +7,7 @@ These projects are maintained independently and are not affiliated with the ccus
 ## Desktop Applications
 
 - [claude-usage-tracker-for-mac](https://github.com/penicillin0/claude-usage-tracker-for-mac) - macOS menu bar app for tracking Claude usage
+- [Burnbar](https://github.com/tangentlin/burnbar) - macOS menu bar app for Claude Code (and other agent CLI) cost tracking, with a durable usage history archive and Chart.js dashboard (forked from [claude-usage-tracker-for-mac](https://github.com/penicillin0/claude-usage-tracker-for-mac))
 - [ClaudeCode_Dashboard](https://github.com/m-sigepon/ClaudeCode_Dashboard) - Web dashboard with charts and visualizations
 - [Ccusage App](https://github.com/EthanBarlo/ccusage-app) - Native application to display ccusage data in graphs and visualizations
 - [CCOwl](https://github.com/sivchari/ccowl) - A cross-platform status bar application that monitors Claude Code usage in real-time.


### PR DESCRIPTION
Adds Burnbar (macOS menu bar app for Claude Code / agent CLI cost tracking) to the Desktop Applications section of the community projects guide.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786065283&installation_id=139163553&pr_number=1400&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1400&signature=e314131dc9a71f11e348bcecbd02b8901730fdffd5e3c68e5f0d89a53e961d0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Burnbar to the Desktop Applications section of the community projects guide. It’s a macOS menu bar app for Claude Code and other agent CLIs that tracks costs, keeps a durable usage history, and provides a Chart.js dashboard.

<sup>Written for commit 8adcd4b495c9119f06f46f53ef4d830aea5478dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1400?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new desktop app entry for Burnbar in the community projects guide.
  * Included a link to its repository and a short description of the app’s macOS menu bar cost-tracking features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->