### PR TITLE
feat: per-model stats and compact token abbreviations

### DIFF
--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -93,7 +93,9 @@ pub(super) fn print_table(
         if let Some(agent_breakdowns) = row.agent_breakdowns.as_ref() {
             for breakdown in agent_breakdowns {
                 table.push(all_table_row(breakdown, compact, true));
-                if shared.breakdown && !breakdown.model_breakdowns.is_empty() {
+                // Always expand multi-model agent rows so each model shows its
+                // own tokens/cost instead of only the summed agent totals.
+                if should_expand_model_breakdowns(shared, &breakdown.model_breakdowns) {
                     push_model_breakdown_rows(
                         &mut table,
                         &breakdown.model_breakdowns,
@@ -102,7 +104,7 @@ pub(super) fn print_table(
                     );
                 }
             }
-        } else if shared.breakdown && !row.model_breakdowns.is_empty() {
+        } else if should_expand_model_breakdowns(shared, &row.model_breakdowns) {
             push_model_breakdown_rows(&mut table, &row.model_breakdowns, compact, shared);
         }
     }
@@ -298,6 +300,10 @@ fn table_total_tokens(row: &AllRow) -> u64 {
         .saturating_add(row.output_tokens)
         .saturating_add(row.cache_creation_tokens)
         .saturating_add(row.cache_read_tokens)
+}
+
+fn should_expand_model_breakdowns(shared: &SharedArgs, breakdowns: &[ModelBreakdown]) -> bool {
+    !breakdowns.is_empty() && (shared.breakdown || breakdowns.len() > 1)
 }
 
 fn push_model_breakdown_rows(

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -242,6 +242,92 @@ mod tests {
     }
 
     #[test]
+    fn expands_multi_model_codex_rows_with_per_model_stats() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{
+                "gpt-5.4": {
+                    "input_cost_per_token": 0.000001,
+                    "output_cost_per_token": 0.000010,
+                    "cache_read_input_token_cost": 0.0000001
+                },
+                "gpt-5.5": {
+                    "input_cost_per_token": 0.000002,
+                    "output_cost_per_token": 0.000020,
+                    "cache_read_input_token_cost": 0.0000002
+                }
+            }"#,
+        );
+        let mut group = crate::CodexGroup {
+            input_tokens: 300,
+            cached_input_tokens: 100,
+            output_tokens: 30,
+            reasoning_output_tokens: 5,
+            total_tokens: 335,
+            last_activity: None,
+            models: BTreeMap::new(),
+        };
+        group.models.insert(
+            "gpt-5.4".to_string(),
+            CodexModelUsage {
+                input_tokens: 100,
+                cached_input_tokens: 40,
+                output_tokens: 10,
+                reasoning_output_tokens: 2,
+                total_tokens: 112,
+                is_fallback: false,
+            },
+        );
+        group.models.insert(
+            "gpt-5.5".to_string(),
+            CodexModelUsage {
+                input_tokens: 200,
+                cached_input_tokens: 60,
+                output_tokens: 20,
+                reasoning_output_tokens: 3,
+                total_tokens: 223,
+                is_fallback: false,
+            },
+        );
+        let groups = BTreeMap::from([("2026-07-10".to_string(), group)]);
+        let report = super::report::report_from_groups(
+            &groups,
+            AgentReportKind::Daily,
+            &pricing,
+            CodexSpeed::Standard,
+        );
+
+        assert_eq!(
+            report["daily"][0]["models"]["gpt-5.5"]["costUSD"]
+                .as_f64()
+                .unwrap_or_default(),
+            calculate_codex_model_cost(
+                "gpt-5.5",
+                groups["2026-07-10"].models.get("gpt-5.5").unwrap(),
+                &pricing,
+                CodexSpeed::Standard,
+            )
+        );
+        assert_eq!(report["daily"][0]["models"]["gpt-5.4"]["inputTokens"], 60);
+        assert_eq!(report["daily"][0]["models"]["gpt-5.5"]["inputTokens"], 140);
+
+        let shared = SharedArgs {
+            no_color: true,
+            ..SharedArgs::default()
+        };
+        // Multi-model table expansion is exercised here so regressions panic
+        // instead of silently collapsing per-model stats again.
+        super::report::print_table_from_groups(
+            &groups,
+            AgentReportKind::Daily,
+            &pricing,
+            CodexSpeed::Standard,
+            &shared,
+        )
+        .unwrap();
+    }
+
+    #[test]
     fn snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models() {
         let mut pricing = PricingMap::default();
         pricing.load_json(

--- a/rust/crates/ccusage/src/adapter/codex/report.rs
+++ b/rust/crates/ccusage/src/adapter/codex/report.rs
@@ -6,8 +6,8 @@ use crate::{
     cli::{AgentReportKind, CodexSpeed, SharedArgs},
     color, format_currency, format_models_multiline, format_number, json_float,
     missing_pricing_model_for_token_total, print_box_title,
-    print_missing_pricing_warnings_for_models, Align, CodexGroup, CodexModelUsage, Color,
-    PricingMap, Result, SimpleTable,
+    print_missing_pricing_warnings_for_models, short_model_name, Align, CodexGroup, CodexModelUsage,
+    Color, PricingMap, Result, SimpleTable,
 };
 
 pub(super) fn report_from_groups(
@@ -57,7 +57,7 @@ fn group_json(
     let models = group
         .models
         .iter()
-        .map(|(model, usage)| (model.clone(), model_usage_json(usage)))
+        .map(|(model, usage)| (model.clone(), model_usage_json(model, usage, pricing, speed)))
         .collect::<BTreeMap<_, _>>();
     let mut row = json!({
         period_key(kind): period,
@@ -82,13 +82,14 @@ pub(crate) fn non_cached_input_tokens(input_tokens: u64, cached_input_tokens: u6
     input_tokens.saturating_sub(cached_input_tokens)
 }
 
-fn model_usage_json(usage: &CodexModelUsage) -> Value {
+fn model_usage_json(model: &str, usage: &CodexModelUsage, pricing: &PricingMap, speed: CodexSpeed) -> Value {
     json!({
         "inputTokens": non_cached_input_tokens(usage.input_tokens, usage.cached_input_tokens),
         "cachedInputTokens": usage.cached_input_tokens,
         "outputTokens": usage.output_tokens,
         "reasoningOutputTokens": usage.reasoning_output_tokens,
         "totalTokens": usage.total_tokens,
+        "costUSD": json_float(calculate_codex_model_cost(model, usage, pricing, speed)),
         "isFallback": usage.is_fallback,
     })
 }
@@ -194,6 +195,38 @@ pub(crate) fn codex_missing_pricing_models(
     models.into_iter().collect()
 }
 
+fn push_codex_model_row(
+    table: &mut SimpleTable,
+    model: &str,
+    usage: &CodexModelUsage,
+    cost: f64,
+    shared: &SharedArgs,
+) {
+    let input_tokens = non_cached_input_tokens(usage.input_tokens, usage.cached_input_tokens);
+    table.push(vec![
+        String::new(),
+        color(
+            shared,
+            format!("- {}", short_model_name(model)),
+            Color::Grey,
+        ),
+        color(shared, format_number(input_tokens), Color::Grey),
+        color(shared, format_number(usage.output_tokens), Color::Grey),
+        color(
+            shared,
+            format_number(usage.reasoning_output_tokens),
+            Color::Grey,
+        ),
+        color(
+            shared,
+            format_number(usage.cached_input_tokens),
+            Color::Grey,
+        ),
+        color(shared, format_number(usage.total_tokens), Color::Grey),
+        color(shared, format_currency(cost), Color::Grey),
+    ]);
+}
+
 pub(super) fn print_table_from_groups(
     groups: &BTreeMap<String, CodexGroup>,
     kind: AgentReportKind,
@@ -263,17 +296,51 @@ pub(super) fn print_table_from_groups(
         total_reasoning += group.reasoning_output_tokens;
         total_tokens += group.total_tokens;
         total_cost += cost;
-        let models = format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
-        table.push(vec![
-            label.clone(),
-            models,
-            format_number(input_tokens),
-            format_number(group.output_tokens),
-            format_number(group.reasoning_output_tokens),
-            format_number(group.cached_input_tokens),
-            format_number(group.total_tokens),
-            format_currency(cost),
-        ]);
+
+        let mut model_rows = group
+            .models
+            .iter()
+            .map(|(model, usage)| {
+                (
+                    model,
+                    usage,
+                    calculate_codex_model_cost(model, usage, pricing, speed),
+                )
+            })
+            .collect::<Vec<_>>();
+        model_rows.sort_by(|a, b| b.2.total_cmp(&a.2).then_with(|| a.0.cmp(b.0)));
+
+        // Multi-model periods used to dump every model name into one cell while
+        // only showing the summed token/cost totals. Expand them so each model
+        // gets its own stats row.
+        if model_rows.len() > 1 {
+            table.push(vec![
+                label.clone(),
+                String::new(),
+                format_number(input_tokens),
+                format_number(group.output_tokens),
+                format_number(group.reasoning_output_tokens),
+                format_number(group.cached_input_tokens),
+                format_number(group.total_tokens),
+                format_currency(cost),
+            ]);
+            for (model, usage, model_cost) in model_rows {
+                push_codex_model_row(&mut table, model, usage, model_cost, shared);
+            }
+        } else {
+            let models =
+                format_models_multiline(&group.models.keys().cloned().collect::<Vec<_>>());
+            table.push(vec![
+                label.clone(),
+                models,
+                format_number(input_tokens),
+                format_number(group.output_tokens),
+                format_number(group.reasoning_output_tokens),
+                format_number(group.cached_input_tokens),
+                format_number(group.total_tokens),
+                format_currency(cost),
+            ]);
+        }
     }
     table.separator();
     table.push(vec![

--- a/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
+++ b/rust/crates/ccusage/src/adapter/codex/snapshots/ccusage__adapter__codex__tests__snapshots_codex_reports_for_periods_sessions_costs_and_fallback_models.snap
@@ -13,6 +13,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -32,6 +33,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -62,6 +64,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -70,6 +73,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
           },
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -103,6 +107,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.0008085,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -125,6 +130,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.000013,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,
@@ -165,6 +171,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5.3-codex": {
             "cachedInputTokens": 110,
+            "costUSD": 0.00040425,
             "inputTokens": 100,
             "isFallback": true,
             "outputTokens": 15,
@@ -184,6 +191,7 @@ expression: "serde_json::json!({\n    \"daily\":\n    report_json(&events, Agent
         "models": {
           "gpt-5-mini": {
             "cachedInputTokens": 0,
+            "costUSD": 0.0000065,
             "inputTokens": 10,
             "isFallback": false,
             "outputTokens": 2,

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -458,16 +458,34 @@ pub(crate) fn format_models_multiline(models: &[String]) -> String {
         .join("\n")
 }
 
+/// Format token/count values for table display.
+///
+/// Large values are abbreviated so multi-model rows stay readable:
+/// `1500 -> 1.5K`, `1_473_687 -> 1.5M`, `2_000_000_000 -> 2B`.
+/// Values under 1,000 stay exact.
 pub(crate) fn format_number(value: u64) -> String {
-    let s = value.to_string();
-    let mut out = String::with_capacity(s.len() + s.len() / 3);
-    for (i, ch) in s.chars().rev().enumerate() {
-        if i > 0 && i % 3 == 0 {
-            out.push(',');
-        }
-        out.push(ch);
+    if value < 1_000 {
+        return value.to_string();
     }
-    out.chars().rev().collect()
+
+    // Prefer the largest unit that still keeps a readable one-decimal value.
+    // Promote on round-up: 999_950 is "1M", not "1000.0K".
+    if value >= 999_950_000 {
+        return format_compact_scaled(value as f64 / 1_000_000_000.0, "B");
+    }
+    if value >= 999_950 {
+        return format_compact_scaled(value as f64 / 1_000_000.0, "M");
+    }
+    format_compact_scaled(value as f64 / 1_000.0, "K")
+}
+
+fn format_compact_scaled(value: f64, suffix: &str) -> String {
+    let rounded = (value * 10.0).round() / 10.0;
+    if (rounded - rounded.floor()).abs() < f64::EPSILON {
+        format!("{}{suffix}", rounded as u64)
+    } else {
+        format!("{rounded:.1}{suffix}")
+    }
 }
 
 pub(crate) fn format_currency(value: f64) -> String {
@@ -614,6 +632,23 @@ mod tests {
         ];
 
         insta::assert_snapshot!(format_models_multiline(&models));
+    }
+
+    #[test]
+    fn formats_token_counts_with_compact_abbreviations() {
+        assert_eq!(format_number(0), "0");
+        assert_eq!(format_number(999), "999");
+        assert_eq!(format_number(1_000), "1K");
+        assert_eq!(format_number(1_500), "1.5K");
+        assert_eq!(format_number(12_345), "12.3K");
+        assert_eq!(format_number(999_949), "999.9K");
+        assert_eq!(format_number(999_950), "1M");
+        assert_eq!(format_number(1_000_000), "1M");
+        assert_eq!(format_number(1_473_687), "1.5M");
+        assert_eq!(format_number(15_781_737), "15.8M");
+        assert_eq!(format_number(999_949_999), "999.9M");
+        assert_eq!(format_number(999_950_000), "1B");
+        assert_eq!(format_number(2_000_000_000), "2B");
     }
 
     fn snapshot_summary(period: &str, project: Option<&str>, credits: Option<f64>) -> UsageSummary {

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -252,7 +252,9 @@ pub(crate) fn print_usage_table(
             values.push(row.last_activity.clone().unwrap_or_default());
         }
         table.push(values);
-        if shared.breakdown {
+        // Multi-model periods should show per-model stats by default; keep the
+        // explicit --breakdown path for single-model rows too.
+        if shared.breakdown || row.model_breakdowns.len() > 1 {
             push_breakdown_rows(&mut table, row, compact, include_last_activity, shared);
         }
     }


### PR DESCRIPTION
## Summary
- Expand multi-model Codex/all/Claude table rows so each model reports its own tokens and cost instead of only the period total
- Auto-expand multi-model rows by default (no need for `--breakdown`)
- Include `costUSD` on each Codex JSON `models` entry
- Abbreviate large table token counts as `K` / `M` / `B` (e.g. `1.5M`, `15.9M`) so multi-model rows stay readable

## Problem
When a day/session used multiple models (for example `gpt-5.5`, `gpt-5.6-luna`, `gpt-5.6-sol`), the Models column listed every model name but the token/cost columns still only showed the combined total. Large absolute numbers also made multi-model tables hard to scan.

## Example
```
2026-07-10
  gpt-5.5       1.5M input   95.6K output   15.8M total   $17.34
  gpt-5.6-luna  302.8K       10.3K           2M           $0.00
  gpt-5.6-sol    57.5K        2.2K         124.2K         $0.00
```

## Test plan
- [x] `cargo test -p ccusage formats_token_counts_with_compact_abbreviations`
- [x] `cargo test -p ccusage adapter::codex`
- [x] `cargo test -p ccusage adapter::all`
- [x] Manual: `ccusage codex daily --offline --since 2026-07-10`
- [x] Manual: `ccusage daily --offline --since 2026-07-10`
- [x] Local global install verified

## Notes
- Single-model rows keep compact display
- Explicit `--breakdown` still works for single-model rows
- Values under 1000 stay exact; round-up promotion keeps `999.9K` / `1M` boundaries clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786244604&installation_id=139163553&pr_number=1421&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1421&signature=8549c9ac93cf2987c808092f764aca899bd6705a13e0426e20b58159e6a934f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show per-model token and cost stats for multi-model periods and make large token counts easier to scan. Adds per-model `costUSD` to Codex JSON output.

- **New Features**
  - Multi-model rows auto-expand so each model shows its own input/output/cached/total tokens and cost; `--breakdown` still works for single-model rows.
  - Codex JSON includes `costUSD` in each `models` entry.
  - Token counts use compact K/M/B formatting (e.g., 1.5M); values under 1,000 stay exact.

<sup>Written for commit 87ec94e10e5b3dc564f22407c9fd44bfacc8f4ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1421?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Codex reports now include per-model cost details in JSON output.
  * Terminal tables expand groups containing multiple models, showing totals and individual model rows sorted by cost.
  * Multi-model breakdowns are displayed automatically, even without enabling the breakdown option.
  * Large token and usage counts now use compact `K`, `M`, and `B` notation while preserving smaller values accurately.

* **Bug Fixes**
  * Improved consistency and reliability of multi-model report expansion across usage tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->