### PR TITLE
feat(codex): show per-model token and cost stats

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -93,7 +93,9 @@ pub(super) fn print_table(
         if let Some(agent_breakdowns) = row.agent_breakdowns.as_ref() {
             for breakdown in agent_breakdowns {
                 table.push(all_table_row(breakdown, compact, true));
-                if shared.breakdown && !breakdown.model_breakdowns.is_empty() {
+                // Always expand multi-model agent rows so each model shows its
+                // own tokens/cost instead of only the summed agent totals.
+                if should_expand_model_breakdowns(shared, &breakdown.model_breakdowns) {
                     push_model_breakdown_rows(
                         &mut table,
                         &breakdown.model_breakdowns,
@@ -102,7 +104,7 @@ pub(super) fn print_table(
                     );
                 }
             }
-        } else if shared.breakdown && !row.model_breakdowns.is_empty() {
+        } else if should_expand_model_breakdowns(shared, &row.model_breakdowns) {
             push_model_breakdown_rows(&mut table, &row.model_breakdowns, compact, shared);
         }
     }
@@ -298,6 +300,10 @@ fn table_total_tokens(row: &AllRow) -> u64 {
         .saturating_add(row.output_tokens)
         .saturating_add(row.cache_creation_tokens)
         .saturating_add(row.cache_read_tokens)
+}
+
+fn should_expand_model_breakdowns(shared: &SharedArgs, breakdowns: &[ModelBreakdown]) -> bool {
+    !breakdowns.is_empty() && (shared.breakdown || breakdowns.len() > 1)
 }
 
 fn push_model_breakdown_rows(

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -242,6 +242,92 @@ mod tests {
     }
 
     #[test]
+    fn expands_multi_model_codex_rows_with_per_model_stats() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-5.4": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010,
+                    "cache_read_input_token_cost": 0.0000001
+                },
+                "gpt-5.5": {
+                    "input_cost_per_token": 0.000002,
+                    "output_cost_per_token": 0.000020,
+                    "cache_read_input_token_cost": 0.0000002
+                }
+            }"#,
+        );
+        let mut group = crate::CodexGroup {
+            input_tokens: 300,
+            cached_input_tokens: 100,
+            output_tokens: 30,
+            reasoning_output_tokens: 5,
+            total_tokens: 335,
+            last_activity: None,
+            models: BTreeMap::new(),
+        };
+        group.models.insert(
+            "gpt-5.4".to_string(),
+            CodexModelUsage {
+                input_tokens: 100,
+                cached_input_tokens: 40,
+                output_tokens: 10,
+                reasoning_output_tokens: 2,
+                total_tokens: 112,
+                is_fallback: false,
+            },
+        );
+        group.models.insert(
+            "gpt-5.5".to_string(),
+            CodexModelUsage {
+                input_tokens: 200,
+                cached_input_tokens: 60,
+                output_tokens: 20,
+                reasoning_output_tokens: 3,
+                total_tokens: 223,
+                is_fallback: false,
+            },
+        );
+        let groups = BTreeMap::from([("2026-07-10".to_string(), group)]);
+        let report = super::report::report_from_groups(
+            &groups,
+            AgentReportKind::Daily,
+            &pricing,
+            CodexSpeed::Standard,
+        );
+
+        assert_eq!(
+            report["daily"][0]["models"]["gpt-5.5"]["costUSD"]
+                .as_f64()
+                .unwrap_or_default(),
+            calculate_codex_model_cost(
+                "gpt-5.5",
+                groups["2026-07-10"].models.get("gpt-5.5").unwrap(),
+                &pricing,
+                CodexSpeed::Standard,
+            )
+        );
+        assert_eq!(report["daily"][0]["models"]["gpt-5.4"]["inputTokens"], 60);
+        assert_eq!(report["daily"][0]["models"]["gpt-5.5"]["inputTokens"], 140);
+
+        let shared = SharedArgs {
+            no_color: true,
+            ..SharedArgs::default()
+        };
+        // Multi-model table expansion is exercised here so regressions panic
+        // instead of silently collapsing per-model stats again.
+        super::report::print_table_from_groups(
+            &groups,
+            AgentReportKind::Daily,
+            &pricing,
+            CodexSpeed::Standard,
+            &shared,
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models() {
         let mut pricing = PricingMap::default();
         pricing.load_json(

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -6,8 +6,8 @@ use crate::{
     cli::{AgentReportKind, CodexSpeed, SharedArgs},
     color, format_currency, format_models_multiline, format_number, json_float,
     missing_pricing_model_for_token_total, print_box_title,
-    print_missing_pricing_warnings_for_models, Align, CodexGroup, CodexModelUsage, Color,
-    PricingMap, Result, SimpleTable,
+    print_missing_pricing_warnings_for_models, short_model_name, Align, CodexGroup, CodexModelUsage,
+    Color, PricingMap, Result, SimpleTable,
 };
 
 pub(super) fn report_from_groups(
@@ -57,7 +57,7 @@ fn group_json(
     let models = group
         .models
         .iter()
-        .map(|(model, usage)| (model.clone(), model_usage_json(usage)))
+        .map(|(model, usage)| (model.clone(), model_usage_json(model, usage, pricing, speed)))
         .collect::<BTreeMap<_, _>>();
     let mut row = json!({
         period_key(kind): period,
@@ -82,13 +82,14 @@ pub(crate) fn non_cached_input_tokens(input_tokens: u64, cached_input_tokens: u6
     input_tokens.saturating_sub(cached_input_tokens)
 }
 
-fn model_usage_json(usage: &CodexModelUsage) -> Value {
+fn model_usage_json(model: &str, usage: &CodexModelUsage, pricing: &PricingMap, speed: CodexSpeed) -> Value {
     json!({
         "inputTokens": non_cached_input_tokens(usage.input_tokens, usage.cached_input_tokens),
         "cachedInputTokens": usage.cached_input_tokens,
         "outputTokens": usage.output_tokens,
         "reasoningOutputTokens": usage.reasoning_output_tokens,
         "totalTokens": usage.total_tokens,
+        "costUSD": json_float(calculate_codex_model_cost(model, usage, pricing, speed)),
         "isFallback": usage.is_fallback,
     })
 }
@@ -194,6 +195,38 @@ pub(crate) fn codex_missing_pricing_models(
     models.into_iter().collect()
 }
 
+fn push_codex_model_row(
+    table: &mut SimpleTable,
+    model: &str,
+    usage: &CodexModelUsage,
+    cost: f64,
+    shared: &SharedArgs,
+) {
+    let input_tokens = non_cached_input_tokens(usage.input_tokens, usage.cached_input_tokens);
+    table.push(vec![
+        String::new(),
+        color(
+            shared,
+            format!("- {}", short_model_name(model)),
+            Color::Grey,
+        ),
+        color(shared, format_number(input_tokens), Color::Grey),
+        color(shared, format_number(usage.output_tokens), Color::Grey),
+        color(
+            shared,
+            format_number(usage.reasoning_output_tokens),
+            Color::Grey,
+        ),
+        color(
+            shared,
+            format_number(usage.cached_input_tokens),
+            Color::Grey,
+        ),
+        color(shared, format_number(usage.total_tokens), Color::Grey),
+        color(shared, format_currency(cost), Color::Grey),
+    ]);
+}
+
 pub(super) fn print_table_from_groups(
     groups: &BTreeMap<String, CodexGroup>,
     kind: AgentReportKind,
@@ -263,17 +296,51 @@ pub(super) fn print_table_from_groups(
         total_reasoning += group.reasoning_output_tokens;
         total_tokens += group.total_tokens;
         total_cost += cost;
-        let models = format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
-        table.push(vec![
-            label.clone(),
-            models,
-            format_number(input_tokens),
-            format_number(group.output_tokens),
-            format_number(group.reasoning_output_tokens),
-            format_number(group.cached_input_tokens),
-            format_number(group.total_tokens),
-            format_currency(cost),
-        ]);
+
+        let mut model_rows = group
+            .models
+            .iter()
+            .map(|(model, usage)| {
+                (
+                    model,
+                    usage,
+                    calculate_codex_model_cost(model, usage, pricing, speed),
+                )
+            })
+            .collect::<Vec<_>>();
+        model_rows.sort_by(|a, b| b.2.total_cmp(&a.2).then_with(|| a.0.cmp(b.0)));
+
+        // Multi-model periods used to dump every model name into one cell while
+        // only showing the summed token/cost totals. Expand them so each model
+        // gets its own stats row.
+        if model_rows.len() > 1 {
+            table.push(vec![
+                label.clone(),
+                String::new(),
+                format_number(input_tokens),
+                format_number(group.output_tokens),
+                format_number(group.reasoning_output_tokens),
+                format_number(group.cached_input_tokens),
+                format_number(group.total_tokens),
+                format_currency(cost),
+            ]);
+            for (model, usage, model_cost) in model_rows {
+                push_codex_model_row(&mut table, model, usage, model_cost, shared);
+            }
+        } else {
+            let models =
+                format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
+            table.push(vec![
+                label.clone(),
+                models,
+                format_number(input_tokens),
+                format_number(group.output_tokens),
+                format_number(group.reasoning_output_tokens),
+                format_number(group.cached_input_tokens),
+                format_number(group.total_tokens),
+                format_currency(cost),
+            ]);
+        }
     }
     table.separator();
     table.push(vec![

--- a/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
+++ b/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
@@ -13,6 +13,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -32,6 +33,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -62,6 +64,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -70,6 +73,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
           },
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -103,6 +107,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.0008085,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -125,6 +130,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.000013,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -165,6 +171,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -184,6 +191,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -252,7 +252,9 @@ pub(crate) fn print_usage_table(
             values.push(row.last_activity.clone().unwrap_or_default());
         }
         table.push(values);
-        if shared.breakdown {
+        // Multi-model periods should show per-model stats by default; keep the
+        // explicit --breakdown path for single-model rows too.
+        if shared.breakdown || row.model_breakdowns.len() > 1 {
             push_breakdown_rows(&mut table, row, compact, include_last_activity, shared);
         }
     }


### PR DESCRIPTION
## Summary
- Expand multi-model Codex table rows so each model shows its own input/output/reasoning/cache/total tokens and cost instead of only the summed period total
- Auto-expand multi-model rows in the unified `all` report and Claude-style usage tables without requiring `--breakdown`
- Include `costUSD` on each Codex JSON `models` entry so programmatic consumers get per-model cost

## Problem
When a day/session used multiple models (for example `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`), the Models column listed every model name but the token/cost columns still only showed the combined total. That made it impossible to see which model spent what.

## Test plan
- [x] `cargo test -p ccusage adapter::codex`
- [x] `cargo test -p ccusage adapter::all`
- [x] Manual: `ccusage codex daily --offline --since 2026-07-10` shows separate rows for each model
- [x] Manual: `ccusage daily --offline --since 2026-07-10` expands multi-model agent rows
- [x] Manual: Codex JSON includes `models.*.costUSD`

## Notes
Single-model rows keep the previous compact display. Explicit `--breakdown` still works for single-model rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786242317&installation_id=139163553&pr_number=1420&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1420&signature=ea348964b989a1dbc13ae4229b7f8677d8657151f67164db4514442883bb48cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show per-model token and cost stats in Codex and unified usage. Multi-model periods now expand by default, and Codex JSON exposes per-model cost.

- **New Features**
  - Expanded multi-model Codex rows to show each model’s input/output/reasoning/cache/total tokens and cost, with the parent row showing totals (per-model rows sorted by cost).
  - Auto-expand multi-model rows in the unified `all` report and Claude usage tables by default; single-model rows stay compact and `--breakdown` still works.
  - Added `costUSD` to each `models` entry in Codex JSON for programmatic per-model cost access.

<sup>Written for commit 97183960269801f951a0b6396c5e0b2a054519bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1420?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Multi-model usage periods now automatically expand to show per-model statistics, even without enabling breakdown mode.
  * Codex reports now display per-model costs in JSON output and terminal tables.
  * Multi-model Codex table rows are sorted by descending cost for easier comparison.

* **Bug Fixes**
  * Corrected reporting so per-model costs and input-token values remain visible for multi-model Codex usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->