### PR TITLE
fix(codex): dedupe replayed usage

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -16,7 +16,7 @@ use crate::{
     format_date_tz, parse_ts_timestamp, parse_tz, wants_json, week_start,
 };
 
-use super::{parser, paths};
+use super::{parser, paths, replay::CodexReplayPlan};
 
 type CodexEventKey = (
     u64,
@@ -53,12 +53,26 @@ fn load_groups_from_sources(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
+    let file_groups = paths::collect_deduped_codex_usage_files(sources);
+    let replay_plan = CodexReplayPlan::new(
+        file_groups
+            .iter()
+            .map(|group| (group.dir.as_path(), group.files.as_slice())),
+        shared.single_thread,
+    );
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
-    for group in paths::collect_deduped_codex_usage_files(sources) {
+    for group in file_groups {
         merge_groups(
             &mut groups,
-            aggregate_files_with_dedupe(&group.dir, &group.files, shared, kind, &seen)?,
+            aggregate_files_with_dedupe(
+                &group.dir,
+                &group.files,
+                shared,
+                kind,
+                &seen,
+                &replay_plan,
+            )?,
         );
     }
     Ok(groups)
@@ -70,11 +84,13 @@ pub(super) fn load_groups_from_directory(
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let files = paths::collect_codex_usage_files(sessions_dir);
+    let replay_plan =
+        CodexReplayPlan::new([(sessions_dir, files.as_slice())], shared.single_thread);
     if shared.single_thread {
-        return aggregate_files_local(sessions_dir, &files, shared, kind);
+        return aggregate_files_local(sessions_dir, &files, shared, kind, &replay_plan);
     }
     let seen = create_dedupe_shards();
-    aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen)
+    aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen, &replay_plan)
 }
 
 fn aggregate_files_with_dedupe(
@@ -83,11 +99,12 @@ fn aggregate_files_with_dedupe(
     shared: &SharedArgs,
     kind: AgentReportKind,
     seen: &CodexDedupeShards,
+    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     if shared.single_thread {
-        return aggregate_files(sessions_dir, files, shared, kind, seen);
+        return aggregate_files(sessions_dir, files, shared, kind, seen, replay_plan);
     }
-    aggregate_files_parallel(sessions_dir, files, shared, kind, seen)
+    aggregate_files_parallel(sessions_dir, files, shared, kind, seen, replay_plan)
 }
 
 fn aggregate_files(
@@ -96,6 +113,7 @@ fn aggregate_files(
     shared: &SharedArgs,
     kind: AgentReportKind,
     seen: &CodexDedupeShards,
+    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
     let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
@@ -107,6 +125,7 @@ fn aggregate_files(
             timezone.as_ref(),
             shared,
             seen,
+            replay_plan,
             &mut groups,
         )?;
     }
@@ -119,13 +138,14 @@ fn aggregate_files_parallel(
     shared: &SharedArgs,
     kind: AgentReportKind,
     seen: &CodexDedupeShards,
+    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let worker_count = thread::available_parallelism()
         .map(usize::from)
         .unwrap_or(1)
         .min(files.len());
     if worker_count <= 1 {
-        return aggregate_files(sessions_dir, files, shared, kind, seen);
+        return aggregate_files(sessions_dir, files, shared, kind, seen, replay_plan);
     }
 
     let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
@@ -144,6 +164,7 @@ fn aggregate_files_parallel(
                         timezone.as_ref(),
                         shared,
                         seen,
+                        replay_plan,
                         &mut groups,
                     )?;
                 }
@@ -171,11 +192,15 @@ fn aggregate_file(
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
     seen: &CodexDedupeShards,
+    replay_plan: &CodexReplayPlan,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
-    parser::visit_codex_session_file(sessions_dir, file, |event| {
-        add_event_to_groups(&event, kind, timezone, shared, seen, groups)
-    })
+    parser::visit_codex_session_file(
+        sessions_dir,
+        file,
+        replay_plan.parent_usage(file),
+        |event| add_event_to_groups(&event, kind, timezone, shared, seen, groups),
+    )
 }
 
 fn aggregate_files_local(
@@ -183,8 +208,9 @@ fn aggregate_files_local(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    Ok(aggregate_files_local_with_seen(sessions_dir, files, shared, kind)?.groups)
+    Ok(aggregate_files_local_with_seen(sessions_dir, files, shared, kind, replay_plan)?.groups)
 }
 
 fn aggregate_files_local_with_seen(
@@ -192,6 +218,7 @@ fn aggregate_files_local_with_seen(
     files: &[PathBuf],
     shared: &SharedArgs,
     kind: AgentReportKind,
+    replay_plan: &CodexReplayPlan,
 ) -> Result<CodexAggregation> {
     let mut aggregation = CodexAggregation {
         groups: BTreeMap::new(),
@@ -205,6 +232,7 @@ fn aggregate_files_local_with_seen(
             kind,
             timezone.as_ref(),
             shared,
+            replay_plan,
             &mut aggregation,
         )?;
     }
@@ -217,11 +245,15 @@ fn aggregate_file_local(
     kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
     shared: &SharedArgs,
+    replay_plan: &CodexReplayPlan,
     aggregation: &mut CodexAggregation,
 ) -> Result<()> {
-    parser::visit_codex_session_file(sessions_dir, file, |event| {
-        add_event_to_groups_local(&event, kind, timezone, shared, aggregation)
-    })
+    parser::visit_codex_session_file(
+        sessions_dir,
+        file,
+        replay_plan.parent_usage(file),
+        |event| add_event_to_groups_local(&event, kind, timezone, shared, aggregation),
+    )
 }
 
 fn add_event_to_groups(
@@ -495,6 +527,70 @@ mod tests {
     use crate::{
         adapter::codex::paths::CodexUsageSource, model_aliases::set_model_aliases_for_tests,
     };
+
+    #[test]
+    fn skips_forked_parent_prefix_rewritten_across_seconds() {
+        fn token_count(timestamp: &str, input: u64, total_input: u64) -> String {
+            json!({
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5.2",
+                        "last_token_usage": {
+                            "input_tokens": input,
+                            "output_tokens": 1,
+                            "total_tokens": input + 1,
+                        },
+                        "total_token_usage": {
+                            "input_tokens": total_input,
+                            "output_tokens": 1,
+                            "total_tokens": total_input + 1,
+                        },
+                    },
+                },
+            })
+            .to_string()
+        }
+
+        let fixture = fs_fixture!({
+            "sessions/parent.jsonl": [
+                json!({
+                    "type": "session_meta",
+                    "payload": {"id": "parent"},
+                })
+                .to_string(),
+                token_count("2026-07-10T08:01:00.000Z", 100, 100),
+                token_count("2026-07-10T08:02:00.000Z", 200, 300),
+            ]
+            .join("\n"),
+            "sessions/child.jsonl": [
+                json!({
+                    "type": "session_meta",
+                    "payload": {"id": "child", "forked_from_id": "parent"},
+                })
+                .to_string(),
+                token_count("2026-07-10T09:00:00.100Z", 100, 100),
+                token_count("2026-07-10T09:00:01.100Z", 200, 300),
+                token_count("2026-07-10T09:00:02.100Z", 50, 350),
+            ]
+            .join("\n"),
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+
+        let groups =
+            load_groups_from_directory(&fixture.path("sessions"), &shared, AgentReportKind::Daily)
+                .unwrap();
+
+        let group = groups.get("2026-07-10").unwrap();
+        assert_eq!(group.input_tokens, 350);
+        assert_eq!(group.total_tokens, 353);
+    }
 
     #[test]
     fn dedupes_copied_token_usage_across_session_files() {

--- a/rust/crates/ccusage/src/adapter/codex/aggregate.rs
+++ b/rust/crates/ccusage/src/adapter/codex/aggregate.rs
@@ -37,6 +37,15 @@ struct CodexAggregation {
     seen: FxHashSet<CodexEventKey>,
 }
 
+/// Read-only inputs every file of one aggregation run shares.
+struct CodexAggregateRun<'a> {
+    sessions_dir: &'a Path,
+    files: &'a [PathBuf],
+    shared: &'a SharedArgs,
+    kind: AgentReportKind,
+    replay_plan: &'a CodexReplayPlan,
+}
+
 pub(crate) fn load_groups(
     shared: &SharedArgs,
     kind: AgentReportKind,
@@ -62,16 +71,18 @@ fn load_groups_from_sources(
     );
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
-    for group in file_groups {
+    for group in &file_groups {
         merge_groups(
             &mut groups,
             aggregate_files_with_dedupe(
-                &group.dir,
-                &group.files,
-                shared,
-                kind,
+                &CodexAggregateRun {
+                    sessions_dir: &group.dir,
+                    files: &group.files,
+                    shared,
+                    kind,
+                    replay_plan: &replay_plan,
+                },
                 &seen,
-                &replay_plan,
             )?,
         );
     }
@@ -86,87 +97,65 @@ pub(super) fn load_groups_from_directory(
     let files = paths::collect_codex_usage_files(sessions_dir);
     let replay_plan =
         CodexReplayPlan::new([(sessions_dir, files.as_slice())], shared.single_thread);
+    let run = CodexAggregateRun {
+        sessions_dir,
+        files: &files,
+        shared,
+        kind,
+        replay_plan: &replay_plan,
+    };
     if shared.single_thread {
-        return aggregate_files_local(sessions_dir, &files, shared, kind, &replay_plan);
+        return aggregate_files_local(&run);
     }
     let seen = create_dedupe_shards();
-    aggregate_files_parallel(sessions_dir, &files, shared, kind, &seen, &replay_plan)
+    aggregate_files_parallel(&run, &seen)
 }
 
 fn aggregate_files_with_dedupe(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
+    run: &CodexAggregateRun<'_>,
     seen: &CodexDedupeShards,
-    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    if shared.single_thread {
-        return aggregate_files(sessions_dir, files, shared, kind, seen, replay_plan);
+    if run.shared.single_thread {
+        return aggregate_files(run, seen);
     }
-    aggregate_files_parallel(sessions_dir, files, shared, kind, seen, replay_plan)
+    aggregate_files_parallel(run, seen)
 }
 
 fn aggregate_files(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
+    run: &CodexAggregateRun<'_>,
     seen: &CodexDedupeShards,
-    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let mut groups = BTreeMap::new();
-    let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
-    for file in files {
-        aggregate_file(
-            sessions_dir,
-            file,
-            kind,
-            timezone.as_ref(),
-            shared,
-            seen,
-            replay_plan,
-            &mut groups,
-        )?;
+    let timezone =
+        parse_tz(run.shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+    for file in run.files {
+        aggregate_file(run, file, timezone.as_ref(), seen, &mut groups)?;
     }
     Ok(groups)
 }
 
 fn aggregate_files_parallel(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
+    run: &CodexAggregateRun<'_>,
     seen: &CodexDedupeShards,
-    replay_plan: &CodexReplayPlan,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let worker_count = thread::available_parallelism()
         .map(usize::from)
         .unwrap_or(1)
-        .min(files.len());
+        .min(run.files.len());
     if worker_count <= 1 {
-        return aggregate_files(sessions_dir, files, shared, kind, seen, replay_plan);
+        return aggregate_files(run, seen);
     }
 
-    let chunks = crate::chunk_file_indexes_by_size(files, worker_count);
+    let chunks = crate::chunk_file_indexes_by_size(run.files, worker_count);
     thread::scope(|scope| {
         let mut handles = Vec::with_capacity(chunks.len());
         for chunk in chunks {
             handles.push(scope.spawn(move || {
                 let mut groups = BTreeMap::new();
-                let timezone =
-                    parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+                let timezone = parse_tz(run.shared.timezone.as_deref())
+                    .or_else(|| Some(JiffTimeZone::system()));
                 for index in chunk {
-                    aggregate_file(
-                        sessions_dir,
-                        &files[index],
-                        kind,
-                        timezone.as_ref(),
-                        shared,
-                        seen,
-                        replay_plan,
-                        &mut groups,
-                    )?;
+                    aggregate_file(run, &run.files[index], timezone.as_ref(), seen, &mut groups)?;
                 }
                 Result::<BTreeMap<String, CodexGroup>>::Ok(groups)
             }));
@@ -186,73 +175,48 @@ fn aggregate_files_parallel(
 }
 
 fn aggregate_file(
-    sessions_dir: &Path,
+    run: &CodexAggregateRun<'_>,
     file: &Path,
-    kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
-    shared: &SharedArgs,
     seen: &CodexDedupeShards,
-    replay_plan: &CodexReplayPlan,
     groups: &mut BTreeMap<String, CodexGroup>,
 ) -> Result<()> {
     parser::visit_codex_session_file(
-        sessions_dir,
+        run.sessions_dir,
         file,
-        replay_plan.parent_usage(file),
-        |event| add_event_to_groups(&event, kind, timezone, shared, seen, groups),
+        run.replay_plan.replay_prefix(file),
+        |event| add_event_to_groups(&event, run.kind, timezone, run.shared, seen, groups),
     )
 }
 
-fn aggregate_files_local(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
-    replay_plan: &CodexReplayPlan,
-) -> Result<BTreeMap<String, CodexGroup>> {
-    Ok(aggregate_files_local_with_seen(sessions_dir, files, shared, kind, replay_plan)?.groups)
+fn aggregate_files_local(run: &CodexAggregateRun<'_>) -> Result<BTreeMap<String, CodexGroup>> {
+    Ok(aggregate_files_local_with_seen(run)?.groups)
 }
 
-fn aggregate_files_local_with_seen(
-    sessions_dir: &Path,
-    files: &[PathBuf],
-    shared: &SharedArgs,
-    kind: AgentReportKind,
-    replay_plan: &CodexReplayPlan,
-) -> Result<CodexAggregation> {
+fn aggregate_files_local_with_seen(run: &CodexAggregateRun<'_>) -> Result<CodexAggregation> {
     let mut aggregation = CodexAggregation {
         groups: BTreeMap::new(),
         seen: FxHashSet::default(),
     };
-    let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
-    for file in files {
-        aggregate_file_local(
-            sessions_dir,
-            file,
-            kind,
-            timezone.as_ref(),
-            shared,
-            replay_plan,
-            &mut aggregation,
-        )?;
+    let timezone =
+        parse_tz(run.shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+    for file in run.files {
+        aggregate_file_local(run, file, timezone.as_ref(), &mut aggregation)?;
     }
     Ok(aggregation)
 }
 
 fn aggregate_file_local(
-    sessions_dir: &Path,
+    run: &CodexAggregateRun<'_>,
     file: &Path,
-    kind: AgentReportKind,
     timezone: Option<&JiffTimeZone>,
-    shared: &SharedArgs,
-    replay_plan: &CodexReplayPlan,
     aggregation: &mut CodexAggregation,
 ) -> Result<()> {
     parser::visit_codex_session_file(
-        sessions_dir,
+        run.sessions_dir,
         file,
-        replay_plan.parent_usage(file),
-        |event| add_event_to_groups_local(&event, kind, timezone, shared, aggregation),
+        run.replay_plan.replay_prefix(file),
+        |event| add_event_to_groups_local(&event, run.kind, timezone, run.shared, aggregation),
     )
 }
 

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -16,6 +16,7 @@ use super::{
         CodexUsageSource, codex_usage_sources, collect_codex_usage_files,
         collect_deduped_codex_usage_files,
     },
+    replay::CodexReplayPlan,
 };
 
 pub(crate) fn load_codex_events_from_directory(
@@ -23,13 +24,14 @@ pub(crate) fn load_codex_events_from_directory(
     single_thread: bool,
 ) -> Result<Vec<CodexTokenUsageEvent>> {
     let files = collect_codex_usage_files(sessions_dir);
+    let replay_plan = CodexReplayPlan::new([(sessions_dir, files.as_slice())], single_thread);
     let mut events = if single_thread {
         files
             .iter()
-            .flat_map(|file| read_codex_session_file(sessions_dir, file))
+            .flat_map(|file| read_codex_session_file(sessions_dir, file, &replay_plan))
             .collect::<Vec<_>>()
     } else {
-        read_codex_session_files_parallel(sessions_dir, &files)
+        read_codex_session_files_parallel(sessions_dir, &files, &replay_plan)
     };
     dedupe_codex_events(&mut events);
     Ok(events)
@@ -53,16 +55,23 @@ fn load_codex_events_from_sources(
         return load_codex_events_from_directory(&source.dir, single_thread);
     }
 
+    let groups = collect_deduped_codex_usage_files(sources);
+    let replay_plan = CodexReplayPlan::new(
+        groups
+            .iter()
+            .map(|group| (group.dir.as_path(), group.files.as_slice())),
+        single_thread,
+    );
     let mut events = Vec::new();
-    for group in collect_deduped_codex_usage_files(sources) {
+    for group in groups {
         let mut source_events = if single_thread {
             group
                 .files
                 .iter()
-                .flat_map(|file| read_codex_session_file(&group.dir, file))
+                .flat_map(|file| read_codex_session_file(&group.dir, file, &replay_plan))
                 .collect::<Vec<_>>()
         } else {
-            read_codex_session_files_parallel(&group.dir, &group.files)
+            read_codex_session_files_parallel(&group.dir, &group.files, &replay_plan)
         };
         events.append(&mut source_events);
     }
@@ -73,6 +82,7 @@ fn load_codex_events_from_sources(
 fn read_codex_session_files_parallel(
     sessions_dir: &Path,
     files: &[PathBuf],
+    replay_plan: &CodexReplayPlan,
 ) -> Vec<CodexTokenUsageEvent> {
     let worker_count = thread::available_parallelism()
         .map(usize::from)
@@ -81,7 +91,7 @@ fn read_codex_session_files_parallel(
     if worker_count <= 1 {
         return files
             .iter()
-            .flat_map(|file| read_codex_session_file(sessions_dir, file))
+            .flat_map(|file| read_codex_session_file(sessions_dir, file, replay_plan))
             .collect();
     }
 
@@ -92,7 +102,12 @@ fn read_codex_session_files_parallel(
             handles.push(scope.spawn(move || {
                 chunk
                     .into_iter()
-                    .map(|index| (index, read_codex_session_file(sessions_dir, &files[index])))
+                    .map(|index| {
+                        (
+                            index,
+                            read_codex_session_file(sessions_dir, &files[index], replay_plan),
+                        )
+                    })
                     .collect::<Vec<_>>()
             }));
         }
@@ -113,12 +128,21 @@ fn read_codex_session_files_parallel(
     })
 }
 
-fn read_codex_session_file(sessions_dir: &Path, path: &Path) -> Vec<CodexTokenUsageEvent> {
+fn read_codex_session_file(
+    sessions_dir: &Path,
+    path: &Path,
+    replay_plan: &CodexReplayPlan,
+) -> Vec<CodexTokenUsageEvent> {
     let mut events = Vec::new();
-    let _ = visit_codex_session_file(sessions_dir, path, |event| {
-        events.push(event);
-        Ok(())
-    });
+    let _ = visit_codex_session_file(
+        sessions_dir,
+        path,
+        replay_plan.parent_usage(path),
+        |event| {
+            events.push(event);
+            Ok(())
+        },
+    );
     events
 }
 
@@ -168,6 +192,108 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].session_id, "session-a");
+    }
+
+    #[test]
+    fn skips_repeated_last_usage_when_cumulative_total_is_unchanged() {
+        let usage = json!({
+            "last_token_usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            "total_token_usage": {
+                "input_tokens": 100,
+                "cached_input_tokens": 20,
+                "output_tokens": 10,
+                "total_tokens": 110,
+            },
+            "model": "gpt-5.5",
+        });
+        let fixture = fs_fixture!({
+            "session.jsonl": [
+                json!({
+                    "timestamp": "2026-07-10T08:00:00.000Z",
+                    "type": "event_msg",
+                    "payload": {"type": "token_count", "info": usage.clone()},
+                })
+                .to_string(),
+                json!({
+                    "timestamp": "2026-07-10T08:00:01.000Z",
+                    "type": "event_msg",
+                    "payload": {"type": "token_count", "info": usage},
+                })
+                .to_string(),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].total_tokens, 110);
+    }
+
+    #[test]
+    fn skips_nested_replays_against_immutable_parent_streams() {
+        fn metadata(id: &str, parent: Option<&str>) -> String {
+            json!({
+                "type": "session_meta",
+                "payload": {"id": id, "forked_from_id": parent},
+            })
+            .to_string()
+        }
+
+        fn token_count(timestamp: &str, input: u64) -> String {
+            json!({
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5.2",
+                        "last_token_usage": {
+                            "input_tokens": input,
+                            "output_tokens": 1,
+                            "total_tokens": input + 1,
+                        },
+                    },
+                },
+            })
+            .to_string()
+        }
+
+        let fixture = fs_fixture!({
+            "01-root.jsonl": [
+                metadata("root", None),
+                token_count("2026-07-10T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+            "02-parent.jsonl": [
+                metadata("parent", Some("root")),
+                token_count("2026-07-10T09:00:00.000Z", 100),
+                token_count("2026-07-10T09:01:00.000Z", 50),
+            ]
+            .join("\n"),
+            "03-child.jsonl": [
+                metadata("child", Some("parent")),
+                token_count("2026-07-10T10:00:00.000Z", 100),
+                token_count("2026-07-10T10:00:01.000Z", 50),
+                token_count("2026-07-10T10:01:00.000Z", 25),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(
+            events
+                .iter()
+                .map(|event| (event.session_id.as_str(), event.input_tokens))
+                .collect::<Vec<_>>(),
+            [("01-root", 100), ("02-parent", 50), ("03-child", 25)]
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -1394,6 +1394,70 @@ mod tests {
     }
 
     #[test]
+    fn keeps_child_usage_matching_parent_event_after_fork() {
+        fn metadata(timestamp: &str, id: &str, parent: Option<&str>) -> String {
+            json!({
+                "timestamp": timestamp,
+                "type": "session_meta",
+                "payload": {"id": id, "forked_from_id": parent},
+            })
+            .to_string()
+        }
+
+        fn token_count(timestamp: &str, input_tokens: u64) -> String {
+            json!({
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": input_tokens,
+                            "output_tokens": 1,
+                            "total_tokens": input_tokens + 1,
+                        },
+                        "model": "gpt-5.2",
+                    },
+                },
+            })
+            .to_string()
+        }
+
+        let fixture = fs_fixture!({
+            "parent.jsonl": [
+                metadata("2026-05-12T08:00:00.000Z", "parent", None),
+                token_count("2026-05-12T08:01:00.000Z", 100),
+                // Written after the child forked.
+                token_count("2026-05-12T08:03:00.000Z", 50),
+            ]
+            .join("\n"),
+            "child.jsonl": [
+                metadata(
+                    "2026-05-12T08:02:00.000Z",
+                    "child",
+                    Some("parent"),
+                ),
+                // Replayed parent state at the fork.
+                token_count("2026-05-12T08:02:00.000Z", 100),
+                // Real child usage that happens to equal the parent's next event.
+                token_count("2026-05-12T08:04:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+
+        for single_thread in [true, false] {
+            let events = load_codex_events_from_directory(fixture.root(), single_thread).unwrap();
+            let child_events = events
+                .iter()
+                .filter(|event| event.session_id == "child")
+                .collect::<Vec<_>>();
+
+            assert_eq!(child_events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(child_events[0].input_tokens, 50);
+        }
+    }
+
+    #[test]
     fn skips_replayed_history_across_multiple_subagent_files() {
         let parent_line = json!({
             "timestamp": "2026-05-12T08:01:00.000Z",

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -384,6 +384,41 @@ mod tests {
     }
 
     #[test]
+    fn bounds_the_replay_at_a_numeric_fork_timestamp() {
+        let fixture = fs_fixture!({
+            "01-parent.jsonl": [
+                replay_metadata("2026-07-10T08:00:00.000Z", "parent", None),
+                replay_token_count("2026-07-10T08:01:00.000Z", 100),
+                // Written after the child forked.
+                replay_token_count("2026-07-10T08:03:00.000Z", 50),
+            ]
+            .join("\n"),
+            "02-child.jsonl": [
+                json!({
+                    // Epoch seconds for 2026-07-10T08:02:00Z.
+                    "timestamp": 1_783_670_520_u64,
+                    "type": "session_meta",
+                    "payload": {"id": "child", "forked_from_id": "parent"},
+                })
+                .to_string(),
+                replay_token_count("2026-07-10T08:02:00.000Z", 100),
+                // Real child usage that happens to equal the parent's next event.
+                replay_token_count("2026-07-10T08:04:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [
+                ("01-parent".to_string(), 100),
+                ("01-parent".to_string(), 50),
+                ("02-child".to_string(), 50),
+            ]
+        );
+    }
+
+    #[test]
     fn keeps_usage_of_a_session_that_lists_itself_as_its_own_parent() {
         let fixture = fs_fixture!({
             "self.jsonl": [

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -236,6 +236,52 @@ mod tests {
     }
 
     #[test]
+    fn skips_missing_parent_replay_when_duplicate_snapshot_is_suppressed() {
+        fn token_count(timestamp: &str, input: u64, total_input: u64) -> String {
+            json!({
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "last_token_usage": {
+                            "input_tokens": input,
+                            "output_tokens": 1,
+                            "total_tokens": input + 1,
+                        },
+                        "total_token_usage": {
+                            "input_tokens": total_input,
+                            "output_tokens": 1,
+                            "total_tokens": total_input + 1,
+                        },
+                        "model": "gpt-5.5",
+                    },
+                },
+            })
+            .to_string()
+        }
+
+        let fixture = fs_fixture!({
+            "child.jsonl": [
+                json!({
+                    "type": "session_meta",
+                    "payload": {"id": "child", "forked_from_id": "missing-parent"},
+                })
+                .to_string(),
+                token_count("2026-07-10T08:00:00.100Z", 100, 100),
+                token_count("2026-07-10T08:00:00.200Z", 100, 100),
+                token_count("2026-07-10T08:00:01.000Z", 50, 50),
+            ]
+            .join("\n"),
+        });
+
+        let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].input_tokens, 50);
+    }
+
+    #[test]
     fn skips_nested_replays_against_immutable_parent_streams() {
         fn metadata(id: &str, parent: Option<&str>) -> String {
             json!({

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -1553,52 +1553,20 @@ mod tests {
 
     #[test]
     fn keeps_child_usage_matching_parent_event_after_fork() {
-        fn metadata(timestamp: &str, id: &str, parent: Option<&str>) -> String {
-            json!({
-                "timestamp": timestamp,
-                "type": "session_meta",
-                "payload": {"id": id, "forked_from_id": parent},
-            })
-            .to_string()
-        }
-
-        fn token_count(timestamp: &str, input_tokens: u64) -> String {
-            json!({
-                "timestamp": timestamp,
-                "type": "event_msg",
-                "payload": {
-                    "type": "token_count",
-                    "info": {
-                        "last_token_usage": {
-                            "input_tokens": input_tokens,
-                            "output_tokens": 1,
-                            "total_tokens": input_tokens + 1,
-                        },
-                        "model": "gpt-5.2",
-                    },
-                },
-            })
-            .to_string()
-        }
-
         let fixture = fs_fixture!({
             "parent.jsonl": [
-                metadata("2026-05-12T08:00:00.000Z", "parent", None),
-                token_count("2026-05-12T08:01:00.000Z", 100),
+                replay_metadata("2026-05-12T08:00:00.000Z", "parent", None),
+                replay_token_count("2026-05-12T08:01:00.000Z", 100),
                 // Written after the child forked.
-                token_count("2026-05-12T08:03:00.000Z", 50),
+                replay_token_count("2026-05-12T08:03:00.000Z", 50),
             ]
             .join("\n"),
             "child.jsonl": [
-                metadata(
-                    "2026-05-12T08:02:00.000Z",
-                    "child",
-                    Some("parent"),
-                ),
+                replay_metadata("2026-05-12T08:02:00.000Z", "child", Some("parent")),
                 // Replayed parent state at the fork.
-                token_count("2026-05-12T08:02:00.000Z", 100),
+                replay_token_count("2026-05-12T08:02:00.000Z", 100),
                 // Real child usage that happens to equal the parent's next event.
-                token_count("2026-05-12T08:04:00.000Z", 50),
+                replay_token_count("2026-05-12T08:04:00.000Z", 50),
             ]
             .join("\n"),
         });

--- a/rust/crates/ccusage/src/adapter/codex/loader.rs
+++ b/rust/crates/ccusage/src/adapter/codex/loader.rs
@@ -137,7 +137,7 @@ fn read_codex_session_file(
     let _ = visit_codex_session_file(
         sessions_dir,
         path,
-        replay_plan.parent_usage(path),
+        replay_plan.replay_prefix(path),
         |event| {
             events.push(event);
             Ok(())
@@ -279,6 +279,129 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].input_tokens, 50);
+    }
+
+    fn replay_metadata(timestamp: &str, id: &str, parent: Option<&str>) -> String {
+        json!({
+            "timestamp": timestamp,
+            "type": "session_meta",
+            "payload": {"id": id, "forked_from_id": parent},
+        })
+        .to_string()
+    }
+
+    fn replay_token_count(timestamp: &str, input_tokens: u64) -> String {
+        json!({
+            "timestamp": timestamp,
+            "type": "event_msg",
+            "payload": {
+                "type": "token_count",
+                "info": {
+                    "model": "gpt-5.2",
+                    "last_token_usage": {
+                        "input_tokens": input_tokens,
+                        "output_tokens": 1,
+                        "total_tokens": input_tokens + 1,
+                    },
+                },
+            },
+        })
+        .to_string()
+    }
+
+    fn replay_input_tokens_by_session(dir: &Path) -> Vec<(String, u64)> {
+        load_codex_events_from_directory(dir, true)
+            .unwrap()
+            .iter()
+            .map(|event| (event.session_id.clone(), event.input_tokens))
+            .collect()
+    }
+
+    #[test]
+    fn keeps_full_parent_stream_when_the_parent_itself_replayed_a_missing_session() {
+        let fixture = fs_fixture!({
+            // The grandparent log is gone, so this session falls back to skipping
+            // its own rewritten second.
+            "01-parent.jsonl": [
+                replay_metadata("2026-07-10T08:00:00.000Z", "parent", Some("missing-grandparent")),
+                replay_token_count("2026-07-10T08:00:00.100Z", 100),
+                replay_token_count("2026-07-10T08:00:00.200Z", 200),
+                replay_token_count("2026-07-10T08:01:00.000Z", 300),
+                replay_token_count("2026-07-10T08:02:00.000Z", 400),
+            ]
+            .join("\n"),
+            "02-child.jsonl": [
+                replay_metadata("2026-07-10T09:00:00.000Z", "child", Some("parent")),
+                replay_token_count("2026-07-10T09:00:00.100Z", 100),
+                replay_token_count("2026-07-10T09:00:00.200Z", 200),
+                replay_token_count("2026-07-10T09:00:00.300Z", 300),
+                replay_token_count("2026-07-10T09:00:00.400Z", 400),
+                replay_token_count("2026-07-10T09:05:00.000Z", 500),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [
+                ("01-parent".to_string(), 300),
+                ("01-parent".to_string(), 400),
+                ("02-child".to_string(), 500),
+            ]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_rewritten_second_when_the_replay_starts_mid_parent_stream() {
+        let fixture = fs_fixture!({
+            "01-parent.jsonl": [
+                replay_metadata("2026-07-10T08:00:00.000Z", "parent", None),
+                replay_token_count("2026-07-10T08:01:00.000Z", 100),
+                replay_token_count("2026-07-10T08:02:00.000Z", 200),
+                replay_token_count("2026-07-10T08:03:00.000Z", 300),
+            ]
+            .join("\n"),
+            // Codex replayed a compacted history, so it does not line up with the
+            // start of the parent stream.
+            "02-child.jsonl": [
+                replay_metadata("2026-07-10T09:00:00.000Z", "child", Some("parent")),
+                replay_token_count("2026-07-10T09:00:00.100Z", 200),
+                replay_token_count("2026-07-10T09:00:00.200Z", 300),
+                replay_token_count("2026-07-10T09:05:00.000Z", 400),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [
+                ("01-parent".to_string(), 100),
+                ("01-parent".to_string(), 200),
+                ("01-parent".to_string(), 300),
+                ("02-child".to_string(), 400),
+            ]
+        );
+    }
+
+    #[test]
+    fn keeps_usage_of_a_session_that_lists_itself_as_its_own_parent() {
+        let fixture = fs_fixture!({
+            "self.jsonl": [
+                json!({
+                    "type": "session_meta",
+                    "payload": {"id": "self", "forked_from_id": "self"},
+                })
+                .to_string(),
+                replay_token_count("2026-07-10T08:01:00.000Z", 100),
+                replay_token_count("2026-07-10T08:02:00.000Z", 200),
+            ]
+            .join("\n"),
+        });
+
+        assert_eq!(
+            replay_input_tokens_by_session(fixture.root()),
+            [("self".to_string(), 100), ("self".to_string(), 200)]
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/codex/mod.rs
+++ b/rust/crates/ccusage/src/adapter/codex/mod.rs
@@ -2,6 +2,7 @@ mod aggregate;
 mod loader;
 mod parser;
 mod paths;
+mod replay;
 mod report;
 mod speed;
 mod types;

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -59,7 +59,22 @@ struct CodexExecTimestamps {
     model: String,
 }
 
-pub(super) fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
+/// Tracks how far a forked session's leading events still match the history it
+/// replayed from its parent.
+enum CodexReplayState<'a> {
+    /// Comparing the child's leading usage against the parent's usage prefix.
+    MatchingParent {
+        prefix: &'a [CodexRawUsage],
+        index: usize,
+    },
+    /// The parent stream could not anchor the replay, so skip the leading burst
+    /// that Codex rewrote into a single second.
+    SkippingSecond([u8; 19]),
+    /// Past the replayed history: every remaining event is the child's own usage.
+    Done,
+}
+
+fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
     let Ok(file) = fs::File::open(path) else {
         return None;
     };
@@ -109,6 +124,11 @@ pub(super) fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
     }
 }
 
+/// Visits every usage event in a Codex session log.
+///
+/// `replayed_prefix` carries the usage a forked session copied from its parent so
+/// it is not counted twice: `None` for sessions that are not forks, and an empty
+/// slice for forks whose parent log is unavailable.
 pub(super) fn visit_codex_session_file(
     sessions_dir: &Path,
     path: &Path,
@@ -125,24 +145,47 @@ pub(super) fn visit_codex_session_file(
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
-    let mut replay_index = 0;
-    let mut matching_replay = replayed_prefix.is_some();
+    let mut replay = match replayed_prefix {
+        Some(prefix) => CodexReplayState::MatchingParent { prefix, index: 0 },
+        None => CodexReplayState::Done,
+    };
     let mut visit_filtered = |event: CodexTokenUsageEvent| {
-        if matching_replay {
-            let usage = CodexRawUsage {
-                input_tokens: event.input_tokens,
-                cached_input_tokens: event.cached_input_tokens,
-                output_tokens: event.output_tokens,
-                reasoning_output_tokens: event.reasoning_output_tokens,
-                total_tokens: event.total_tokens,
-            };
-            if replayed_prefix.and_then(|prefix| prefix.get(replay_index)) == Some(&usage) {
-                replay_index += 1;
-                return Ok(());
+        // Each arm either returns or advances the state toward `Done`, so this
+        // loop only re-runs to apply the event to the state it switched to.
+        loop {
+            match replay {
+                CodexReplayState::MatchingParent { prefix, index } => {
+                    let usage = CodexRawUsage {
+                        input_tokens: event.input_tokens,
+                        cached_input_tokens: event.cached_input_tokens,
+                        output_tokens: event.output_tokens,
+                        reasoning_output_tokens: event.reasoning_output_tokens,
+                        total_tokens: event.total_tokens,
+                    };
+                    if prefix.get(index) == Some(&usage) {
+                        replay = CodexReplayState::MatchingParent {
+                            prefix,
+                            index: index + 1,
+                        };
+                        return Ok(());
+                    }
+                    // Nothing matched, so the parent stream cannot anchor this
+                    // replay: the log is unavailable, or Codex rewrote the copied
+                    // history. Fall back to the same-second burst instead.
+                    replay = (index == 0)
+                        .then(|| detect_replay_second(path))
+                        .flatten()
+                        .map_or(CodexReplayState::Done, CodexReplayState::SkippingSecond);
+                }
+                CodexReplayState::SkippingSecond(second) => {
+                    if event.timestamp.as_bytes().get(..19) == Some(second.as_slice()) {
+                        return Ok(());
+                    }
+                    replay = CodexReplayState::Done;
+                }
+                CodexReplayState::Done => return visit(event),
             }
-            matching_replay = false;
         }
-        visit(event)
     };
 
     loop {

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -59,6 +59,56 @@ struct CodexExecTimestamps {
     model: String,
 }
 
+pub(super) fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
+    let Ok(file) = fs::File::open(path) else {
+        return None;
+    };
+    let mut reader = BufReader::new(file);
+    let mut line = Vec::new();
+    let mut first_second: Option<[u8; 19]> = None;
+
+    loop {
+        line.clear();
+        let Ok(bytes_read) = reader.read_until(b'\n', &mut line) else {
+            return None;
+        };
+        if bytes_read == 0 {
+            return None;
+        }
+        let Some(CodexLineKind::Session) = codex_line_usage_kind(&line) else {
+            continue;
+        };
+        let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
+            continue;
+        };
+        let info = value.payload.as_ref().and_then(|payload| {
+            (value.entry_type.as_deref() == Some("event_msg")
+                && payload.payload_type.as_deref() == Some("token_count"))
+            .then_some(payload.info.as_ref())
+            .flatten()
+        });
+        if info
+            .is_none_or(|info| info.last_token_usage.is_none() && info.total_token_usage.is_none())
+        {
+            continue;
+        }
+        let Some(timestamp) = codex_session_timestamp(value.timestamp.as_ref()) else {
+            continue;
+        };
+        let Some(second) = timestamp
+            .as_bytes()
+            .get(..19)
+            .and_then(|second| second.try_into().ok())
+        else {
+            continue;
+        };
+        match first_second {
+            None => first_second = Some(second),
+            Some(first) => return (first == second).then_some(first),
+        }
+    }
+}
+
 pub(super) fn visit_codex_session_file(
     sessions_dir: &Path,
     path: &Path,

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -904,6 +904,14 @@ fn raw_or_normalized_value_timestamp(value: Option<&Value>) -> Option<String> {
     normalize_value_timestamp(Some(value))
 }
 
+/// Reads a Codex timestamp field that can hold an RFC3339 string or an epoch
+/// number, using the same normalization as session events.
+pub(super) fn codex_value_timestamp(value: Option<&Value>) -> Option<TimestampMs> {
+    normalize_value_timestamp(value)
+        .as_deref()
+        .and_then(crate::parse_ts_timestamp)
+}
+
 fn normalize_value_timestamp(value: Option<&Value>) -> Option<String> {
     let value = value?;
     if let Some(text) = value.as_str() {

--- a/rust/crates/ccusage/src/adapter/codex/parser.rs
+++ b/rust/crates/ccusage/src/adapter/codex/parser.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     fs,
-    io::{BufRead, BufReader, Read},
+    io::{BufRead, BufReader},
     path::Path,
     sync::LazyLock,
 };
@@ -32,11 +32,6 @@ static INPUT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""input_tokens":"#));
 static PROMPT_TOKENS_FIELD_FINDER: LazyLock<Finder<'static>> =
     LazyLock::new(|| Finder::new(br#""prompt_tokens":"#));
-static THREAD_SPAWN_FINDER: LazyLock<Finder<'static>> =
-    LazyLock::new(|| Finder::new(b"thread_spawn"));
-static FORKED_FROM_ID_FINDER: LazyLock<Finder<'static>> =
-    LazyLock::new(|| Finder::new(b"forked_from_id"));
-
 const CODEX_AUTO_REVIEW_MODEL: &str = "codex-auto-review";
 const CODEX_AUTO_REVIEW_FALLBACKS_JSON: &str = include_str!("codex-auto-review-fallbacks.json");
 
@@ -64,86 +59,12 @@ struct CodexExecTimestamps {
     model: String,
 }
 
-fn is_codex_replay_session(path: &Path) -> bool {
-    let Ok(mut file) = fs::File::open(path) else {
-        return false;
-    };
-    let mut buf = [0u8; 16 * 1024];
-    let Ok(n) = file.read(&mut buf) else {
-        return false;
-    };
-    THREAD_SPAWN_FINDER.find(&buf[..n]).is_some() || FORKED_FROM_ID_FINDER.find(&buf[..n]).is_some()
-}
-
-fn detect_replay_second(path: &Path) -> Option<[u8; 19]> {
-    let Ok(file) = fs::File::open(path) else {
-        return None;
-    };
-    let mut reader = BufReader::new(file);
-    let mut line = Vec::new();
-    let mut first_second: Option<[u8; 19]> = None;
-
-    loop {
-        line.clear();
-        let Ok(n) = reader.read_until(b'\n', &mut line) else {
-            return None;
-        };
-        if n == 0 {
-            break;
-        }
-        let Some(kind) = codex_line_usage_kind(&line) else {
-            continue;
-        };
-        if !matches!(kind, CodexLineKind::Session) {
-            continue;
-        }
-        let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
-            continue;
-        };
-        if value.entry_type.as_deref() != Some("event_msg") {
-            continue;
-        }
-        let Some(payload) = value.payload.as_ref() else {
-            continue;
-        };
-        if payload.payload_type.as_deref() != Some("token_count") {
-            continue;
-        }
-        let info = payload.info.as_ref();
-        if info.and_then(|i| i.last_token_usage.as_ref()).is_none()
-            && info.and_then(|i| i.total_token_usage.as_ref()).is_none()
-        {
-            continue;
-        }
-        let Some(ts) = codex_session_timestamp(value.timestamp.as_ref()) else {
-            continue;
-        };
-        let ts_bytes = ts.as_bytes();
-        let ts_second: [u8; 19] = ts_bytes.get(0..19).and_then(|s| s.try_into().ok())?;
-        match first_second {
-            None => {
-                first_second = Some(ts_second);
-            }
-            Some(ref first) => {
-                if first == &ts_second {
-                    return Some(ts_second);
-                }
-                return None;
-            }
-        }
-    }
-    None
-}
-
 pub(super) fn visit_codex_session_file(
     sessions_dir: &Path,
     path: &Path,
+    replayed_prefix: Option<&[CodexRawUsage]>,
     mut visit: impl FnMut(CodexTokenUsageEvent) -> Result<()>,
 ) -> Result<()> {
-    let is_replay_session = is_codex_replay_session(path);
-    let replay_second = is_replay_session
-        .then(|| detect_replay_second(path))
-        .flatten();
     let Ok(file) = fs::File::open(path) else {
         return Ok(());
     };
@@ -154,7 +75,25 @@ pub(super) fn visit_codex_session_file(
     let mut current_model: Option<String> = None;
     let mut current_model_is_fallback = false;
     let fallback_timestamp = file_modified_timestamp(path);
-    let mut skip_replay = replay_second.is_some();
+    let mut replay_index = 0;
+    let mut matching_replay = replayed_prefix.is_some();
+    let mut visit_filtered = |event: CodexTokenUsageEvent| {
+        if matching_replay {
+            let usage = CodexRawUsage {
+                input_tokens: event.input_tokens,
+                cached_input_tokens: event.cached_input_tokens,
+                output_tokens: event.output_tokens,
+                reasoning_output_tokens: event.reasoning_output_tokens,
+                total_tokens: event.total_tokens,
+            };
+            if replayed_prefix.and_then(|prefix| prefix.get(replay_index)) == Some(&usage) {
+                replay_index += 1;
+                return Ok(());
+            }
+            matching_replay = false;
+        }
+        visit(event)
+    };
 
     loop {
         line.clear();
@@ -172,42 +111,13 @@ pub(super) fn visit_codex_session_file(
                 let Ok(value) = serde_json::from_slice::<CodexSessionLogEntry<'_>>(&line) else {
                     continue;
                 };
-                if let Some(ref replay_ts) = replay_second
-                    && skip_replay
-                    && value.entry_type.as_deref() == Some("event_msg")
-                    && value
-                        .payload
-                        .as_ref()
-                        .is_some_and(|p| p.payload_type.as_deref() == Some("token_count"))
-                {
-                    let Some(ts) = codex_session_timestamp(value.timestamp.as_ref()) else {
-                        continue;
-                    };
-                    let matches_replay = ts
-                        .as_bytes()
-                        .get(0..19)
-                        .is_some_and(|sec| sec.len() == 19 && sec == replay_ts.as_slice());
-                    if matches_replay {
-                        if let Some(total_usage) = value
-                            .payload
-                            .as_ref()
-                            .and_then(|payload| payload.info.as_ref())
-                            .and_then(|info| info.total_token_usage.as_ref())
-                            .copied()
-                        {
-                            previous_totals.replace(total_usage);
-                        }
-                        continue;
-                    }
-                    skip_replay = false;
-                }
                 visit_codex_session_entry(
                     &session_id,
                     value,
                     &mut previous_totals,
                     &mut current_model,
                     &mut current_model_is_fallback,
-                    &mut visit,
+                    &mut visit_filtered,
                 )?;
             }
             CodexLineKind::Headless => {
@@ -218,7 +128,7 @@ pub(super) fn visit_codex_session_file(
                         &fallback_timestamp,
                         &mut current_model,
                         &mut current_model_is_fallback,
-                        &mut visit,
+                        &mut visit_filtered,
                     )?;
                 } else {
                     add_codex_exec_event_from_value(
@@ -227,7 +137,7 @@ pub(super) fn visit_codex_session_file(
                         &fallback_timestamp,
                         &mut current_model,
                         &mut current_model_is_fallback,
-                        &mut visit,
+                        &mut visit_filtered,
                     )?;
                 };
             }
@@ -267,8 +177,12 @@ fn visit_codex_session_entry(
     }
     let info = payload.info.as_ref();
     let total_usage = info.and_then(|info| info.total_token_usage.as_ref().copied());
+    let cumulative_advanced = total_usage
+        .as_ref()
+        .is_none_or(|total_usage| previous_totals.as_ref() != Some(total_usage));
     let raw_usage = info
         .and_then(|info| info.last_token_usage.as_ref().copied())
+        .filter(|_| cumulative_advanced)
         .or_else(|| {
             total_usage
                 .as_ref()

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::{CodexRawUsage, chunk_file_indexes_by_size};
 
-use super::parser::visit_codex_session_file;
+use super::parser::{detect_replay_second, visit_codex_session_file};
 
 pub(super) struct CodexReplayPlan {
     parent_by_child: HashMap<PathBuf, PathBuf>,
@@ -149,22 +149,10 @@ fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawU
 }
 
 fn replayed_usage_from_first_second(sessions_dir: &Path, path: &Path) -> Vec<CodexRawUsage> {
-    let usage = read_usage_events(sessions_dir, path);
-    let Some(first_second): Option<[u8; 19]> = usage
-        .first()
-        .and_then(|(timestamp, _)| timestamp.as_bytes().get(..19))
-        .and_then(|second| second.try_into().ok())
-    else {
+    let Some(first_second) = detect_replay_second(path) else {
         return Vec::new();
     };
-    if usage
-        .get(1)
-        .and_then(|(timestamp, _)| timestamp.as_bytes().get(..19))
-        != Some(first_second.as_slice())
-    {
-        return Vec::new();
-    }
-    usage
+    read_usage_events(sessions_dir, path)
         .into_iter()
         .take_while(|(timestamp, _)| {
             timestamp.as_bytes().get(..19) == Some(first_second.as_slice())

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::{CodexRawUsage, TimestampMs, chunk_file_indexes_by_size, parse_ts_timestamp};
 
-use super::parser::visit_codex_session_file;
+use super::parser::{codex_value_timestamp, visit_codex_session_file};
 
 pub(super) struct CodexReplayPlan {
     parent_by_child: HashMap<PathBuf, ParentReplay>,
@@ -240,10 +240,7 @@ fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
         .then_some(value.get("payload"))
         .flatten();
     CodexSessionMetadata {
-        timestamp: value
-            .get("timestamp")
-            .and_then(Value::as_str)
-            .and_then(parse_ts_timestamp),
+        timestamp: codex_value_timestamp(value.get("timestamp")),
         session_id: payload
             .and_then(|payload| payload.get("id"))
             .and_then(Value::as_str)

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -1,0 +1,218 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs::File,
+    io::{BufRead, BufReader},
+    path::{Path, PathBuf},
+    thread,
+};
+
+use serde_json::Value;
+
+use crate::{CodexRawUsage, chunk_file_indexes_by_size};
+
+use super::parser::visit_codex_session_file;
+
+pub(super) struct CodexReplayPlan {
+    parent_by_child: HashMap<PathBuf, PathBuf>,
+    usage_by_parent: HashMap<PathBuf, Vec<CodexRawUsage>>,
+}
+
+impl CodexReplayPlan {
+    pub(super) fn new<'a>(
+        groups: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
+        single_thread: bool,
+    ) -> Self {
+        let groups = groups.into_iter().collect::<Vec<_>>();
+        let metadata = groups
+            .iter()
+            .flat_map(|(sessions_dir, files)| {
+                files.iter().map(|path| {
+                    (
+                        path.clone(),
+                        *sessions_dir,
+                        read_codex_session_metadata(path),
+                    )
+                })
+            })
+            .collect::<Vec<_>>();
+        let files_by_session_id = metadata
+            .iter()
+            .filter_map(|(path, _, metadata)| {
+                metadata
+                    .session_id
+                    .as_ref()
+                    .map(|session_id| (session_id.as_str(), path.clone()))
+            })
+            .collect::<HashMap<_, _>>();
+        let mut parent_by_child = metadata
+            .iter()
+            .filter_map(|(child, _, metadata)| {
+                metadata.parent_id.as_deref().and_then(|parent_id| {
+                    files_by_session_id
+                        .get(parent_id)
+                        .map(|parent| (child.clone(), parent.clone()))
+                })
+            })
+            .collect::<HashMap<_, _>>();
+        let parent_paths = parent_by_child.values().cloned().collect::<HashSet<_>>();
+        let parents = metadata
+            .iter()
+            .filter(|(path, _, _)| parent_paths.contains(path))
+            .map(|(path, sessions_dir, _)| (path.clone(), *sessions_dir))
+            .collect::<Vec<_>>();
+        let mut usage_by_parent = read_parent_usage(&parents, single_thread);
+        for (child, sessions_dir, metadata) in &metadata {
+            if metadata.parent_id.is_some() && !parent_by_child.contains_key(child) {
+                let replayed_usage = replayed_usage_from_first_second(sessions_dir, child);
+                if !replayed_usage.is_empty() {
+                    parent_by_child.insert(child.clone(), child.clone());
+                    usage_by_parent.insert(child.clone(), replayed_usage);
+                }
+            }
+        }
+
+        Self {
+            parent_by_child,
+            usage_by_parent,
+        }
+    }
+
+    pub(super) fn parent_usage(&self, child: &Path) -> Option<&[CodexRawUsage]> {
+        self.parent_by_child
+            .get(child)
+            .and_then(|parent| self.usage_by_parent.get(parent))
+            .map(Vec::as_slice)
+    }
+}
+
+fn read_parent_usage(
+    parents: &[(PathBuf, &Path)],
+    single_thread: bool,
+) -> HashMap<PathBuf, Vec<CodexRawUsage>> {
+    if parents.is_empty() {
+        return HashMap::new();
+    }
+    let worker_count = if single_thread {
+        1
+    } else {
+        thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(parents.len())
+    };
+    let paths = parents
+        .iter()
+        .map(|(path, _)| path.clone())
+        .collect::<Vec<_>>();
+    let chunks = chunk_file_indexes_by_size(&paths, worker_count);
+    thread::scope(|scope| {
+        chunks
+            .into_iter()
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .into_iter()
+                        .map(|index| {
+                            let (path, sessions_dir) = &parents[index];
+                            let usage = read_usage_events(sessions_dir, path)
+                                .into_iter()
+                                .map(|(_, usage)| usage)
+                                .collect();
+                            (path.clone(), usage)
+                        })
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(|handle| handle.join().expect("codex replay worker panicked"))
+            .collect()
+    })
+}
+
+fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawUsage)> {
+    let mut usage = Vec::new();
+    let _ = visit_codex_session_file(sessions_dir, path, None, |event| {
+        usage.push((
+            event.timestamp,
+            CodexRawUsage {
+                input_tokens: event.input_tokens,
+                cached_input_tokens: event.cached_input_tokens,
+                output_tokens: event.output_tokens,
+                reasoning_output_tokens: event.reasoning_output_tokens,
+                total_tokens: event.total_tokens,
+            },
+        ));
+        Ok(())
+    });
+    usage
+}
+
+fn replayed_usage_from_first_second(sessions_dir: &Path, path: &Path) -> Vec<CodexRawUsage> {
+    let usage = read_usage_events(sessions_dir, path);
+    let Some(first_second): Option<[u8; 19]> = usage
+        .first()
+        .and_then(|(timestamp, _)| timestamp.as_bytes().get(..19))
+        .and_then(|second| second.try_into().ok())
+    else {
+        return Vec::new();
+    };
+    if usage
+        .get(1)
+        .and_then(|(timestamp, _)| timestamp.as_bytes().get(..19))
+        != Some(first_second.as_slice())
+    {
+        return Vec::new();
+    }
+    usage
+        .into_iter()
+        .take_while(|(timestamp, _)| {
+            timestamp.as_bytes().get(..19) == Some(first_second.as_slice())
+        })
+        .map(|(_, usage)| usage)
+        .collect()
+}
+
+#[derive(Default)]
+struct CodexSessionMetadata {
+    session_id: Option<String>,
+    parent_id: Option<String>,
+}
+
+fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
+    let Ok(file) = File::open(path) else {
+        return CodexSessionMetadata::default();
+    };
+    let mut reader = BufReader::new(file);
+    let mut line = String::new();
+    let Ok(bytes_read) = reader.read_line(&mut line) else {
+        return CodexSessionMetadata::default();
+    };
+    if bytes_read == 0 {
+        return CodexSessionMetadata::default();
+    }
+    let Ok(value) = serde_json::from_str::<Value>(&line) else {
+        return CodexSessionMetadata::default();
+    };
+    let payload = (value.get("type").and_then(Value::as_str) == Some("session_meta"))
+        .then_some(value.get("payload"))
+        .flatten();
+    CodexSessionMetadata {
+        session_id: payload
+            .and_then(|payload| payload.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_string),
+        parent_id: payload
+            .and_then(|payload| payload.get("forked_from_id"))
+            .and_then(Value::as_str)
+            .or_else(|| {
+                payload
+                    .and_then(|payload| {
+                        payload.pointer("/source/subagent/thread_spawn/parent_thread_id")
+                    })
+                    .and_then(Value::as_str)
+            })
+            .filter(|parent_id| !parent_id.is_empty())
+            .map(str::to_string),
+    }
+}

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -8,13 +8,23 @@ use std::{
 
 use serde_json::Value;
 
-use crate::{CodexRawUsage, chunk_file_indexes_by_size};
+use crate::{CodexRawUsage, TimestampMs, chunk_file_indexes_by_size, parse_ts_timestamp};
 
 use super::parser::{detect_replay_second, visit_codex_session_file};
 
 pub(super) struct CodexReplayPlan {
-    parent_by_child: HashMap<PathBuf, PathBuf>,
-    usage_by_parent: HashMap<PathBuf, Vec<CodexRawUsage>>,
+    parent_by_child: HashMap<PathBuf, ParentReplay>,
+    usage_by_parent: HashMap<PathBuf, ParentUsage>,
+}
+
+struct ParentReplay {
+    path: PathBuf,
+    forked_at: Option<TimestampMs>,
+}
+
+struct ParentUsage {
+    timestamps: Vec<Option<TimestampMs>>,
+    usage: Vec<CodexRawUsage>,
 }
 
 impl CodexReplayPlan {
@@ -48,13 +58,22 @@ impl CodexReplayPlan {
             .iter()
             .filter_map(|(child, _, metadata)| {
                 metadata.parent_id.as_deref().and_then(|parent_id| {
-                    files_by_session_id
-                        .get(parent_id)
-                        .map(|parent| (child.clone(), parent.clone()))
+                    files_by_session_id.get(parent_id).map(|parent| {
+                        (
+                            child.clone(),
+                            ParentReplay {
+                                path: parent.clone(),
+                                forked_at: metadata.timestamp,
+                            },
+                        )
+                    })
                 })
             })
             .collect::<HashMap<_, _>>();
-        let parent_paths = parent_by_child.values().cloned().collect::<HashSet<_>>();
+        let parent_paths = parent_by_child
+            .values()
+            .map(|parent| parent.path.clone())
+            .collect::<HashSet<_>>();
         let parents = metadata
             .iter()
             .filter(|(path, _, _)| parent_paths.contains(path))
@@ -65,8 +84,20 @@ impl CodexReplayPlan {
             if metadata.parent_id.is_some() && !parent_by_child.contains_key(child) {
                 let replayed_usage = replayed_usage_from_first_second(sessions_dir, child);
                 if !replayed_usage.is_empty() {
-                    parent_by_child.insert(child.clone(), child.clone());
-                    usage_by_parent.insert(child.clone(), replayed_usage);
+                    parent_by_child.insert(
+                        child.clone(),
+                        ParentReplay {
+                            path: child.clone(),
+                            forked_at: None,
+                        },
+                    );
+                    usage_by_parent.insert(
+                        child.clone(),
+                        ParentUsage {
+                            timestamps: vec![None; replayed_usage.len()],
+                            usage: replayed_usage,
+                        },
+                    );
                 }
             }
         }
@@ -78,17 +109,23 @@ impl CodexReplayPlan {
     }
 
     pub(super) fn parent_usage(&self, child: &Path) -> Option<&[CodexRawUsage]> {
-        self.parent_by_child
-            .get(child)
-            .and_then(|parent| self.usage_by_parent.get(parent))
-            .map(Vec::as_slice)
+        let parent = self.parent_by_child.get(child)?;
+        let stream = self.usage_by_parent.get(&parent.path)?;
+        let replay_len = parent.forked_at.map_or(stream.usage.len(), |forked_at| {
+            stream
+                .timestamps
+                .iter()
+                .position(|timestamp| timestamp.is_some_and(|timestamp| timestamp > forked_at))
+                .unwrap_or(stream.usage.len())
+        });
+        Some(&stream.usage[..replay_len])
     }
 }
 
 fn read_parent_usage(
     parents: &[(PathBuf, &Path)],
     single_thread: bool,
-) -> HashMap<PathBuf, Vec<CodexRawUsage>> {
+) -> HashMap<PathBuf, ParentUsage> {
     if parents.is_empty() {
         return HashMap::new();
     }
@@ -114,11 +151,11 @@ fn read_parent_usage(
                         .into_iter()
                         .map(|index| {
                             let (path, sessions_dir) = &parents[index];
-                            let usage = read_usage_events(sessions_dir, path)
+                            let (timestamps, usage) = read_usage_events(sessions_dir, path)
                                 .into_iter()
-                                .map(|(_, usage)| usage)
-                                .collect();
-                            (path.clone(), usage)
+                                .map(|(timestamp, usage)| (parse_ts_timestamp(&timestamp), usage))
+                                .unzip();
+                            (path.clone(), ParentUsage { timestamps, usage })
                         })
                         .collect::<Vec<_>>()
                 })
@@ -165,6 +202,7 @@ fn replayed_usage_from_first_second(sessions_dir: &Path, path: &Path) -> Vec<Cod
 struct CodexSessionMetadata {
     session_id: Option<String>,
     parent_id: Option<String>,
+    timestamp: Option<TimestampMs>,
 }
 
 fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
@@ -186,6 +224,10 @@ fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
         .then_some(value.get("payload"))
         .flatten();
     CodexSessionMetadata {
+        timestamp: value
+            .get("timestamp")
+            .and_then(Value::as_str)
+            .and_then(parse_ts_timestamp),
         session_id: payload
             .and_then(|payload| payload.get("id"))
             .and_then(Value::as_str)

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -10,7 +10,7 @@ use serde_json::Value;
 
 use crate::{CodexRawUsage, TimestampMs, chunk_file_indexes_by_size, parse_ts_timestamp};
 
-use super::parser::{detect_replay_second, visit_codex_session_file};
+use super::parser::visit_codex_session_file;
 
 pub(super) struct CodexReplayPlan {
     parent_by_child: HashMap<PathBuf, ParentReplay>,
@@ -18,7 +18,8 @@ pub(super) struct CodexReplayPlan {
 }
 
 struct ParentReplay {
-    path: PathBuf,
+    /// `None` when the referenced parent log is not part of the scanned files.
+    path: Option<PathBuf>,
     forked_at: Option<TimestampMs>,
 }
 
@@ -32,85 +33,73 @@ impl CodexReplayPlan {
         groups: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
         single_thread: bool,
     ) -> Self {
-        let groups = groups.into_iter().collect::<Vec<_>>();
-        let metadata = groups
-            .iter()
+        let files = groups
+            .into_iter()
             .flat_map(|(sessions_dir, files)| {
-                files.iter().map(|path| {
-                    (
-                        path.clone(),
-                        *sessions_dir,
-                        read_codex_session_metadata(path),
-                    )
-                })
+                files.iter().map(move |path| (path.clone(), sessions_dir))
             })
             .collect::<Vec<_>>();
-        let files_by_session_id = metadata
+        let metadata = read_session_metadata(&files, single_thread);
+        // The same session can be reachable from more than one source directory,
+        // so keep the first file and stay independent of source ordering.
+        let mut files_by_session_id = HashMap::new();
+        for ((path, _), metadata) in files.iter().zip(&metadata) {
+            if let Some(session_id) = metadata.session_id.as_deref() {
+                files_by_session_id.entry(session_id).or_insert(path);
+            }
+        }
+        let parent_by_child = files
             .iter()
-            .filter_map(|(path, _, metadata)| {
-                metadata
-                    .session_id
-                    .as_ref()
-                    .map(|session_id| (session_id.as_str(), path.clone()))
-            })
-            .collect::<HashMap<_, _>>();
-        let mut parent_by_child = metadata
-            .iter()
-            .filter_map(|(child, _, metadata)| {
-                metadata.parent_id.as_deref().and_then(|parent_id| {
-                    files_by_session_id.get(parent_id).map(|parent| {
-                        (
-                            child.clone(),
-                            ParentReplay {
-                                path: parent.clone(),
-                                forked_at: metadata.timestamp,
-                            },
-                        )
-                    })
-                })
+            .zip(&metadata)
+            .filter_map(|((child, _), metadata)| {
+                let parent_id = metadata.parent_id.as_deref()?;
+                let path = files_by_session_id
+                    .get(parent_id)
+                    // A session listing itself as its own parent would match its
+                    // whole stream and drop every event it recorded.
+                    .filter(|parent| **parent != child)
+                    .map(|parent| (*parent).clone());
+                Some((
+                    child.clone(),
+                    ParentReplay {
+                        path,
+                        forked_at: metadata.timestamp,
+                    },
+                ))
             })
             .collect::<HashMap<_, _>>();
         let parent_paths = parent_by_child
             .values()
-            .map(|parent| parent.path.clone())
+            .filter_map(|parent| parent.path.clone())
             .collect::<HashSet<_>>();
-        let parents = metadata
+        let parents = files
             .iter()
-            .filter(|(path, _, _)| parent_paths.contains(path))
-            .map(|(path, sessions_dir, _)| (path.clone(), *sessions_dir))
+            .filter(|(path, _)| parent_paths.contains(path))
+            .cloned()
             .collect::<Vec<_>>();
-        let mut usage_by_parent = read_parent_usage(&parents, single_thread);
-        for (child, sessions_dir, metadata) in &metadata {
-            if metadata.parent_id.is_some() && !parent_by_child.contains_key(child) {
-                let replayed_usage = replayed_usage_from_first_second(sessions_dir, child);
-                if !replayed_usage.is_empty() {
-                    parent_by_child.insert(
-                        child.clone(),
-                        ParentReplay {
-                            path: child.clone(),
-                            forked_at: None,
-                        },
-                    );
-                    usage_by_parent.insert(
-                        child.clone(),
-                        ParentUsage {
-                            timestamps: vec![None; replayed_usage.len()],
-                            usage: replayed_usage,
-                        },
-                    );
-                }
-            }
-        }
 
         Self {
             parent_by_child,
-            usage_by_parent,
+            usage_by_parent: read_parent_usage(&parents, single_thread),
         }
     }
 
-    pub(super) fn parent_usage(&self, child: &Path) -> Option<&[CodexRawUsage]> {
+    /// Usage history that `child` replayed from the session it forked from.
+    ///
+    /// Returns `None` for sessions that are not forks. Forked sessions whose
+    /// parent log is unavailable return an empty slice, which tells the parser
+    /// to fall back to the rewritten-second heuristic.
+    pub(super) fn replay_prefix(&self, child: &Path) -> Option<&[CodexRawUsage]> {
         let parent = self.parent_by_child.get(child)?;
-        let stream = self.usage_by_parent.get(&parent.path)?;
+        let Some(stream) = parent
+            .path
+            .as_ref()
+            .and_then(|path| self.usage_by_parent.get(path))
+        else {
+            return Some(&[]);
+        };
+        // Usage the parent recorded after the fork was never replayed, so it must
+        // not mask the child's own events.
         let replay_len = parent.forked_at.map_or(stream.usage.len(), |forked_at| {
             stream
                 .timestamps
@@ -122,6 +111,53 @@ impl CodexReplayPlan {
     }
 }
 
+fn replay_worker_count(files: usize, single_thread: bool) -> usize {
+    if single_thread || files <= 1 {
+        return 1;
+    }
+    thread::available_parallelism()
+        .map(usize::from)
+        .unwrap_or(1)
+        .min(files)
+}
+
+fn read_session_metadata(
+    files: &[(PathBuf, &Path)],
+    single_thread: bool,
+) -> Vec<CodexSessionMetadata> {
+    let worker_count = replay_worker_count(files.len(), single_thread);
+    if worker_count <= 1 {
+        return files
+            .iter()
+            .map(|(path, _)| read_codex_session_metadata(path))
+            .collect();
+    }
+    // Every file costs one open plus one line, so split by count instead of by
+    // size, and keep chunks in order so duplicate session ids resolve the same
+    // way as the single-threaded pass.
+    let chunk_size = files.len().div_ceil(worker_count);
+    thread::scope(|scope| {
+        files
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(|| {
+                    chunk
+                        .iter()
+                        .map(|(path, _)| read_codex_session_metadata(path))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>()
+            .into_iter()
+            .flat_map(|handle| {
+                handle
+                    .join()
+                    .expect("codex replay metadata worker panicked")
+            })
+            .collect()
+    })
+}
+
 fn read_parent_usage(
     parents: &[(PathBuf, &Path)],
     single_thread: bool,
@@ -129,14 +165,7 @@ fn read_parent_usage(
     if parents.is_empty() {
         return HashMap::new();
     }
-    let worker_count = if single_thread {
-        1
-    } else {
-        thread::available_parallelism()
-            .map(usize::from)
-            .unwrap_or(1)
-            .min(parents.len())
-    };
+    let worker_count = replay_worker_count(parents.len(), single_thread);
     let paths = parents
         .iter()
         .map(|(path, _)| path.clone())
@@ -185,19 +214,6 @@ fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawU
     usage
 }
 
-fn replayed_usage_from_first_second(sessions_dir: &Path, path: &Path) -> Vec<CodexRawUsage> {
-    let Some(first_second) = detect_replay_second(path) else {
-        return Vec::new();
-    };
-    read_usage_events(sessions_dir, path)
-        .into_iter()
-        .take_while(|(timestamp, _)| {
-            timestamp.as_bytes().get(..19) == Some(first_second.as_slice())
-        })
-        .map(|(_, usage)| usage)
-        .collect()
-}
-
 #[derive(Default)]
 struct CodexSessionMetadata {
     session_id: Option<String>,
@@ -226,18 +242,8 @@ fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
     CodexSessionMetadata {
         timestamp: value
             .get("timestamp")
-            .and_then(|timestamp| match timestamp {
-                Value::String(timestamp) => parse_ts_timestamp(timestamp),
-                Value::Number(timestamp) => timestamp.as_u64().and_then(|raw| {
-                    let millis = if raw > 10_000_000_000 {
-                        raw
-                    } else {
-                        raw.checked_mul(1_000)?
-                    };
-                    Some(TimestampMs::from_millis(millis.min(i64::MAX as u64) as i64))
-                }),
-                _ => None,
-            }),
+            .and_then(Value::as_str)
+            .and_then(parse_ts_timestamp),
         session_id: payload
             .and_then(|payload| payload.get("id"))
             .and_then(Value::as_str)

--- a/rust/crates/ccusage/src/adapter/codex/replay.rs
+++ b/rust/crates/ccusage/src/adapter/codex/replay.rs
@@ -226,8 +226,18 @@ fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
     CodexSessionMetadata {
         timestamp: value
             .get("timestamp")
-            .and_then(Value::as_str)
-            .and_then(parse_ts_timestamp),
+            .and_then(|timestamp| match timestamp {
+                Value::String(timestamp) => parse_ts_timestamp(timestamp),
+                Value::Number(timestamp) => timestamp.as_u64().and_then(|raw| {
+                    let millis = if raw > 10_000_000_000 {
+                        raw
+                    } else {
+                        raw.checked_mul(1_000)?
+                    };
+                    Some(TimestampMs::from_millis(millis.min(i64::MAX as u64) as i64))
+                }),
+                _ => None,
+            }),
         session_id: payload
             .and_then(|payload| payload.get("id"))
             .and_then(Value::as_str)


### PR DESCRIPTION
Codex fork and subagent logs replay parent `token_count` history with rewritten timestamps. The existing same-second heuristic misses replay bursts spanning multiple seconds and nested forks, causing the copied history to be aggregated again. Codex can also re-emit `last_token_usage` snapshots without advancing `total_token_usage`.

Match forked session event prefixes against immutable parent streams before aggregation. This handles replay bursts spanning multiple seconds and nested parents without mutating ancestry needed by children. When the referenced parent log is unavailable, retain the existing same-second fallback.

Skip last-token snapshots when cumulative totals do not advance, preserving session-aware and alias-aware report deduplication.

Addresses #950, #988, #1288, #1337, and #1349.

@ryoppippi this fixes #1434

I dogfooded this locally on a frozen 16 GB Codex history. The corrected report matched the sampled root-session totals in Codex’s `state_5.sqlite`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1435"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786465095&installation_id=139163553&pr_number=1435&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1435&signature=e82071299e4e1be075f1c095d9bbaa2ed681ff1d59ee469aec223d1f2a663174"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deduplicates replayed Codex usage by matching each fork’s leading events to its immutable parent stream, bounded at the fork (RFC3339 or epoch). Falls back to same‑second detection when the parent can’t anchor the replay and skips non‑advancing snapshots so session/alias reports stay correct.

- **Bug Fixes**
  - Per‑session replay plan; drop only the replayed prefix; bound at RFC3339/epoch; skip self‑parent sessions; keep real post‑fork child events even if equal; works single‑threaded and in parallel.
  - Parser does two‑phase replay filtering: try parent‑prefix match, then same‑second fallback if the first event doesn’t match; detect the fallback second from raw token‑count records before cumulative suppression to handle missing parents, multi‑second, mid‑stream, and nested replays.
  - Ignore `last_token_usage` when cumulative totals don’t advance. Fixes #1434; addresses #950, #988, #1288, #1337, #1349.

- **Refactors**
  - Group aggregation inputs into `CodexAggregateRun`; read session metadata on all workers; resolve duplicate session IDs to the first file; normalize numeric fork timestamps via shared event timestamp parsing.
  - Tests: reuse shared replay fixture builders.

<sup>Written for commit 8b4078c9dee99cd8449e785dfe1b6709549bc853. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1435?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex usage reporting by generating and applying per-session “parent usage” context via a replay plan during session parsing (consistent for sequential and parallel runs).
  * Reworked replay detection to use prefix-based filtering with timestamp/second alignment, avoiding incorrect replay skipping and duplicate token usage.
  * Refined event usage selection (favoring totals when available, otherwise using last-token usage).

* **Tests**
  * Expanded coverage for replay skipping correctness, missing-parent handling, nested replays, and fork/next-event preservation, including `skips_forked_parent_prefix_rewritten_across_seconds`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->