### PR TITLE
feat: add Grok Build CLI usage adapter

### DIFF
--- a/.agents/skills/agent-sources/SKILL.md
+++ b/.agents/skills/agent-sources/SKILL.md
@@ -44,6 +44,7 @@ flags:
 - OpenCode: `rust/crates/ccusage/src/adapter/opencode/README.md`
 - Amp: `rust/crates/ccusage/src/adapter/amp/README.md`
 - pi-agent: `rust/crates/ccusage/src/adapter/pi/README.md`
+- Grok Build CLI: `rust/crates/ccusage/src/adapter/grok/README.md`
 
 ## Implementation Notes
 

--- a/LOCAL_PRICING_PATCH.md
+++ b/LOCAL_PRICING_PATCH.md
@@ -5,13 +5,31 @@ pricing. It is used by the normal `ccusage` command on this machine.
 
 ## Normal Command Path
 
-The shell command resolves through the user wrapper:
+The shell command resolves through the user wrapper to a **stable** binary
+outside the git worktree (so branch switches cannot remove Grok support):
+
+```sh
+/Users/rk/bin/ccusage
+-> /Users/rk/bin/tools/claude-code-tools/ccusage   # wrapper (--mode calculate)
+-> ~/.local/lib/ccusage/ccusage                  # copied release binary
+```
+
+Legacy shims also point at the same wrapper:
 
 ```sh
 /Users/rk/bin/.links/ccusage
--> /Users/rk/bin/claude-code-tools/ccusage
--> /Volumes/Projects/ccusage-custom-fixes/rust/target/release/ccusage
+/Users/rk/bin/claude-code-tools/ccusage
 ```
+
+Reinstall / refresh after building a Grok-capable release:
+
+```sh
+~/bin/tools/claude-code-tools/install-ccusage-local
+# or force rebuild from CCUSAGE_REPO (default: this checkout):
+~/bin/tools/claude-code-tools/install-ccusage-local --rebuild
+```
+
+Override binary for one-off tests: `CCUSAGE_BIN=/path/to/ccusage ccusage ...`.
 
 The wrapper runs the local binary with `--mode calculate` unless an explicit
 `--mode` or `-m` argument is supplied. That means normal commands use calculated
@@ -63,11 +81,11 @@ Current locally added deterministic rates:
 `xai/grok-code-fast` until a public list price is published.
 
 The Grok Build CLI adapter lives at `rust/crates/ccusage/src/adapter/grok/`.
-After pricing or adapter changes, rebuild the release binary used by the local
-wrapper:
+After pricing or adapter changes, rebuild and reinstall the stable binary:
 
 ```sh
 cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release
+~/bin/tools/claude-code-tools/install-ccusage-local
 ```
 
 ## Adapter Behavior
@@ -119,10 +137,11 @@ If a provider changes its public rates:
    cargo +stable test --manifest-path rust/Cargo.toml --locked -p ccusage
    ```
 
-3. Rebuild the local binary:
+3. Rebuild and reinstall the stable binary:
 
    ```sh
    cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release
+   ~/bin/tools/claude-code-tools/install-ccusage-local
    ```
 
 4. Verify the normal command still points at the local binary:
@@ -137,10 +156,11 @@ If a provider changes its public rates:
    ```sh
    ccusage pi daily --since 2026-07-07 --until 2026-07-07 --breakdown --json
    ccusage opencode daily --since 2026-07-07 --until 2026-07-07 --breakdown --json
+   ccusage grok daily --since 2026-07-13 --until 2026-07-14
    ```
 
-The wrapper points directly at `rust/target/release/ccusage`, so rebuilding that
-binary is enough for normal `ccusage` commands to use the new rates.
+The wrapper points at `~/.local/lib/ccusage/ccusage`. Rebuild +
+`install-ccusage-local` is required for normal `ccusage` to pick up new rates.
 
 ## Validation Evidence From This Patch
 

--- a/LOCAL_PRICING_PATCH.md
+++ b/LOCAL_PRICING_PATCH.md
@@ -1,0 +1,175 @@
+# Local Pricing Patch
+
+This checkout contains a local ccusage source patch for estimated token-list
+pricing. It is used by the normal `ccusage` command on this machine.
+
+## Normal Command Path
+
+The shell command resolves through the user wrapper:
+
+```sh
+/Users/rk/bin/.links/ccusage
+-> /Users/rk/bin/claude-code-tools/ccusage
+-> /Volumes/Projects/ccusage-custom-fixes/rust/target/release/ccusage
+```
+
+The wrapper runs the local binary with `--mode calculate` unless an explicit
+`--mode` or `-m` argument is supplied. That means normal commands use calculated
+token-list estimates:
+
+```sh
+ccusage pi daily --since 2026-07-07 --until 2026-07-07 --breakdown
+ccusage opencode daily --since 2026-07-07 --until 2026-07-07 --breakdown
+```
+
+To view recorded/display costs instead:
+
+```sh
+ccusage --mode display pi daily --since 2026-07-07 --until 2026-07-07 --breakdown
+```
+
+The previous wrapper was backed up at:
+
+```sh
+/Users/rk/bin/claude-code-tools/ccusage.bak-20260708-192005
+```
+
+## Embedded Fixed Prices
+
+The fixed prices are embedded in:
+
+```sh
+rust/crates/ccusage/src/pricing.rs
+```
+
+The rates are stored per token. For example, `$1.40/M` is represented as
+`1.4e-6`.
+
+Current locally added deterministic rates:
+
+| Model keys | Input | Cached input | Output |
+| --- | ---: | ---: | ---: |
+| `glm-5.2`, `zai/glm-5.2` | $1.40/M | $0.26/M | $4.40/M |
+| `deepseek-v4-flash`, `deepseek/deepseek-v4-flash` | $0.14/M | $0.0028/M | $0.28/M |
+| `deepseek-v4-pro`, `deepseek/deepseek-v4-pro` | $0.435/M | $0.003625/M | $0.87/M |
+| `grok-build-0.1` | $1.00/M | $0.20/M | $2.00/M |
+| `grok-4.3` | $1.25/M | $0.20/M | $2.50/M |
+| `grok-4.5`, `xai/grok-4.5`, `x-ai/grok-4.5` | $2.00/M | $0.50/M | $6.00/M |
+| `grok-composer-2.5-fast` (+ `xai/` / `x-ai/` keys) | $0.20/M | $0.02/M | $1.50/M |
+| `MiniMax-M2.5`, `minimax-m2.5`, `minimax/minimax-m2.5` | $0.30/M | $0.03/M | $1.20/M |
+
+`grok-4.5` rates match OpenRouter/LiteLLM list prices for `x-ai/grok-4.5`
+(2026-07-13). `grok-composer-2.5-fast` is provisional, aligned with
+`xai/grok-code-fast` until a public list price is published.
+
+The Grok Build CLI adapter lives at `rust/crates/ccusage/src/adapter/grok/`.
+After pricing or adapter changes, rebuild the release binary used by the local
+wrapper:
+
+```sh
+cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release
+```
+
+## Adapter Behavior
+
+Pi reports keep the displayed model label, such as `[pi] glm-5.2`, but pricing
+also tries the raw underlying model key, such as `glm-5.2`.
+
+Grok reports keep the displayed model label, such as `[grok] grok-4.5`, but
+pricing also tries the raw model id and `xai/<model>` / `x-ai/<model>` keys.
+Reasoning tokens are billed at the output rate while the displayed output column
+stays as raw output tokens.
+
+OpenCode pricing tries both raw model keys and provider-qualified keys, such as:
+
+```text
+deepseek-v4-pro
+deepseek/deepseek-v4-pro
+```
+
+Config override precedence for candidate pricing is:
+
+1. Exact displayed override key.
+2. Exact raw/provider override key.
+3. Built-in fixed-price entry or alias.
+4. Existing models.dev/LiteLLM fallback.
+5. Missing-pricing warning.
+
+## Intentionally Warning-Only
+
+These remain unpriced unless logs expose the deterministic underlying model:
+
+- `openrouter/auto`
+- `openrouter/fusion*`
+- `fusion-*`
+- `ark-code-latest`
+- `antigravity-gemini-3-flash`
+
+Qwen models were also left out of this local pass until ccusage has an explicit
+non-USD or currency-conversion policy.
+
+## Updating Prices Later
+
+If a provider changes its public rates:
+
+1. Edit the relevant entries in `rust/crates/ccusage/src/pricing.rs`.
+2. Run focused tests:
+
+   ```sh
+   cargo +stable test --manifest-path rust/Cargo.toml --locked -p ccusage
+   ```
+
+3. Rebuild the local binary:
+
+   ```sh
+   cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release
+   ```
+
+4. Verify the normal command still points at the local binary:
+
+   ```sh
+   which ccusage
+   ccusage --version
+   ```
+
+5. Smoke test pricing:
+
+   ```sh
+   ccusage pi daily --since 2026-07-07 --until 2026-07-07 --breakdown --json
+   ccusage opencode daily --since 2026-07-07 --until 2026-07-07 --breakdown --json
+   ```
+
+The wrapper points directly at `rust/target/release/ccusage`, so rebuilding that
+binary is enough for normal `ccusage` commands to use the new rates.
+
+## Validation Evidence From This Patch
+
+Known successful checks:
+
+```sh
+cargo +stable fmt --manifest-path rust/Cargo.toml --all
+cargo +stable test --manifest-path rust/Cargo.toml --locked -p ccusage
+cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release
+git diff --check
+```
+
+Known smoke-test results for July 7, 2026:
+
+- `ccusage pi daily --since 2026-07-07 --until 2026-07-07 --breakdown --json`
+  reports `totalCost: 5.322367962`.
+- `ccusage --mode display pi daily --since 2026-07-07 --until 2026-07-07 --breakdown --json`
+  reports `totalCost: 3.492302999999999`.
+- `ccusage opencode daily --since 2026-07-07 --until 2026-07-07 --breakdown --json`
+  reports `totalCost: 1.1722099999999998`.
+
+`just check` depends on `nix flake check`. It was blocked until the local
+`nix-daemon` was restarted. If `direnv` reports a daemon socket refusal, restart
+the daemon and reload:
+
+```sh
+sudo launchctl kickstart -k system/org.nixos.nix-daemon
+direnv reload
+```
+
+Repeated hook-install warnings during `direnv reload` are from this machine's
+global `core.hooksPath` setting. They do not affect normal `ccusage` usage.

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -60,6 +60,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | pi-agent           | `ccusage pi daily`       |
 | Goose              | `ccusage goose daily`    |
 | OpenClaw           | `ccusage openclaw daily` |
+| Grok Build CLI     | `ccusage grok daily`     |
 | Kilo               | `ccusage kilo daily`     |
 | Kimi               | `ccusage kimi daily`     |
 | Qwen               | `ccusage qwen daily`     |
@@ -114,6 +115,7 @@ bunx ccusage codebuff daily
 bunx ccusage hermes daily
 bunx ccusage goose daily
 bunx ccusage openclaw daily
+bunx ccusage grok daily
 bunx ccusage kilo daily
 bunx ccusage kimi daily
 bunx ccusage qwen daily

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Grok Build CLI', link: '/guide/grok/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -49,6 +49,7 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | pi-agent     | `pi`       | `ccusage pi monthly`      |
 | Goose        | `goose`    | `ccusage goose daily`     |
 | OpenClaw     | `openclaw` | `ccusage openclaw daily`  |
+| Grok Build   | `grok`     | `ccusage grok daily`      |
 | Kilo         | `kilo`     | `ccusage kilo daily`      |
 | Kimi         | `kimi`     | `ccusage kimi daily`      |
 | Qwen         | `qwen`     | `ccusage qwen daily`      |
@@ -68,6 +69,7 @@ ccusage droid session
 ccusage codebuff daily
 ccusage pi session --pi-path /path/to/sessions
 ccusage openclaw daily --open-claw-path /path/to/openclaw
+ccusage grok daily --grok-path /path/to/.grok
 ccusage kilo session
 ccusage qwen daily
 ccusage copilot daily --json

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -391,7 +391,7 @@ ccusage blocks --config /path/to/team-config.json
 
 ## Pricing Overrides
 
-ccusage looks up token costs from a LiteLLM pricing snapshot embedded in the binary, optionally refreshed at runtime (or skipped with `--offline`). When a model is missing from LiteLLM (private deployments, internal wrappers like Pi's `[pi] gpt-5.4`, custom proxies), or when the snapshot price differs from your contract, set `pricingOverrides` under `defaults` to supply per-model values.
+ccusage looks up token costs from a LiteLLM pricing snapshot embedded in the binary, optionally refreshed at runtime (or skipped with `--offline`). Calculated costs are estimates from public USD token-list rates, not invoice-real costs. When a model is missing from LiteLLM (private deployments, internal wrappers like Pi's `[pi] gpt-5.4`, custom proxies), or when the snapshot price differs from your contract, set `pricingOverrides` under `defaults` to supply per-model values.
 
 ```json
 {
@@ -415,12 +415,16 @@ ccusage looks up token costs from a LiteLLM pricing snapshot embedded in the bin
 
 ### Raw Model Names
 
-Keys in `pricingOverrides` must match the **raw model name** as recorded in the source logs, including any adapter prefix:
+Keys in `pricingOverrides` must match a pricing candidate derived from the source log:
 
 | Adapter                                | Prefix  | Example key                    |
 | -------------------------------------- | ------- | ------------------------------ |
-| Pi                                     | `[pi] ` | `[pi] gpt-5.4`                 |
+| Pi                                     | `[pi] ` | `[pi] gpt-5.4` or `gpt-5.4`    |
 | Others (Claude, Codex, OpenCode, etc.) | none    | `claude-sonnet-4-5`, `gpt-5.5` |
+
+For Pi, an exact displayed key such as `[pi] gpt-5.4` wins over the raw key.
+Use the raw key when the same underlying model should share one override across
+Pi and non-Pi sources.
 
 To find the exact name, run `ccusage <agent> daily --json` and look at the `model` field in the per-row breakdown.
 

--- a/docs/guide/cost-modes.md
+++ b/docs/guide/cost-modes.md
@@ -180,6 +180,11 @@ When calculating costs from tokens, ccusage uses:
 - **Automatic updates** - Pricing refreshed regularly
 - **Multiple models** - Supports Claude Opus 4.1, Sonnet 4.5, and other models
 
+Token-based costs are estimates from public USD token-list rates. They are not
+invoice-real costs and do not include subscription amortization, negotiated
+discounts, credits, taxes, or dynamic router decisions unless the source log
+records a deterministic underlying model or pre-calculated cost.
+
 #### Token Types
 
 ```typescript

--- a/docs/guide/grok/index.md
+++ b/docs/guide/grok/index.md
@@ -1,0 +1,174 @@
+# Grok Build CLI Data Source
+
+ccusage can read Grok Build CLI session usage as one of its supported local data sources. Grok writes per-turn token accounting on `turn_completed` events in session `updates.jsonl` files under `~/.grok/sessions`.
+
+## What is Grok Build CLI?
+
+Grok Build is xAI's coding agent CLI. Sessions live under `~/.grok` and record usage on each completed turn, including input, output, cache-read, and reasoning tokens per model.
+
+## Focused Views
+
+```bash
+# Recommended
+bunx ccusage grok --help
+
+# Alternative package runners
+npx ccusage@latest grok --help
+pnpm dlx ccusage grok --help
+pnpx ccusage grok --help
+```
+
+## Data Source
+
+The CLI scans these directories for Grok session files:
+
+| Source | Default paths | Override |
+| ------ | ------------- | -------- |
+| Grok Build CLI | `~/.grok/sessions/**/updates.jsonl` | `GROK_HOME` or `--grok-path` |
+
+ccusage walks each Grok home root for `sessions/**/updates.jsonl` and optionally reads a sibling `summary.json` for project path metadata (`info.cwd` / `git_root_dir`).
+
+Both `GROK_HOME` and `--grok-path` can be one root directory or a comma-separated list of root directories.
+
+## Report Views
+
+```bash
+# Show daily Grok usage
+ccusage grok daily
+
+# Show monthly Grok usage
+ccusage grok monthly
+
+# Show session-based Grok usage
+ccusage grok session
+
+# JSON output for automation
+ccusage grok daily --json
+
+# Custom Grok home
+ccusage grok daily --grok-path /path/to/.grok
+
+# Multiple Grok homes
+ccusage grok daily --grok-path /path/to/.grok,/archive/.grok
+
+# Filter by date range
+ccusage grok daily --since 2026-07-01 --until 2026-07-13
+```
+
+## Cost Calculation
+
+Grok does not embed USD costs in session files. ccusage calculates cost from token counts and model pricing:
+
+- Displayed **output** tokens stay as Grok's `outputTokens`.
+- **Reasoning** tokens (`reasoningTokens`) are included in total token accounting via `extra_total_tokens` and are billed at the **output** unit price (same pattern as Goose).
+- Embedded fixed rates exist for active models such as `grok-4.5` and `grok-composer-2.5-fast`. Unknown models warn as missing pricing rather than inventing rates.
+
+## Model Attribution
+
+Models come from each turn's `usage.modelUsage` map. Multi-model turns emit one row per model. Display names use a `[grok]` prefix so Grok rows stay distinct in unified `ccusage daily` reports.
+
+## Environment Variables
+
+| Variable | Description |
+| -------- | ----------- |
+| `GROK_HOME` | Custom path, or comma-separated paths, to Grok home directories (default: `~/.grok`) |
+| `LOG_LEVEL` | Adjust logging verbosity (0 silent … 5 trace) |
+
+## Daily View
+
+```bash
+# Recommended (fastest)
+bunx ccusage grok daily
+
+# Using npx
+npx ccusage@latest grok daily
+```
+
+### Options
+
+| Flag | Short | Description |
+| ---- | ----- | ----------- |
+| `--since` | | Start date filter (YYYY-MM-DD or YYYYMMDD) |
+| `--until` | | End date filter (YYYY-MM-DD or YYYYMMDD) |
+| `--timezone` | `-z` | Override timezone for date grouping |
+| `--json` | `-j` | Emit structured JSON instead of a table |
+| `--compact` | | Force compact table layout for narrow terminals |
+| `--grok-path` | | Custom path, or comma-separated paths, to Grok home directories |
+| `--breakdown` | `-b` | Show per-model breakdown |
+
+### Example Output
+
+```text
+┌────────────┬──────────────────────────┬───────────┬───────────┬──────────────┬────────────┬──────────────┬──────────────┐
+│ Date       │ Models                   │     Input │    Output │ Cache Create │ Cache Read │ Total Tokens │   Cost (USD) │
+├────────────┼──────────────────────────┼───────────┼───────────┼──────────────┼────────────┼──────────────┼──────────────┤
+│ 2026-07-13 │ - [grok] grok-4.5        │    70,378 │     8,294 │            0 │     38,272 │      124,015 │       $0.24 │
+├────────────┼──────────────────────────┼───────────┼───────────┼──────────────┼────────────┼──────────────┼──────────────┤
+│ Total      │                          │    70,378 │     8,294 │            0 │     38,272 │      124,015 │       $0.24 │
+└────────────┴──────────────────────────┴───────────┴───────────┴──────────────┴────────────┴──────────────┴──────────────┘
+```
+
+### JSON Output
+
+```bash
+ccusage grok daily --json
+```
+
+Returns structured data:
+
+<!-- eslint-skip -->
+
+```json
+{
+	"daily": [
+		{
+			"date": "2026-07-13",
+			"inputTokens": 70378,
+			"outputTokens": 8294,
+			"cacheCreationTokens": 0,
+			"cacheReadTokens": 38272,
+			"totalTokens": 124015,
+			"totalCost": 0.24,
+			"modelsUsed": ["[grok] grok-4.5"]
+		}
+	],
+	"totals": {
+		"inputTokens": 70378,
+		"outputTokens": 8294,
+		"cacheCreationTokens": 0,
+		"cacheReadTokens": 38272,
+		"totalTokens": 124015,
+		"totalCost": 0.24
+	}
+}
+```
+
+## Monthly View
+
+```bash
+ccusage grok monthly
+ccusage grok monthly --json
+ccusage grok monthly --since 2026-01-01 --until 2026-07-31
+```
+
+## Session View
+
+Session IDs are the Grok session directory UUID (parent of `updates.jsonl`).
+
+```bash
+ccusage grok session
+ccusage grok session --json
+ccusage grok session --since 2026-07-09
+```
+
+## Limitations
+
+- Local files only — ccusage does not scrape xAI cloud billing.
+- Only `turn_completed` events with billable token fields are loaded. Tool updates and meta-only `totalTokens` lines are ignored.
+- Reasoning tokens are billed at the output rate for cost estimates; the output column still shows raw output tokens.
+- Nested `subagents/` directories currently hold metadata pointers only; child usage lives in sibling session directories and is loaded separately (see adapter README).
+
+## Related
+
+- [ccusage](https://github.com/ccusage/ccusage) - Main usage analysis tool for coding (agent) CLIs
+- [Source Support Q&A](/guide/source-support-qa) - Support criteria for other CLIs

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Grok Build CLI, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Grok, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Grok Build CLI, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -84,6 +84,7 @@ ccusage reads from local coding CLI data directories:
 | pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`         |
 | Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`  |
 | OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                  |
+| Grok Build   | `grok`     | `${GROK_HOME:-~/.grok}/sessions/**/updates.jsonl` |
 | Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`         |
 | Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}`                     |
 | Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                     |
@@ -93,7 +94,7 @@ ccusage reads from local coding CLI data directories:
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI and Devin CLI.
 
 ## Report Shape
 
@@ -119,6 +120,7 @@ ccusage hermes daily
 ccusage pi monthly
 ccusage goose daily
 ccusage openclaw daily
+ccusage grok daily
 ccusage kilo daily
 ccusage kimi daily
 ccusage qwen daily

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -29,10 +29,12 @@ The CLI log files include operational events such as conversation creation, stre
 Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
 :::
 
-::: details Why is Grok CLI not supported?
-Grok CLI was investigated, but its local SQLite data did not contain usable token accounting. Without token counts, model usage, or recorded costs in the local database, ccusage has nothing reliable to aggregate.
+::: details Is Grok Build CLI supported?
+Yes. Grok Build CLI (current local session layout under `~/.grok/sessions`) writes per-turn usage on `turn_completed` events in `updates.jsonl`, including input, output, cache-read, and reasoning tokens per model.
 
-Estimating tokens from message text would ignore provider-side context, hidden prompts, tool-call payloads, cached input, and tokenizer differences, so ccusage does not do that.
+Use `ccusage grok daily|monthly|session` or the unified `ccusage daily` report when Grok data is present. See the [Grok guide](/guide/grok/) for paths, `GROK_HOME`, `--grok-path`, and cost notes.
+
+Older investigations that looked only at SQLite without turn usage no longer apply to the JSONL session updates layout.
 :::
 
 ::: details Why is Devin CLI not supported?

--- a/docs/plans/2026-07-13-001-feat-grok-cli-usage-adapter-plan.md
+++ b/docs/plans/2026-07-13-001-feat-grok-cli-usage-adapter-plan.md
@@ -1,0 +1,421 @@
+---
+title: "feat: Add Grok CLI usage adapter"
+date: 2026-07-13
+type: feat
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-plan-bootstrap
+execution: code
+deepened: false
+---
+
+# feat: Add Grok CLI usage adapter
+
+## Goal Capsule
+
+- **Objective:** Make Grok Build CLI usage visible in `ccusage` daily/monthly/session reports with token totals and estimated USD cost, using local session files under `~/.grok/sessions`.
+- **Authority:** This plan; adapter architecture in `rust/crates/ccusage/src/adapter/README.md` and `adapter/AGENTS.md`; local pricing patch conventions in `LOCAL_PRICING_PATCH.md`.
+- **Stop when:** `ccusage grok daily` and unified `ccusage daily` show Grok models from real local data; fixture tests pass; release binary rebuilt for the local wrapper; docs no longer claim Grok CLI is unsupported.
+- **Out of scope:** Scraping xAI cloud billing APIs; estimating tokens from transcript text; changing other agents' loaders beyond registration hooks.
+
+## Product Contract
+
+### Summary
+
+Users who run Grok Build CLI heavily currently see **no Grok line** in `ccusage` because there is no adapter. Grok now writes per-turn token accounting on `turn_completed` events in session `updates.jsonl`. This plan adds a first-class `grok` agent source, pricing for the models in active use (`grok-4.5`, `grok-composer-2.5-fast`), and docs so Grok usage rolls into the unified report.
+
+Product Contract preservation: N/A (ce-plan-bootstrap; no upstream brainstorm).
+
+### Requirements
+
+- R1. `ccusage` discovers Grok session data under the default Grok home (`~/.grok`) and optional overrides (`GROK_HOME`, `--grok-path` / config).
+- R2. Only billable turn usage is loaded: `sessionUpdate == "turn_completed"` records that carry `usage.modelUsage` (or top-level usage with model identity).
+- R3. Each model in `modelUsage` becomes one or more `LoadedEntry` rows with input, output, cache-read, and reasoning token fields mapped into ccusage's token model.
+- R4. Cost in calculate/auto modes bills `reasoningTokens` at the **output** rate (Goose pattern), while totals still account for reasoning via `extra_total_tokens`.
+- R5. Embedded fixed prices exist for `grok-4.5` and `grok-composer-2.5-fast` (and keep existing `grok-4.3` / `grok-build-0.1` entries). Unknown models warn missing-pricing rather than invent rates.
+- R6. Users can run `ccusage grok daily|monthly|session` and see Grok included in unified `ccusage daily` when data exists.
+- R7. Docs and Source Support Q&A reverse the "Grok CLI not supported" guidance and document paths, env, flags, and caveats.
+- R8. Local wrapper continues to point at the rebuilt release binary so normal `ccusage` picks up Grok without special flags.
+
+### Actors
+
+- A1. Interactive CLI user checking multi-agent spend.
+- A2. Local custom-fixes maintainer rebuilding the release binary.
+
+### Key Flows
+
+- F1. User runs `ccusage daily --breakdown` → Grok rows appear under Agent/Models when `~/.grok/sessions` has recent `turn_completed` usage.
+- F2. User runs `ccusage grok daily --since … --until … --json` → JSON totals match sum of fixture/local turn usage for that window.
+- F3. User sets `GROK_HOME` or `--grok-path` to an alternate data root → only that tree is scanned.
+
+### Acceptance Examples
+
+- AE1. Fixture with two `turn_completed` events (mixed models) → loader yields two entries, correct per-model tokens, non-zero cost for priced models.
+- AE2. Session with only tool updates / `totalTokens` meta and no `turn_completed` usage → zero entries (no invented usage).
+- AE3. Live smoke (skipped unless local data present): `ccusage grok daily --since <today>` returns rows for machines with active Grok use.
+- AE4. Unified daily "Detected:" line includes Grok when data is present.
+
+### Scope Boundaries
+
+**In scope**
+
+- New `adapter/grok` module (paths, parser, loader, report, mod).
+- CLI/command/config/progress/all-agent registration.
+- Pricing entries + cost mapping for active Grok model IDs.
+- Docs: guide page, index table, source-support Q&A, related links/nav.
+- Rebuild local release binary used by the shell wrapper.
+
+**Out of scope**
+
+- Headless SDK-only streams that never write `updates.jsonl`.
+- Estimating tokens from `chat_history.jsonl` text.
+- Upstream PR process (may happen later; this plan targets this checkout).
+- Changing the default cost mode of the shell wrapper.
+
+**Deferred to Follow-Up Work**
+
+- Official models.dev / LiteLLM sync for Grok model IDs (local fixed rates first).
+- Blocks/statusline integration if Grok lacks Claude-style billing blocks.
+- Subagent double-count audit refinements if parent turns ever embed child totals (see Open Questions).
+
+---
+
+## Planning Contract
+
+### Assumptions
+
+- Grok's `turn_completed.usage` values are **per-turn** (not cumulative session totals). Confirmed on live data: consecutive turns can go down as well as up.
+- `timestamp` on `updates.jsonl` lines is Unix seconds (UTC-based grouping via existing timezone helpers).
+- `GROK_HOME` unset means `~/.grok` (matches current CLI auth/log layout).
+- Display model labels should use a `[grok]` prefix in multi-agent views, matching OpenClaw/pi conventions.
+- Exact public USD rates for `grok-4.5` / `grok-composer-2.5-fast` may need a short docs lookup at implementation time; if unavailable, use documented provisional rates aligned with nearby Grok coding models and record the source in `pricing.rs` comments / `LOCAL_PRICING_PATCH.md`.
+
+### Key Technical Decisions
+
+- KTD1. **Source of truth:** Parse `**/updates.jsonl` under `<grok-home>/sessions/`. Ignore `worktrees.db` (no token accounting). Prefer `usage.modelUsage` over coarse `tokens_used` on `subagent_finished`.
+- KTD2. **Granularity:** One `LoadedEntry` per `(turn, model)` from `modelUsage`. Multi-model turns emit multiple entries sharing session id and timestamp.
+- KTD3. **Reasoning cost:** Mirror Goose — store reasoning in `extra_total_tokens`; for cost calculation, bill `output_tokens + reasoning_tokens` at the output unit price. Do not double-count reasoning in displayed output token columns.
+- KTD4. **Project/session identity:** Session id = directory name (UUID). Project path prefer `summary.json` `info.cwd` / `git_root_dir` when present; else URL-decode the parent path segment under `sessions/`.
+- KTD5. **Walk strategy:** Discover `updates.jsonl` files (and optional sibling `summary.json` for metadata). Use `read_files_parallel` like OpenClaw. Fast detection short-circuits once any usable file exists for "detected agents" banners.
+- KTD6. **Dedupe key:** Prefer `_meta.eventId` when present; else stable hash of session id + timestamp + model + token tuple so re-reads do not inflate totals.
+- KTD7. **Pricing:** Extend embedded fixed-price map (existing local patch path) for `grok-4.5` and `grok-composer-2.5-fast`; keep `grok-4.3` / `grok-build-0.1`. Use candidate keys: raw model id, optional `xai/<model>`.
+- KTD8. **Registration surface:** Full first-class agent — `Command::Grok`, config schema, `UsageLoadAgent::Grok`, `adapter/all` loader entry, help text, docs guide.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart LR
+  subgraph disk [Grok home]
+    S["sessions/.../UUID/updates.jsonl"]
+    M["summary.json optional"]
+  end
+  subgraph adapter [adapter/grok]
+    P[paths]
+    R[parser turn_completed]
+    L[loader parallel + dedupe]
+    C[cost + pricing candidates]
+  end
+  subgraph shared [shared ccusage]
+    E[LoadedEntry]
+    A[all-agent rollup]
+    T[tables / JSON]
+  end
+  S --> R
+  M --> L
+  P --> L
+  R --> L
+  L --> C --> E --> A --> T
+```
+
+**Directional parse sketch (not implementation code):**
+
+```text
+for each line in updates.jsonl:
+  if method not session update: skip
+  update = params.update
+  if update.sessionUpdate != "turn_completed": skip
+  usage = update.usage or empty
+  models = usage.modelUsage or { currentModel: usage }
+  for (model, u) in models:
+    emit entry(
+      input=u.inputTokens,
+      output=u.outputTokens,
+      cache_read=u.cachedReadTokens,
+      reasoning=u.reasoningTokens,
+      ts=line.timestamp,
+      session=params.sessionId
+    )
+```
+
+### Alternatives Considered
+
+| Approach | Why not |
+|---|---|
+| Keep pricing-only for Grok models in other agents | User's Grok TUI traffic never appears; that was the observed gap. |
+| Estimate tokens from chat history text | Explicitly forbidden by product policy and Source Support Q&A. |
+| Scrape xAI cloud usage | ccusage is local read-only; no authenticated cloud scraping. |
+| Session-level max snapshot instead of per-turn sum | Under-counts multi-turn sessions; live data shows per-turn independence. |
+
+### Risks and Dependencies
+
+| Risk | Mitigation |
+|---|---|
+| Parent turn usage already includes subagent tokens, and child sessions also emit `turn_completed` → double count | During U2/U3, sample a parent+child pair; if double-count proven, exclude nested `subagents/` session paths or filter child sessions. Default: load every session dir's `turn_completed` until evidence says otherwise; document the choice. |
+| Schema drift (field renames) | Lenient serde + fixture tests; skipped live smoke test. |
+| Provisional pricing wrong | Fixed rates documented; easy override via `pricingOverrides` / rebuild. |
+| Large session trees slow load | Parallel file reads; only open `updates.jsonl` (not chat history). |
+
+### Open Questions
+
+- OQ1 (deferred): Confirm whether parent `turn_completed` usage includes child subagent API usage. Resolve during implementation with one live multi-subagent session; record the rule in `adapter/grok/README.md`.
+- OQ2 (deferred): Final public list prices for `grok-4.5` and `grok-composer-2.5-fast` — look up at implement time from xAI docs; if missing, provisional rates with comment.
+
+---
+
+## Implementation Units
+
+### U1. Grok path discovery and adapter skeleton
+
+**Goal:** Create the `adapter/grok` module shell and discover session roots/files without parsing usage yet.
+
+**Requirements:** R1
+
+**Dependencies:** None
+
+**Files:**
+
+- `rust/crates/ccusage/src/adapter/grok/mod.rs` (create)
+- `rust/crates/ccusage/src/adapter/grok/paths.rs` (create)
+- `rust/crates/ccusage/src/adapter/mod.rs` (modify)
+- `rust/crates/ccusage/src/adapter/grok/paths.rs` tests via `ccusage_test_support::fs_fixture`
+
+**Approach:**
+
+- Default roots: `$GROK_HOME` if set (comma-separated allowed), else `~/.grok`.
+- Optional CLI/config custom path mirrors OpenClaw's multi-root list.
+- Collect `sessions/**/updates.jsonl` (skip symlinks). Optionally pair each with sibling `summary.json`.
+- Export empty/stub `load_entries` returning `Ok(vec![])` so later units can wire CLI without unfinished parse.
+
+**Patterns to follow:** `adapter/openclaw/paths.rs`, `adapter/hermes/paths.rs` env overrides.
+
+**Test scenarios:**
+
+- Env `GROK_HOME` pointing at a fixture with nested session `updates.jsonl` → discovery returns that file.
+- Missing home / empty sessions → empty list, no error.
+- Comma-separated roots → both scanned; dedupe by canonical path.
+
+**Verification:** Unit tests green; module compiles with `adapter::grok` registered in `adapter/mod.rs`.
+
+---
+
+### U2. Parse `turn_completed` usage into LoadedEntry
+
+**Goal:** Convert JSONL lines into typed usage rows with correct token mapping and timestamps.
+
+**Requirements:** R2, R3, R4 (field mapping only; cost can be 0 until U3)
+
+**Dependencies:** U1
+
+**Files:**
+
+- `rust/crates/ccusage/src/adapter/grok/parser.rs` (create)
+- `rust/crates/ccusage/src/adapter/grok/loader.rs` (create/extend)
+- Fixture JSONL under test fixtures (inline `fs_fixture!` or `tests/fixtures/grok/` if repo prefers files)
+
+**Approach:**
+
+- Serde structs for the minimal envelope: `timestamp`, `params.sessionId`, `params.update.sessionUpdate`, `params.update.usage`, `params._meta.eventId`.
+- Map camelCase token fields → `TokenUsageRaw` (`cachedReadTokens` → `cache_read_input_tokens`; `reasoningTokens` → `extra_total_tokens`).
+- Timestamp: Unix seconds → millis via existing helpers (same idea as Goose).
+- Model label: raw id for pricing candidates; displayed model `[grok] <id>` for multi-agent distinction.
+- Skip lines that are not `turn_completed` or lack any positive token counts.
+
+**Patterns to follow:** `adapter/openclaw/parser.rs` (JSONL + prefilter), `adapter/goose/parser.rs` (reasoning / timestamp).
+
+**Execution note:** Implement parser tests before wiring cost so token mapping is locked.
+
+**Test scenarios:**
+
+- Happy path: one model, all token fields present → correct `LoadedEntry` usage and date under UTC.
+- Multi-model `modelUsage` → one entry per model.
+- Zero-token / missing usage → skipped.
+- Non-`turn_completed` lines with large `totalTokens` meta only → ignored.
+- Timestamp seconds vs millis edge: values like `1783901683` group to the correct calendar day in a fixed timezone.
+
+**Verification:** Parser unit tests only; no CLI smoke required yet.
+
+---
+
+### U3. Loader aggregation, cost, and pricing candidates
+
+**Goal:** Parallel load, dedupe, cost calculation with reasoning-as-output billing, missing-pricing warnings.
+
+**Requirements:** R3, R4, R5
+
+**Dependencies:** U2
+
+**Files:**
+
+- `rust/crates/ccusage/src/adapter/grok/loader.rs` (modify)
+- `rust/crates/ccusage/src/adapter/grok/parser.rs` (cost helpers)
+- `rust/crates/ccusage/src/pricing.rs` (modify — model rates)
+- `LOCAL_PRICING_PATCH.md` (modify — document new rates)
+
+**Approach:**
+
+- `track_usage_load(UsageLoadAgent::Grok, …)` wrapper.
+- `read_files_parallel` over discovered `updates.jsonl` files.
+- Cost helper mirrors Goose: `output_tokens + reasoning_tokens` for pricing; display usage keeps original output.
+- Pricing candidates: model id, `xai/{model}` if useful.
+- Embed fixed rates for `grok-4.5` and `grok-composer-2.5-fast`; update context limits if known (e.g. 500k for 4.5 from models cache).
+- Resolve OQ1 with a quick parent/child sample before finalizing which paths load.
+
+**Patterns to follow:** `calculate_goose_cost`, local `fixed_cached_input_pricing` helpers already in `pricing.rs`.
+
+**Test scenarios:**
+
+- Priced model fixture → cost > 0 and matches hand calculation for known rates.
+- Unknown model with tokens → cost 0 + `missing_pricing_model` set.
+- Dedupe: duplicate `eventId` twice → single entry.
+- Reasoning-only addition: output=100, reasoning=50 → cost uses 150 output units; displayed output tokens remain 100; `extra_total_tokens` includes 50.
+
+**Verification:** Focused cargo tests for grok parser/loader/pricing.
+
+---
+
+### U4. CLI command, config, progress, and all-agent rollup
+
+**Goal:** Expose `ccusage grok …` and include Grok in unified reports when data exists.
+
+**Requirements:** R6, R8
+
+**Dependencies:** U3
+
+**Files:**
+
+- `rust/crates/ccusage-cli/src/types.rs` (modify — `Command::Grok`)
+- CLI parse/help wiring in the clap/parser module(s) under `rust/crates/ccusage-cli/` (modify as required)
+- `rust/crates/ccusage/src/main.rs` (modify — dispatch)
+- `rust/crates/ccusage/src/progress.rs` (modify — `UsageLoadAgent::Grok`)
+- `rust/crates/ccusage/src/adapter/all/loader.rs` (modify)
+- `rust/crates/ccusage/src/adapter/all/report.rs` (modify — display name)
+- `rust/crates/ccusage/src/config.rs` / `config_schema.rs` (modify — grok path options)
+- `rust/crates/ccusage/src/adapter/grok/report.rs` (create)
+- `rust/crates/ccusage/src/adapter/grok/mod.rs` (run entry)
+
+**Approach:**
+
+- Mirror Hermes/OpenClaw agent command args (`daily`/`monthly`/`session` kinds already shared).
+- Optional `--grok-path` analogous to `--open-claw-path`.
+- All-agent detection should list Grok only when path discovery finds usable files (existing short-circuit pattern).
+
+**Patterns to follow:** `adapter/hermes/mod.rs` `run`, `adapter/all/loader.rs` agent table.
+
+**Test scenarios:**
+
+- CLI help includes `grok`.
+- Integration-style test: fixture `GROK_HOME` + `ccusage`-level load path returns summaries for daily kind (prefer unit-level summarize tests if full CLI harness is heavy).
+- All-agent loader includes grok agent key when fixture present.
+
+**Verification:** `cargo test -p ccusage` covering new registration; manual `ccusage grok --help`.
+
+---
+
+### U5. Docs and Source Support Q&A
+
+**Goal:** User-facing documentation matches the new agent.
+
+**Requirements:** R7
+
+**Dependencies:** U4 (command names/flags stable)
+
+**Files:**
+
+- `docs/guide/grok/index.md` (create)
+- `docs/guide/index.md` (modify — agent table)
+- `docs/guide/all-reports.md` (modify)
+- `docs/guide/source-support-qa.md` (modify — remove/replace "Grok not supported")
+- VitePress nav under `docs/` (modify as existing agents do)
+- `apps/ccusage/README.md` and/or root README agent list if they enumerate agents
+- `rust/crates/ccusage/src/adapter/grok/README.md` (create — path/schema notes)
+- `.agents/skills/agent-sources/SKILL.md` (modify — point at Grok README)
+
+**Approach:** Follow OpenClaw guide structure: install invocation examples, data paths, env/flags, sample table, JSON sample, limitations (local only; reasoning billed as output for cost).
+
+**Test expectation:** none — documentation only; link-check via normal docs workflow if available.
+
+**Verification:** Docs skill audit checklist satisfied for user-facing agent addition.
+
+---
+
+### U6. Local binary rebuild and smoke validation
+
+**Goal:** The machine's normal `ccusage` command reports Grok usage.
+
+**Requirements:** R8, AE3, AE4
+
+**Dependencies:** U1–U5
+
+**Files:**
+
+- `LOCAL_PRICING_PATCH.md` (modify — mention Grok adapter + rebuild steps)
+- No source beyond rebuild if already complete
+
+**Approach:**
+
+- `cargo +stable build --manifest-path rust/Cargo.toml --locked -p ccusage --release`
+- Confirm wrapper still targets `rust/target/release/ccusage`
+- Smoke: `ccusage grok daily --since <yesterday> --breakdown` and unified `ccusage daily --since <yesterday> --breakdown`
+- Confirm models `grok-4.5` / `grok-composer-2.5-fast` appear with non-zero tokens
+
+**Execution note:** Prefer install/runtime smoke verification over additional unit tests for this unit.
+
+**Test expectation:** none beyond smoke outcomes above.
+
+**Verification:** Live report shows Grok; version string still 20.x from this checkout.
+
+---
+
+## Verification Contract
+
+- Focused: `cargo +stable test --manifest-path rust/Cargo.toml --locked -p ccusage` (or package-filtered grok/pricing tests during iteration).
+- Format: `just fmt` / rustfmt when Rust files change.
+- Smoke (local data present):
+  - `ccusage grok daily --since 2026-07-12 --until 2026-07-13 --breakdown`
+  - `ccusage daily --since 2026-07-12 --until 2026-07-13 --breakdown` includes Grok in Detected + table.
+- Docs: manual spot-check of guide page and Source Support Q&A.
+- Rebuild release binary after tests pass so the wrapper path is current.
+
+## Definition of Done
+
+- [ ] U1–U6 complete.
+- [ ] Fixture tests cover parse, multi-model, skip non-usage lines, cost+reasoning, path discovery.
+- [ ] `ccusage grok` command works; unified daily detects Grok when data exists.
+- [ ] Pricing present for `grok-4.5` and `grok-composer-2.5-fast`; missing-pricing for unknowns.
+- [ ] Docs no longer claim Grok CLI is unsupported; new guide exists.
+- [ ] Local release binary rebuilt and smoke-tested against real `~/.grok` data.
+- [ ] Parent/child double-count decision documented in adapter README.
+
+## Appendix
+
+### Evidence from pre-plan investigation
+
+- Official docs previously said Grok local DB lacked token accounting; live Grok 0.2.x sessions now write full `usage` on `turn_completed`.
+- Last ~24h on the authoring machine (sum of turn events): ~190M input / ~2M output for `grok-4.5`, ~94M input for `grok-composer-2.5-fast` — all invisible to current `ccusage`.
+- Local pricing patch already prices other agents and older Grok model keys, but has **no adapter** and **no** `grok-4.5` / `grok-composer-2.5-fast` rates.
+
+### Pattern references
+
+| Concern | Follow |
+|---|---|
+| JSONL session walk | `adapter/openclaw/` |
+| Reasoning → cost as output | `adapter/goose/parser.rs` `calculate_goose_cost` |
+| Agent `run` + report | `adapter/hermes/mod.rs` |
+| All-agent registration | `adapter/all/loader.rs` |
+| Fixed local rates | `pricing.rs` + `LOCAL_PRICING_PATCH.md` |
+| New agent docs | `docs/guide/openclaw/index.md` |
+
+### Sources & Research
+
+- Local research only: adapter architecture docs, OpenClaw/Goose/Hermes adapters, live `~/.grok/sessions` samples.
+- External research skipped for architecture (strong in-repo patterns). Pricing URLs to consult at implement time: xAI developer pricing docs (same source comment style as existing Grok entries in `pricing.rs`).

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -1,15 +1,43 @@
 {
 	"combinedOptions": {
-		"all_agent_session_options": ["all_agent_options", "session_options"],
-		"blocks_combined_options": ["shared_claude_options", "blocks_options"],
-		"claude_daily_options": ["shared_claude_options", "daily_options"],
-		"claude_session_options": ["shared_claude_options", "session_options"],
-		"claude_weekly_options": ["shared_claude_options", "weekly_options"],
-		"openclaw_combined_options": ["agent_options", "openclaw_options"],
-		"pi_combined_options": ["agent_options", "pi_options"]
+		"all_agent_session_options": [
+			"all_agent_options",
+			"session_options"
+		],
+		"blocks_combined_options": [
+			"shared_claude_options",
+			"blocks_options"
+		],
+		"claude_daily_options": [
+			"shared_claude_options",
+			"daily_options"
+		],
+		"claude_session_options": [
+			"shared_claude_options",
+			"session_options"
+		],
+		"claude_weekly_options": [
+			"shared_claude_options",
+			"weekly_options"
+		],
+		"openclaw_combined_options": [
+			"agent_options",
+			"openclaw_options"
+		],
+		"pi_combined_options": [
+			"agent_options",
+			"pi_options"
+		],
+		"grok_combined_options": [
+			"agent_options",
+			"grok_options"
+		]
 	},
 	"root": {
-		"usage": ["ccusage [daily] <OPTIONS>", "ccusage <COMMANDS>"],
+		"usage": [
+			"ccusage [daily] <OPTIONS>",
+			"ccusage <COMMANDS>"
+		],
 		"commands": [
 			{
 				"name": "daily",
@@ -94,48 +122,66 @@
 			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
+			},
+			{
+				"name": "grok",
+				"description": "Show Grok Build CLI usage commands"
 			}
 		]
 	},
 	"pages": [
 		{
-			"path": ["daily"],
+			"path": [
+				"daily"
+			],
 			"description": "Show all detected coding (agent) CLI usage grouped by date",
 			"usage": "ccusage daily <OPTIONS>",
 			"options": "all_agent_options"
 		},
 		{
-			"path": ["monthly"],
+			"path": [
+				"monthly"
+			],
 			"description": "Show all detected coding (agent) CLI usage grouped by month",
 			"usage": "ccusage monthly <OPTIONS>",
 			"options": "all_agent_options"
 		},
 		{
-			"path": ["weekly"],
+			"path": [
+				"weekly"
+			],
 			"description": "Show all detected coding (agent) CLI usage grouped by week",
 			"usage": "ccusage weekly <OPTIONS>",
 			"options": "all_agent_options"
 		},
 		{
-			"path": ["session"],
+			"path": [
+				"session"
+			],
 			"description": "Show all detected coding (agent) CLI usage grouped by session",
 			"usage": "ccusage session <OPTIONS>",
 			"options": "all_agent_session_options"
 		},
 		{
-			"path": ["blocks"],
+			"path": [
+				"blocks"
+			],
 			"description": "Show usage report grouped by session billing blocks",
 			"usage": "ccusage blocks <OPTIONS>",
 			"options": "blocks_combined_options"
 		},
 		{
-			"path": ["statusline"],
+			"path": [
+				"statusline"
+			],
 			"description": "Display compact status line for Claude Code hooks with hybrid time+file caching (Beta)",
 			"usage": "ccusage statusline <OPTIONS>",
 			"options": "statusline_options"
 		},
 		{
-			"path": ["claude"],
+			"path": [
+				"claude"
+			],
 			"description": "Usage reports for claude.",
 			"usage": "ccusage claude <COMMANDS>",
 			"commands": [
@@ -166,43 +212,63 @@
 			]
 		},
 		{
-			"path": ["claude", "daily"],
+			"path": [
+				"claude",
+				"daily"
+			],
 			"description": "Show usage report grouped by date",
 			"usage": "ccusage claude daily <OPTIONS>",
 			"options": "claude_daily_options"
 		},
 		{
-			"path": ["claude", "monthly"],
+			"path": [
+				"claude",
+				"monthly"
+			],
 			"description": "Show usage report grouped by month",
 			"usage": "ccusage claude monthly <OPTIONS>",
 			"options": "shared_claude_options"
 		},
 		{
-			"path": ["claude", "weekly"],
+			"path": [
+				"claude",
+				"weekly"
+			],
 			"description": "Show usage report grouped by week",
 			"usage": "ccusage claude weekly <OPTIONS>",
 			"options": "claude_weekly_options"
 		},
 		{
-			"path": ["claude", "session"],
+			"path": [
+				"claude",
+				"session"
+			],
 			"description": "Show usage report grouped by conversation session",
 			"usage": "ccusage claude session <OPTIONS>",
 			"options": "claude_session_options"
 		},
 		{
-			"path": ["claude", "blocks"],
+			"path": [
+				"claude",
+				"blocks"
+			],
 			"description": "Show usage report grouped by session billing blocks",
 			"usage": "ccusage claude blocks <OPTIONS>",
 			"options": "blocks_combined_options"
 		},
 		{
-			"path": ["claude", "statusline"],
+			"path": [
+				"claude",
+				"statusline"
+			],
 			"description": "Display compact status line for Claude Code hooks with hybrid time+file caching (Beta)",
 			"usage": "ccusage claude statusline <OPTIONS>",
 			"options": "statusline_options"
 		},
 		{
-			"path": ["codex"],
+			"path": [
+				"codex"
+			],
 			"description": "Usage reports for codex.",
 			"usage": "ccusage codex <COMMANDS>",
 			"commands": [
@@ -221,25 +287,36 @@
 			]
 		},
 		{
-			"path": ["codex", "daily"],
+			"path": [
+				"codex",
+				"daily"
+			],
 			"description": "Show Codex token usage grouped by day",
 			"usage": "ccusage codex daily <OPTIONS>",
 			"options": "codex_options"
 		},
 		{
-			"path": ["codex", "monthly"],
+			"path": [
+				"codex",
+				"monthly"
+			],
 			"description": "Show Codex token usage grouped by month",
 			"usage": "ccusage codex monthly <OPTIONS>",
 			"options": "codex_options"
 		},
 		{
-			"path": ["codex", "session"],
+			"path": [
+				"codex",
+				"session"
+			],
 			"description": "Show Codex token usage grouped by session",
 			"usage": "ccusage codex session <OPTIONS>",
 			"options": "codex_options"
 		},
 		{
-			"path": ["opencode"],
+			"path": [
+				"opencode"
+			],
 			"description": "Usage reports for opencode.",
 			"usage": "ccusage opencode <COMMANDS>",
 			"commands": [
@@ -262,31 +339,45 @@
 			]
 		},
 		{
-			"path": ["opencode", "daily"],
+			"path": [
+				"opencode",
+				"daily"
+			],
 			"description": "Show OpenCode token usage grouped by day",
 			"usage": "ccusage opencode daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["opencode", "weekly"],
+			"path": [
+				"opencode",
+				"weekly"
+			],
 			"description": "Show OpenCode token usage grouped by week",
 			"usage": "ccusage opencode weekly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["opencode", "monthly"],
+			"path": [
+				"opencode",
+				"monthly"
+			],
 			"description": "Show OpenCode token usage grouped by month",
 			"usage": "ccusage opencode monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["opencode", "session"],
+			"path": [
+				"opencode",
+				"session"
+			],
 			"description": "Show OpenCode token usage grouped by session",
 			"usage": "ccusage opencode session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["amp"],
+			"path": [
+				"amp"
+			],
 			"description": "Usage reports for amp.",
 			"usage": "ccusage amp <COMMANDS>",
 			"commands": [
@@ -305,25 +396,36 @@
 			]
 		},
 		{
-			"path": ["amp", "daily"],
+			"path": [
+				"amp",
+				"daily"
+			],
 			"description": "Show Amp token usage grouped by day",
 			"usage": "ccusage amp daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["amp", "monthly"],
+			"path": [
+				"amp",
+				"monthly"
+			],
 			"description": "Show Amp token usage grouped by month",
 			"usage": "ccusage amp monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["amp", "session"],
+			"path": [
+				"amp",
+				"session"
+			],
 			"description": "Show Amp token usage grouped by session",
 			"usage": "ccusage amp session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["droid"],
+			"path": [
+				"droid"
+			],
 			"description": "Usage reports for droid.",
 			"usage": "ccusage droid <COMMANDS>",
 			"commands": [
@@ -342,25 +444,36 @@
 			]
 		},
 		{
-			"path": ["droid", "daily"],
+			"path": [
+				"droid",
+				"daily"
+			],
 			"description": "Show Droid usage grouped by date",
 			"usage": "ccusage droid daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["droid", "monthly"],
+			"path": [
+				"droid",
+				"monthly"
+			],
 			"description": "Show Droid usage grouped by month",
 			"usage": "ccusage droid monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["droid", "session"],
+			"path": [
+				"droid",
+				"session"
+			],
 			"description": "Show Droid usage grouped by session",
 			"usage": "ccusage droid session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["codebuff"],
+			"path": [
+				"codebuff"
+			],
 			"description": "Usage reports for codebuff.",
 			"usage": "ccusage codebuff <COMMANDS>",
 			"commands": [
@@ -379,25 +492,36 @@
 			]
 		},
 		{
-			"path": ["codebuff", "daily"],
+			"path": [
+				"codebuff",
+				"daily"
+			],
 			"description": "Show Codebuff usage grouped by date",
 			"usage": "ccusage codebuff daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["codebuff", "monthly"],
+			"path": [
+				"codebuff",
+				"monthly"
+			],
 			"description": "Show Codebuff usage grouped by month",
 			"usage": "ccusage codebuff monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["codebuff", "session"],
+			"path": [
+				"codebuff",
+				"session"
+			],
 			"description": "Show Codebuff usage grouped by session",
 			"usage": "ccusage codebuff session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["hermes"],
+			"path": [
+				"hermes"
+			],
 			"description": "Usage reports for hermes.",
 			"usage": "ccusage hermes <COMMANDS>",
 			"commands": [
@@ -416,25 +540,36 @@
 			]
 		},
 		{
-			"path": ["hermes", "daily"],
+			"path": [
+				"hermes",
+				"daily"
+			],
 			"description": "Show Hermes usage grouped by date",
 			"usage": "ccusage hermes daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["hermes", "monthly"],
+			"path": [
+				"hermes",
+				"monthly"
+			],
 			"description": "Show Hermes usage grouped by month",
 			"usage": "ccusage hermes monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["hermes", "session"],
+			"path": [
+				"hermes",
+				"session"
+			],
 			"description": "Show Hermes usage grouped by session",
 			"usage": "ccusage hermes session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["pi"],
+			"path": [
+				"pi"
+			],
 			"description": "Usage reports for pi.",
 			"usage": "ccusage pi <COMMANDS>",
 			"commands": [
@@ -453,25 +588,36 @@
 			]
 		},
 		{
-			"path": ["pi", "daily"],
+			"path": [
+				"pi",
+				"daily"
+			],
 			"description": "Show pi-agent usage grouped by date",
 			"usage": "ccusage pi daily <OPTIONS>",
 			"options": "pi_combined_options"
 		},
 		{
-			"path": ["pi", "monthly"],
+			"path": [
+				"pi",
+				"monthly"
+			],
 			"description": "Show pi-agent usage grouped by month",
 			"usage": "ccusage pi monthly <OPTIONS>",
 			"options": "pi_combined_options"
 		},
 		{
-			"path": ["pi", "session"],
+			"path": [
+				"pi",
+				"session"
+			],
 			"description": "Show pi-agent usage grouped by session",
 			"usage": "ccusage pi session <OPTIONS>",
 			"options": "pi_combined_options"
 		},
 		{
-			"path": ["goose"],
+			"path": [
+				"goose"
+			],
 			"description": "Usage reports for goose.",
 			"usage": "ccusage goose <COMMANDS>",
 			"commands": [
@@ -490,25 +636,36 @@
 			]
 		},
 		{
-			"path": ["goose", "daily"],
+			"path": [
+				"goose",
+				"daily"
+			],
 			"description": "Show Goose usage grouped by date",
 			"usage": "ccusage goose daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["goose", "monthly"],
+			"path": [
+				"goose",
+				"monthly"
+			],
 			"description": "Show Goose usage grouped by month",
 			"usage": "ccusage goose monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["goose", "session"],
+			"path": [
+				"goose",
+				"session"
+			],
 			"description": "Show Goose usage grouped by session",
 			"usage": "ccusage goose session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kilo"],
+			"path": [
+				"kilo"
+			],
 			"description": "Usage reports for kilo.",
 			"usage": "ccusage kilo <COMMANDS>",
 			"commands": [
@@ -527,25 +684,36 @@
 			]
 		},
 		{
-			"path": ["kilo", "daily"],
+			"path": [
+				"kilo",
+				"daily"
+			],
 			"description": "Show Kilo usage grouped by date",
 			"usage": "ccusage kilo daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kilo", "monthly"],
+			"path": [
+				"kilo",
+				"monthly"
+			],
 			"description": "Show Kilo usage grouped by month",
 			"usage": "ccusage kilo monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kilo", "session"],
+			"path": [
+				"kilo",
+				"session"
+			],
 			"description": "Show Kilo usage grouped by session",
 			"usage": "ccusage kilo session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["copilot"],
+			"path": [
+				"copilot"
+			],
 			"description": "Usage reports for copilot.",
 			"usage": "ccusage copilot <COMMANDS>",
 			"commands": [
@@ -564,25 +732,36 @@
 			]
 		},
 		{
-			"path": ["copilot", "daily"],
+			"path": [
+				"copilot",
+				"daily"
+			],
 			"description": "Show GitHub Copilot CLI usage grouped by date",
 			"usage": "ccusage copilot daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["copilot", "monthly"],
+			"path": [
+				"copilot",
+				"monthly"
+			],
 			"description": "Show GitHub Copilot CLI usage grouped by month",
 			"usage": "ccusage copilot monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["copilot", "session"],
+			"path": [
+				"copilot",
+				"session"
+			],
 			"description": "Show GitHub Copilot CLI usage grouped by session",
 			"usage": "ccusage copilot session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["gemini"],
+			"path": [
+				"gemini"
+			],
 			"description": "Usage reports for gemini.",
 			"usage": "ccusage gemini <COMMANDS>",
 			"commands": [
@@ -601,25 +780,36 @@
 			]
 		},
 		{
-			"path": ["gemini", "daily"],
+			"path": [
+				"gemini",
+				"daily"
+			],
 			"description": "Show Gemini CLI usage grouped by date",
 			"usage": "ccusage gemini daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["gemini", "monthly"],
+			"path": [
+				"gemini",
+				"monthly"
+			],
 			"description": "Show Gemini CLI usage grouped by month",
 			"usage": "ccusage gemini monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["gemini", "session"],
+			"path": [
+				"gemini",
+				"session"
+			],
 			"description": "Show Gemini CLI usage grouped by session",
 			"usage": "ccusage gemini session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kimi"],
+			"path": [
+				"kimi"
+			],
 			"description": "Usage reports for kimi.",
 			"usage": "ccusage kimi <COMMANDS>",
 			"commands": [
@@ -638,25 +828,36 @@
 			]
 		},
 		{
-			"path": ["kimi", "daily"],
+			"path": [
+				"kimi",
+				"daily"
+			],
 			"description": "Show Kimi usage grouped by date",
 			"usage": "ccusage kimi daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kimi", "monthly"],
+			"path": [
+				"kimi",
+				"monthly"
+			],
 			"description": "Show Kimi usage grouped by month",
 			"usage": "ccusage kimi monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["kimi", "session"],
+			"path": [
+				"kimi",
+				"session"
+			],
 			"description": "Show Kimi usage grouped by session",
 			"usage": "ccusage kimi session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["qwen"],
+			"path": [
+				"qwen"
+			],
 			"description": "Usage reports for qwen.",
 			"usage": "ccusage qwen <COMMANDS>",
 			"commands": [
@@ -675,25 +876,36 @@
 			]
 		},
 		{
-			"path": ["qwen", "daily"],
+			"path": [
+				"qwen",
+				"daily"
+			],
 			"description": "Show Qwen usage grouped by date",
 			"usage": "ccusage qwen daily <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["qwen", "monthly"],
+			"path": [
+				"qwen",
+				"monthly"
+			],
 			"description": "Show Qwen usage grouped by month",
 			"usage": "ccusage qwen monthly <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["qwen", "session"],
+			"path": [
+				"qwen",
+				"session"
+			],
 			"description": "Show Qwen usage grouped by session",
 			"usage": "ccusage qwen session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{
-			"path": ["openclaw"],
+			"path": [
+				"openclaw"
+			],
 			"description": "Usage reports for openclaw.",
 			"usage": "ccusage openclaw <COMMANDS>",
 			"commands": [
@@ -712,22 +924,79 @@
 			]
 		},
 		{
-			"path": ["openclaw", "daily"],
+			"path": [
+				"openclaw",
+				"daily"
+			],
 			"description": "Show OpenClaw usage grouped by date",
 			"usage": "ccusage openclaw daily <OPTIONS>",
 			"options": "openclaw_combined_options"
 		},
 		{
-			"path": ["openclaw", "monthly"],
+			"path": [
+				"openclaw",
+				"monthly"
+			],
 			"description": "Show OpenClaw usage grouped by month",
 			"usage": "ccusage openclaw monthly <OPTIONS>",
 			"options": "openclaw_combined_options"
 		},
 		{
-			"path": ["openclaw", "session"],
+			"path": [
+				"openclaw",
+				"session"
+			],
 			"description": "Show OpenClaw usage grouped by session",
 			"usage": "ccusage openclaw session <OPTIONS>",
 			"options": "openclaw_combined_options"
+		},
+		{
+			"path": [
+				"grok"
+			],
+			"description": "Usage reports for Grok Build CLI.",
+			"usage": "ccusage grok <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Grok usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Grok usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Grok usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": [
+				"grok",
+				"daily"
+			],
+			"description": "Show Grok usage grouped by date",
+			"usage": "ccusage grok daily <OPTIONS>",
+			"options": "grok_combined_options"
+		},
+		{
+			"path": [
+				"grok",
+				"monthly"
+			],
+			"description": "Show Grok usage grouped by month",
+			"usage": "ccusage grok monthly <OPTIONS>",
+			"options": "grok_combined_options"
+		},
+		{
+			"path": [
+				"grok",
+				"session"
+			],
+			"description": "Show Grok usage grouped by session",
+			"usage": "ccusage grok session <OPTIONS>",
+			"options": "grok_combined_options"
 		}
 	]
 }

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -178,7 +178,11 @@
 			"flags": "--speed [speed]",
 			"description": "Cost speed tier: auto reads Codex config.toml service_tier; use standard or fast to override",
 			"default": "auto",
-			"choices": ["auto", "standard", "fast"]
+			"choices": [
+				"auto",
+				"standard",
+				"fast"
+			]
 		},
 		{
 			"flags": "--compact",
@@ -265,7 +269,11 @@
 			"flags": "-m, --mode [mode]",
 			"description": "Cost calculation mode",
 			"default": "auto",
-			"choices": ["auto", "calculate", "display"]
+			"choices": [
+				"auto",
+				"calculate",
+				"display"
+			]
 		},
 		{
 			"flags": "-d, --debug",
@@ -281,7 +289,10 @@
 			"flags": "-o, --order [order]",
 			"description": "Sort order",
 			"default": "asc",
-			"choices": ["desc", "asc"]
+			"choices": [
+				"desc",
+				"asc"
+			]
 		},
 		{
 			"flags": "-b, --breakdown",
@@ -350,13 +361,23 @@
 			"flags": "-B, --visual-burn-rate [visual-burn-rate]",
 			"description": "Controls the visualization of the burn rate status",
 			"default": "off",
-			"choices": ["off", "emoji", "text", "emoji-text"]
+			"choices": [
+				"off",
+				"emoji",
+				"text",
+				"emoji-text"
+			]
 		},
 		{
 			"flags": "--cost-source [cost-source]",
 			"description": "Session cost source",
 			"default": "auto",
-			"choices": ["auto", "ccusage", "cc", "both"]
+			"choices": [
+				"auto",
+				"ccusage",
+				"cc",
+				"both"
+			]
 		},
 		{
 			"flags": "--cache",
@@ -410,7 +431,21 @@
 			"flags": "-w, --start-of-week [start-of-week]",
 			"description": "Start day of the week",
 			"default": "sunday",
-			"choices": ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
+			"choices": [
+				"sunday",
+				"monday",
+				"tuesday",
+				"wednesday",
+				"thursday",
+				"friday",
+				"saturday"
+			]
+		}
+	],
+	"grok_options": [
+		{
+			"flags": "--grok-path <grok-path>",
+			"description": "Path or comma-separated paths to Grok home directories (default: ~/.grok)"
 		}
 	]
 }

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -264,6 +264,7 @@ fn parse_command(
             Command::Qwen,
         ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
+        "grok" => parse_grok_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -286,6 +287,7 @@ fn parse_all_command(
         kind,
         pi_path: None,
         open_claw_path: None,
+        grok_path: None,
         codex_speed: CodexSpeed::Auto,
     }))
 }
@@ -319,6 +321,7 @@ fn parse_top_level_session_command(
         kind: AgentReportKind::Session,
         pi_path: None,
         open_claw_path: None,
+        grok_path: None,
         codex_speed: CodexSpeed::Auto,
     }))
 }
@@ -458,7 +461,7 @@ fn parse_codex_command(
 ) -> Result<Command, String> {
     let kind = parse_agent_report_kind(parser, "codex", STANDARD_AGENT_REPORTS)?;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, None);
+    config.apply_agent_args(&mut codex_speed, None, None, None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -473,6 +476,7 @@ fn parse_codex_command(
         kind,
         pi_path: None,
         open_claw_path: None,
+        grok_path: None,
         codex_speed,
     }))
 }
@@ -485,7 +489,7 @@ fn parse_pi_command(
     let kind = parse_agent_report_kind(parser, "pi", STANDARD_AGENT_REPORTS)?;
     let mut pi_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, Some(&mut pi_path), None);
+    config.apply_agent_args(&mut codex_speed, Some(&mut pi_path), None, None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -500,6 +504,7 @@ fn parse_pi_command(
         kind,
         pi_path,
         open_claw_path: None,
+        grok_path: None,
         codex_speed,
     }))
 }
@@ -512,7 +517,7 @@ fn parse_openclaw_command(
     let kind = parse_agent_report_kind(parser, "openclaw", STANDARD_AGENT_REPORTS)?;
     let mut open_claw_path = None;
     let mut codex_speed = CodexSpeed::Auto;
-    config.apply_agent_args(&mut codex_speed, None, Some(&mut open_claw_path));
+    config.apply_agent_args(&mut codex_speed, None, Some(&mut open_claw_path), None);
     while parser.peek().is_some() {
         if parse_shared_arg_for_command(parser, &mut shared)? {
             continue;
@@ -527,6 +532,35 @@ fn parse_openclaw_command(
         kind,
         pi_path: None,
         open_claw_path,
+        grok_path: None,
+        codex_speed,
+    }))
+}
+
+fn parse_grok_command(
+    parser: &mut ArgParser,
+    mut shared: SharedArgs,
+    config: &dyn CliConfig,
+) -> Result<Command, String> {
+    let kind = parse_agent_report_kind(parser, "grok", STANDARD_AGENT_REPORTS)?;
+    let mut grok_path = None;
+    let mut codex_speed = CodexSpeed::Auto;
+    config.apply_agent_args(&mut codex_speed, None, None, Some(&mut grok_path));
+    while parser.peek().is_some() {
+        if parse_shared_arg_for_command(parser, &mut shared)? {
+            continue;
+        }
+        match parser.next_flag()?.as_str() {
+            "--grok-path" => grok_path = Some(parser.value_for("--grok-path")?),
+            flag => return Err(format!("Unknown grok option '{flag}'")),
+        }
+    }
+    Ok(Command::Grok(AgentCommandArgs {
+        shared,
+        kind,
+        pi_path: None,
+        open_claw_path: None,
+        grok_path,
         codex_speed,
     }))
 }
@@ -555,6 +589,7 @@ fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommand
         kind,
         pi_path: None,
         open_claw_path: None,
+        grok_path: None,
         codex_speed: CodexSpeed::Auto,
     }
 }
@@ -631,6 +666,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "grok"
     )
 }
 
@@ -767,6 +803,7 @@ fn option_takes_value(arg: &str) -> bool {
             | "--speed"
             | "--pi-path"
             | "--open-claw-path"
+            | "--grok-path"
     )
 }
 
@@ -788,6 +825,7 @@ fn is_agent_command(command: &str) -> bool {
             | "kimi"
             | "qwen"
             | "openclaw"
+            | "grok"
     )
 }
 
@@ -800,7 +838,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -824,6 +862,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
+        "grok" => "Grok",
         _ => unreachable!("agent is prevalidated"),
     }
 }

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__root_help.snap
@@ -28,6 +28,7 @@ COMMANDS:
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
+  grok                       Show Grok Build CLI usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -51,6 +52,7 @@ For more info, run any command with the `--help` flag:
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help
+  ccusage grok --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli/src/snapshots/ccusage_cli__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage/src/cli.rs
+source: crates/ccusage-cli/src/tests.rs
 expression: cases
 ---
 [
@@ -33,6 +33,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "grokPath": null,
         "kind": "Daily",
         "openClawPath": null,
         "piPath": null,
@@ -179,6 +180,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Fast",
+        "grokPath": null,
         "kind": "Monthly",
         "openClawPath": null,
         "piPath": null,
@@ -229,6 +231,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "grokPath": null,
         "kind": "Weekly",
         "openClawPath": null,
         "piPath": null,
@@ -279,6 +282,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "grokPath": null,
         "kind": "Session",
         "openClawPath": null,
         "piPath": "/tmp/pi-sessions",
@@ -329,6 +333,7 @@ expression: cases
     "cli": {
       "command": {
         "codexSpeed": "Auto",
+        "grokPath": null,
         "kind": "Session",
         "openClawPath": "/tmp/openclaw",
         "piPath": null,

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -43,6 +43,7 @@ struct TestConfig {
     codex_speed: Option<CodexSpeed>,
     pi_path: Option<&'static str>,
     open_claw_path: Option<&'static str>,
+    grok_path: Option<&'static str>,
 }
 
 impl CliConfig for TestConfig {
@@ -99,6 +100,7 @@ impl CliConfig for TestConfig {
         codex_speed: &mut CodexSpeed,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
+        grok_path: Option<&mut Option<String>>,
     ) {
         if let Some(speed) = self.codex_speed {
             *codex_speed = speed;
@@ -108,6 +110,9 @@ impl CliConfig for TestConfig {
         }
         if let (Some(path), Some(open_claw_path)) = (self.open_claw_path, open_claw_path) {
             *open_claw_path = Some(path.to_string());
+        }
+        if let (Some(path), Some(grok_path)) = (self.grok_path, grok_path) {
+            *grok_path = Some(path.to_string());
         }
     }
 }
@@ -202,6 +207,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
     }
 }
 
@@ -212,6 +218,7 @@ fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
         "kind": format!("{:?}", args.kind),
         "piPath": args.pi_path,
         "openClawPath": args.open_claw_path,
+        "grokPath": args.grok_path,
         "codexSpeed": format!("{:?}", args.codex_speed),
     })
 }
@@ -947,3 +954,23 @@ fn parses_openclaw_session_options() {
     assert!(args.shared.json);
     assert_eq!(args.open_claw_path.as_deref(), Some("/tmp/openclaw"));
 }
+
+#[test]
+fn parses_grok_session_options() {
+    let cli = parse(&[
+        "ccusage",
+        "grok",
+        "session",
+        "--json",
+        "--grok-path",
+        "/tmp/grok",
+    ]);
+    let Some(Command::Grok(args)) = cli.command else {
+        panic!("expected grok command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
+    assert_eq!(args.grok_path.as_deref(), Some("/tmp/grok"));
+}
+
+

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -30,6 +30,7 @@ pub enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+    Grok(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]
@@ -122,6 +123,7 @@ pub struct AgentCommandArgs {
     pub kind: AgentReportKind,
     pub pi_path: Option<String>,
     pub open_claw_path: Option<String>,
+    pub grok_path: Option<String>,
     pub codex_speed: CodexSpeed,
 }
 
@@ -246,6 +248,7 @@ pub trait CliConfig {
         _codex_speed: &mut CodexSpeed,
         _pi_path: Option<&mut Option<String>>,
         _open_claw_path: Option<&mut Option<String>>,
+        _grok_path: Option<&mut Option<String>>,
     ) {
     }
 }

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -5,8 +5,8 @@ use serde_json::{Value, json};
 use crate::{
     CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result, SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
+        openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -237,6 +237,21 @@ pub(super) fn load_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<Al
                 agent: "qwen",
                 progress_agent: crate::progress::UsageLoadAgent::Qwen,
                 load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+            },
+            AgentLoadSpec {
+                index: 15,
+                agent: "grok",
+                progress_agent: crate::progress::UsageLoadAgent::Grok,
+                load: Box::new(|| {
+                    load_session_capable_summary_agent_rows(
+                        "grok",
+                        load_kind,
+                        &loader_shared,
+                        &pricing,
+                        grok::load_entries,
+                        grok::summarize_entries,
+                    )
+                }),
             },
         ],
         &mut progress,

--- a/rust/crates/ccusage/src/adapter/all/report.rs
+++ b/rust/crates/ccusage/src/adapter/all/report.rs
@@ -463,6 +463,7 @@ fn agent_label(agent: &str) -> &str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "grok" => "Grok",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage/src/adapter/grok/README.md
+++ b/rust/crates/ccusage/src/adapter/grok/README.md
@@ -1,0 +1,55 @@
+# Grok Build CLI adapter
+
+Reads local Grok Build CLI session usage from `~/.grok/sessions/**/updates.jsonl`.
+
+## Data source
+
+| Field | Value |
+| --- | --- |
+| Default home | `~/.grok` |
+| Env override | `GROK_HOME` (comma-separated roots) |
+| CLI override | `--grok-path` (comma-separated roots) |
+| Config | `grok.defaults.grokPath` / per-command `grokPath` |
+| Files | `sessions/**/updates.jsonl` (+ optional sibling `summary.json`) |
+
+Only `sessionUpdate == "turn_completed"` records with billable token counts load.
+Per-model maps come from `usage.modelUsage`; each model becomes one `LoadedEntry`.
+
+Token mapping:
+
+| Grok field | ccusage field |
+| --- | --- |
+| `inputTokens` | `input_tokens` |
+| `outputTokens` | `output_tokens` (display column) |
+| `cachedReadTokens` | `cache_read_input_tokens` |
+| `reasoningTokens` | `extra_total_tokens` (totals) and billed at **output** rate for cost |
+
+Display model labels use a `[grok]` prefix. Pricing candidates try the raw model
+id, `xai/<model>`, and `x-ai/<model>`.
+
+## Parent / child sessions (OQ1)
+
+Live sampling (2026-07-13):
+
+- Nested `…/<session>/subagents/<child-id>/` directories currently hold only
+  `meta.json` pointers — **no** nested `updates.jsonl`.
+- Child agent work is stored as **sibling** session directories under the same
+  project path (their own `updates.jsonl`).
+- There was no evidence that parent `turn_completed.usage` embeds child API
+  usage in a way that would double-count when both trees are loaded.
+
+**Rule:** load every session directory's `turn_completed` usage (all
+`updates.jsonl` under `sessions/`). Do not special-case `subagents/` unless
+future schema evidence shows nested usage files that already appear on the
+parent turn.
+
+## Dedup
+
+Prefer `_meta.eventId` + model. Fallback: session id + timestamp + model + token
+tuple.
+
+## Out of scope
+
+- Cloud xAI billing APIs
+- Token estimation from `chat_history.jsonl` text
+- Headless streams that never write `updates.jsonl`

--- a/rust/crates/ccusage/src/adapter/grok/loader.rs
+++ b/rust/crates/ccusage/src/adapter/grok/loader.rs
@@ -1,0 +1,148 @@
+use std::{collections::HashSet, path::PathBuf};
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
+
+use super::{
+    parser::{entry_id, parse_session_files},
+    paths::{GrokSessionFiles, collect_session_files, paths},
+};
+
+pub(crate) fn load_entries(
+    shared: &SharedArgs,
+    custom_path: Option<&str>,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Grok, shared.json, || {
+        load_entries_inner(shared, custom_path, pricing)
+    })
+}
+
+fn load_entries_inner(
+    shared: &SharedArgs,
+    custom_path: Option<&str>,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for root in paths(custom_path) {
+        let session_files = collect_session_files(&root)?;
+        let update_paths = session_files
+            .iter()
+            .map(|file| file.updates.clone())
+            .collect::<Vec<PathBuf>>();
+        // Parallel reads take PathBuf; reattach optional sibling summary.json per file.
+        let loaded = read_files_parallel(&update_paths, shared.single_thread, |updates| {
+            let summary = updates
+                .parent()
+                .map(|parent| parent.join("summary.json"))
+                .filter(|candidate| candidate.is_file());
+            let files = GrokSessionFiles {
+                updates: updates.to_path_buf(),
+                summary,
+            };
+            parse_session_files(&files, tz.as_ref(), shared.mode, pricing).unwrap_or_else(|error| {
+                debug_log(
+                    shared,
+                    format!(
+                        "Failed to read Grok session file {}: {error}",
+                        updates.display()
+                    ),
+                );
+                Vec::new()
+            })
+        });
+        for file_entries in loaded {
+            for entry in file_entries {
+                if seen.insert(entry_id(&entry)) {
+                    entries.push(entry);
+                }
+            }
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    use super::super::paths::GROK_HOME_ENV;
+
+    static GROK_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    fn turn_line(event_id: &str, model: &str, input: u64, output: u64) -> String {
+        format!(
+            r#"{{"timestamp":1783903216,"params":{{"sessionId":"sess","update":{{"sessionUpdate":"turn_completed","usage":{{"modelUsage":{{"{model}":{{"inputTokens":{input},"outputTokens":{output},"reasoningTokens":0}}}}}}}},"_meta":{{"eventId":"{event_id}"}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn loads_and_dedupes_by_event_id() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let line = turn_line("evt-dup", "grok-4.5", 10, 2);
+        let fixture = fs_fixture!({
+            "sessions/p/s1/updates.jsonl": format!("{line}\n{line}\n"),
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            mode: crate::cli::CostMode::Calculate,
+            offline: true,
+            ..SharedArgs::default()
+        };
+        let pricing = PricingMap::load_with_overrides(true, false, std::iter::empty());
+        let entries = load_entries(&shared, fixture.root().to_str(), Some(&pricing)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("[grok] grok-4.5"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+    }
+
+    #[test]
+    fn priced_model_cost_matches_hand_calculation() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        // input 1000 @ 2e-6, output 500 @ 6e-6, reasoning 100 billed as output
+        let line = r#"{"timestamp":1783903216,"params":{"sessionId":"s","update":{"sessionUpdate":"turn_completed","usage":{"modelUsage":{"grok-4.5":{"inputTokens":1000,"outputTokens":500,"reasoningTokens":100}}}},"_meta":{"eventId":"e"}}}"#;
+        let fixture = fs_fixture!({
+            "sessions/p/s/updates.jsonl": line,
+        });
+        let shared = SharedArgs {
+            mode: crate::cli::CostMode::Calculate,
+            offline: true,
+            ..SharedArgs::default()
+        };
+        let pricing = PricingMap::load_with_overrides(true, false, std::iter::empty());
+        let entries = load_entries(&shared, fixture.root().to_str(), Some(&pricing)).unwrap();
+        assert_eq!(entries.len(), 1);
+        // 1000*2e-6 + 600*6e-6 = 0.002 + 0.0036 = 0.0056
+        assert!(
+            (entries[0].cost - 0.0056).abs() < 1e-9,
+            "cost={}",
+            entries[0].cost
+        );
+        assert_eq!(entries[0].data.message.usage.output_tokens, 500);
+        assert_eq!(entries[0].extra_total_tokens, 100);
+    }
+
+    #[test]
+    fn grok_home_env_is_used_when_no_custom_path() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "sessions/p/s/updates.jsonl": turn_line("e", "grok-4.5", 1, 1),
+        });
+        let _cleanup = EnvVarGuard::set(GROK_HOME_ENV, fixture.root());
+        let shared = SharedArgs {
+            offline: true,
+            mode: crate::cli::CostMode::Calculate,
+            ..SharedArgs::default()
+        };
+        let pricing = PricingMap::load_with_overrides(true, false, std::iter::empty());
+        let entries = load_entries(&shared, None, Some(&pricing)).unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/mod.rs
+++ b/rust/crates/ccusage/src/adapter/grok/mod.rs
@@ -1,0 +1,42 @@
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    Result, cli::AgentCommandArgs, filter_loaded_entries_by_date, print_json_or_jq,
+    print_usage_table, sort_summaries, wants_json,
+};
+
+pub(crate) use loader::load_entries;
+pub(crate) use report::{report_from_rows, summarize_entries};
+
+pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
+    let pricing = crate::PricingMap::load_with_overrides(
+        args.shared.offline,
+        crate::log_level() != Some(0),
+        args.shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&args.shared, args.grok_path.as_deref(), Some(&pricing))?;
+    filter_loaded_entries_by_date(&mut entries, &args.shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &args.shared.order, |row| {
+        super::opencode::summary_period(row)
+    });
+    if wants_json(&args.shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            args.shared.jq.as_deref(),
+            args.shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Grok Token Usage Report",
+        super::opencode::first_column(args.kind),
+        &rows,
+        &args.shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/crates/ccusage/src/adapter/grok/parser.rs
+++ b/rust/crates/ccusage/src/adapter/grok/parser.rs
@@ -1,0 +1,736 @@
+use std::{collections::HashMap, fs, path::Path, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
+use serde_json::Value;
+
+use super::super::jsonl;
+use super::paths::GrokSessionFiles;
+use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_pricing_candidates, cli::CostMode, fast::LinePrefilter, format_date_tz,
+    missing_pricing_model_for_pricing_candidates,
+};
+
+/// Top-level Grok session update line.
+#[derive(Debug, Default, Deserialize)]
+struct GrokLine {
+    #[serde(default)]
+    timestamp: Option<Value>,
+    #[serde(default)]
+    params: Option<GrokParams>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokParams {
+    #[serde(
+        rename = "sessionId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    session_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
+    update: Option<GrokUpdate>,
+    #[serde(rename = "_meta", default, deserialize_with = "jsonl::lenient_object")]
+    meta: Option<GrokMeta>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokUpdate {
+    #[serde(
+        rename = "sessionUpdate",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    session_update: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
+    usage: Option<GrokUsage>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokMeta {
+    #[serde(
+        rename = "eventId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    event_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokUsage {
+    #[serde(
+        rename = "inputTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    input_tokens: u64,
+    #[serde(
+        rename = "outputTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    output_tokens: u64,
+    #[serde(
+        rename = "cachedReadTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    cached_read_tokens: u64,
+    #[serde(
+        rename = "reasoningTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    reasoning_tokens: u64,
+    #[serde(
+        rename = "totalTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    total_tokens: u64,
+    #[serde(rename = "modelUsage", default)]
+    model_usage: HashMap<String, GrokModelUsage>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokModelUsage {
+    #[serde(
+        rename = "inputTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    input_tokens: u64,
+    #[serde(
+        rename = "outputTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    output_tokens: u64,
+    #[serde(
+        rename = "cachedReadTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    cached_read_tokens: u64,
+    #[serde(
+        rename = "reasoningTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    reasoning_tokens: u64,
+    #[serde(
+        rename = "totalTokens",
+        default,
+        deserialize_with = "jsonl::lenient_u64"
+    )]
+    total_tokens: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummary {
+    #[serde(default)]
+    info: Option<GrokSummaryInfo>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    git_root_dir: Option<String>,
+    #[serde(
+        rename = "current_model_id",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    current_model_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummaryInfo {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    cwd: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+}
+
+pub(super) fn parse_session_files(
+    files: &GrokSessionFiles,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let session_meta = session_metadata(files);
+    let content = fs::read(&files.updates)?;
+    // Prefer turn_completed lines that carry usage; admit either marker so the
+    // prefilter stays cheap without dropping multi-model rows.
+    let prefilter = LinePrefilter::any(&[br#""turn_completed""#, br#""modelUsage""#]);
+    let mut entries = Vec::new();
+    for record in jsonl::records::<GrokLine>(&content, Some(&prefilter)) {
+        entries.extend(parse_turn_completed(
+            &record,
+            &session_meta,
+            tz,
+            mode,
+            pricing,
+        ));
+    }
+    Ok(entries)
+}
+
+struct SessionMeta {
+    session_id: String,
+    project: String,
+    project_path: String,
+    fallback_model: Option<String>,
+}
+
+fn session_metadata(files: &GrokSessionFiles) -> SessionMeta {
+    let session_id = files
+        .updates
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut project_path = decode_project_path_from_updates(&files.updates);
+    let mut fallback_model = None;
+    if let Some(summary_path) = files.summary.as_ref()
+        && let Ok(bytes) = fs::read(summary_path)
+        && let Ok(summary) = serde_json::from_slice::<GrokSummary>(&bytes)
+    {
+        if let Some(cwd) = summary
+            .info
+            .as_ref()
+            .and_then(|info| info.cwd.clone())
+            .or(summary.git_root_dir.clone())
+        {
+            project_path = cwd.trim_end_matches('/').to_string();
+        }
+        if let Some(id) = summary
+            .info
+            .as_ref()
+            .and_then(|info| info.id.clone())
+            .filter(|id| !id.is_empty())
+        {
+            // Prefer explicit summary session id when present.
+            let _ = id;
+        }
+        fallback_model = summary.current_model_id;
+    }
+
+    let project = project_path
+        .rsplit('/')
+        .find(|segment| !segment.is_empty())
+        .unwrap_or("grok")
+        .to_string();
+
+    SessionMeta {
+        session_id,
+        project,
+        project_path,
+        fallback_model,
+    }
+}
+
+fn decode_project_path_from_updates(updates: &Path) -> String {
+    // sessions/<url-encoded-project>/<uuid>/updates.jsonl
+    let mut components = updates
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    // Drop file name and session uuid when present.
+    if components
+        .last()
+        .is_some_and(|name| *name == "updates.jsonl")
+    {
+        components.pop();
+    }
+    if components.len() >= 2 {
+        let encoded = components[components.len() - 2];
+        if encoded != "sessions" {
+            return percent_decode(encoded);
+        }
+    }
+    for (index, component) in components.iter().enumerate() {
+        if *component == "sessions" {
+            if let Some(encoded) = components.get(index + 1) {
+                return percent_decode(encoded);
+            }
+        }
+    }
+    "Grok".to_string()
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) =
+                (from_hex(bytes[index + 1]), from_hex(bytes[index + 2]))
+        {
+            out.push((high << 4) | low);
+            index += 3;
+            continue;
+        }
+        out.push(bytes[index]);
+        index += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn from_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn parse_turn_completed(
+    record: &GrokLine,
+    session_meta: &SessionMeta,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Vec<LoadedEntry> {
+    let Some(params) = record.params.as_ref() else {
+        return Vec::new();
+    };
+    let Some(update) = params.update.as_ref() else {
+        return Vec::new();
+    };
+    if update.session_update.as_deref() != Some("turn_completed") {
+        return Vec::new();
+    }
+    let Some(usage) = update.usage.as_ref() else {
+        return Vec::new();
+    };
+
+    let session_id = params
+        .session_id
+        .clone()
+        .unwrap_or_else(|| session_meta.session_id.clone());
+    let event_id = params.meta.as_ref().and_then(|meta| meta.event_id.clone());
+    let timestamp = parse_timestamp(record.timestamp.as_ref()).unwrap_or(TimestampMs::UNIX_EPOCH);
+    let timestamp_text = crate::format_rfc3339_millis(timestamp);
+
+    let model_rows = model_usage_rows(usage, session_meta.fallback_model.as_deref());
+    let mut entries = Vec::with_capacity(model_rows.len());
+    for (raw_model, model_usage) in model_rows {
+        let input_tokens = model_usage.input_tokens;
+        let output_tokens = model_usage.output_tokens;
+        let cache_read = model_usage.cached_read_tokens;
+        let reasoning_tokens = model_usage.reasoning_tokens;
+        if input_tokens == 0 && output_tokens == 0 && cache_read == 0 && reasoning_tokens == 0 {
+            // Skip zero-token rows (including empty totalTokens-only metadata).
+            if model_usage.total_tokens == 0 {
+                continue;
+            }
+            // totalTokens alone without billable breakdown is ignored.
+            continue;
+        }
+
+        let usage_raw = TokenUsageRaw {
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: cache_read,
+            speed: None,
+            cache_creation: None,
+        };
+        let display_model = format!("[grok] {raw_model}");
+        let candidates = pricing_candidates(&display_model, &raw_model);
+        let cost = calculate_grok_cost(&candidates, usage_raw, reasoning_tokens, mode, pricing);
+        let missing_pricing_model = missing_grok_pricing(
+            &display_model,
+            &candidates,
+            usage_raw,
+            reasoning_tokens,
+            mode,
+            pricing,
+        );
+        let message_id = event_id
+            .as_ref()
+            .map(|id| format!("{id}:{raw_model}"))
+            .or_else(|| Some(format!("{session_id}:{timestamp_text}:{raw_model}")));
+        let data = UsageEntry {
+            session_id: Some(session_id.clone()),
+            timestamp: timestamp_text.clone(),
+            version: None,
+            message: UsageMessage {
+                usage: usage_raw,
+                model: Some(display_model.clone()),
+                id: message_id,
+            },
+            cost_usd: None,
+            request_id: event_id.clone(),
+            is_api_error_message: None,
+            is_sidechain: None,
+        };
+        entries.push(LoadedEntry {
+            date: format_date_tz(timestamp, tz),
+            timestamp,
+            project: Arc::from(session_meta.project.as_str()),
+            session_id: Arc::from(session_id.as_str()),
+            project_path: Arc::from(session_meta.project_path.as_str()),
+            cost,
+            credits: None,
+            model: Some(display_model),
+            usage_limit_reset_time: None,
+            missing_pricing_model,
+            extra_total_tokens: reasoning_tokens,
+            message_count: None,
+            data,
+        });
+    }
+    entries
+}
+
+struct ModelUsageRow {
+    input_tokens: u64,
+    output_tokens: u64,
+    cached_read_tokens: u64,
+    reasoning_tokens: u64,
+    total_tokens: u64,
+}
+
+fn model_usage_rows(
+    usage: &GrokUsage,
+    fallback_model: Option<&str>,
+) -> Vec<(String, ModelUsageRow)> {
+    if !usage.model_usage.is_empty() {
+        let mut rows = usage
+            .model_usage
+            .iter()
+            .map(|(model, row)| {
+                (
+                    model.clone(),
+                    ModelUsageRow {
+                        input_tokens: row.input_tokens,
+                        output_tokens: row.output_tokens,
+                        cached_read_tokens: row.cached_read_tokens,
+                        reasoning_tokens: row.reasoning_tokens,
+                        total_tokens: row.total_tokens,
+                    },
+                )
+            })
+            .collect::<Vec<_>>();
+        rows.sort_by(|left, right| left.0.cmp(&right.0));
+        return rows;
+    }
+    let model = fallback_model.unwrap_or("unknown").to_string();
+    vec![(
+        model,
+        ModelUsageRow {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cached_read_tokens: usage.cached_read_tokens,
+            reasoning_tokens: usage.reasoning_tokens,
+            total_tokens: usage.total_tokens,
+        },
+    )]
+}
+
+fn parse_timestamp(value: Option<&Value>) -> Option<TimestampMs> {
+    let value = value?;
+    if let Some(raw) = value.as_i64() {
+        let millis = if raw > 1_000_000_000_000 {
+            raw
+        } else {
+            raw.checked_mul(1_000)?
+        };
+        return (millis > 0).then(|| TimestampMs::from_millis(millis));
+    }
+    if let Some(raw) = value.as_u64() {
+        let millis = if raw > 1_000_000_000_000 {
+            i64::try_from(raw).ok()?
+        } else {
+            i64::try_from(raw.checked_mul(1_000)?).ok()?
+        };
+        return (millis > 0).then(|| TimestampMs::from_millis(millis));
+    }
+    crate::parse_ts_timestamp(value.as_str()?)
+}
+
+fn pricing_candidates(display_model: &str, raw_model: &str) -> Vec<String> {
+    let mut candidates = vec![
+        display_model.to_string(),
+        raw_model.to_string(),
+        format!("xai/{raw_model}"),
+        format!("x-ai/{raw_model}"),
+    ];
+    candidates.dedup();
+    candidates
+}
+
+/// Bill reasoning at the output rate while leaving displayed output unchanged.
+fn calculate_grok_cost(
+    candidates: &[String],
+    usage: TokenUsageRaw,
+    reasoning_tokens: u64,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> f64 {
+    let cost_usage = TokenUsageRaw {
+        output_tokens: usage.output_tokens.saturating_add(reasoning_tokens),
+        cache_creation: None,
+        ..usage
+    };
+    calculate_cost_for_pricing_candidates(
+        candidates.iter().map(String::as_str),
+        cost_usage,
+        None,
+        mode,
+        pricing,
+    )
+}
+
+fn missing_grok_pricing(
+    display_model: &str,
+    candidates: &[String],
+    usage: TokenUsageRaw,
+    reasoning_tokens: u64,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<String> {
+    let cost_usage = TokenUsageRaw {
+        output_tokens: usage.output_tokens.saturating_add(reasoning_tokens),
+        cache_creation: None,
+        ..usage
+    };
+    missing_pricing_model_for_pricing_candidates(
+        display_model,
+        candidates.iter().map(String::as_str),
+        crate::total_usage_tokens(cost_usage),
+        None,
+        mode,
+        pricing,
+    )
+}
+
+pub(super) fn entry_id(entry: &LoadedEntry) -> String {
+    if let Some(request_id) = entry.data.request_id.as_ref()
+        && let Some(model) = entry.model.as_ref()
+    {
+        return format!("grok:{request_id}:{model}");
+    }
+    if let Some(message_id) = entry.data.message.id.as_ref() {
+        return format!("grok:{message_id}");
+    }
+    let usage = entry.data.message.usage;
+    [
+        "grok".to_string(),
+        entry.session_id.to_string(),
+        entry.data.timestamp.clone(),
+        entry.model.clone().unwrap_or_default(),
+        usage.input_tokens.to_string(),
+        usage.output_tokens.to_string(),
+        usage.cache_read_input_tokens.to_string(),
+        entry.extra_total_tokens.to_string(),
+    ]
+    .join(":")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    fn turn_line(
+        timestamp: i64,
+        session_id: &str,
+        event_id: &str,
+        model_usage_json: &str,
+    ) -> String {
+        format!(
+            r#"{{"timestamp":{timestamp},"method":"_x.ai/session/update","params":{{"sessionId":"{session_id}","update":{{"sessionUpdate":"turn_completed","usage":{{"inputTokens":1,"outputTokens":1,"modelUsage":{model_usage_json}}}}},"_meta":{{"eventId":"{event_id}"}}}}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_happy_path_tokens_and_utc_date() {
+        let line = turn_line(
+            1_783_903_216,
+            "sess-1",
+            "evt-1",
+            r#"{"grok-4.5":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"totalTokens":130}}"#,
+        );
+        let fixture = fs_fixture!({
+            "sessions/%2Fproj%2Fdemo/sess-1/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture
+                .root()
+                .join("sessions/%2Fproj%2Fdemo/sess-1/updates.jsonl"),
+            summary: None,
+        };
+        let entries = parse_session_files(&files, None, CostMode::Calculate, None).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2026-07-13");
+        assert_eq!(entries[0].session_id.as_ref(), "sess-1");
+        assert_eq!(entries[0].model.as_deref(), Some("[grok] grok-4.5"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 20);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 40);
+        assert_eq!(entries[0].extra_total_tokens, 10);
+        assert!(entries[0].project_path.as_ref().contains("proj"));
+    }
+
+    #[test]
+    fn multi_model_emits_one_entry_per_model() {
+        let line = turn_line(
+            1_783_903_216,
+            "sess-2",
+            "evt-2",
+            r#"{"grok-4.5":{"inputTokens":10,"outputTokens":1,"reasoningTokens":0},"grok-composer-2.5-fast":{"inputTokens":5,"outputTokens":2,"reasoningTokens":1}}"#,
+        );
+        let fixture = fs_fixture!({
+            "s/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.root().join("s/updates.jsonl"),
+            summary: None,
+        };
+        let entries = parse_session_files(&files, None, CostMode::Calculate, None).unwrap();
+        assert_eq!(entries.len(), 2);
+        let models: Vec<_> = entries
+            .iter()
+            .filter_map(|entry| entry.model.clone())
+            .collect();
+        assert!(models.iter().any(|m| m == "[grok] grok-4.5"));
+        assert!(models.iter().any(|m| m == "[grok] grok-composer-2.5-fast"));
+    }
+
+    #[test]
+    fn skips_zero_token_and_non_turn_completed() {
+        let content = [
+            r#"{"timestamp":1783903216,"params":{"sessionId":"s","update":{"sessionUpdate":"tool_call_update","usage":{"totalTokens":99999}},"_meta":{"eventId":"e0"}}}"#,
+            r#"{"timestamp":1783903216,"params":{"sessionId":"s","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":0,"outputTokens":0,"modelUsage":{"m":{"inputTokens":0,"outputTokens":0}}}},"_meta":{"eventId":"e1"}}}"#,
+            &turn_line(
+                1_783_903_216,
+                "s",
+                "e2",
+                r#"{"m":{"inputTokens":3,"outputTokens":1}}"#,
+            ),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "s/updates.jsonl": content,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.root().join("s/updates.jsonl"),
+            summary: None,
+        };
+        let entries = parse_session_files(&files, None, CostMode::Calculate, None).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 3);
+    }
+
+    #[test]
+    fn timestamp_seconds_group_to_calendar_day() {
+        // 1783901683 seconds ≈ 2026-07-13 UTC
+        let line = turn_line(
+            1_783_901_683,
+            "s",
+            "e",
+            r#"{"m":{"inputTokens":1,"outputTokens":1}}"#,
+        );
+        let fixture = fs_fixture!({
+            "s/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.root().join("s/updates.jsonl"),
+            summary: None,
+        };
+        let entries = parse_session_files(&files, None, CostMode::Calculate, None).unwrap();
+        assert_eq!(entries[0].date, "2026-07-13");
+    }
+
+    #[test]
+    fn summary_cwd_preferred_for_project_path() {
+        let line = turn_line(
+            1_783_903_216,
+            "uuid-1",
+            "e",
+            r#"{"m":{"inputTokens":1,"outputTokens":1}}"#,
+        );
+        let fixture = fs_fixture!({
+            "sessions/%2Fencoded/uuid-1/updates.jsonl": line,
+            "sessions/%2Fencoded/uuid-1/summary.json": r#"{"info":{"id":"uuid-1","cwd":"/Users/rk/Projects/real"},"git_root_dir":"/Users/rk/Projects/real/"}"#,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture
+                .root()
+                .join("sessions/%2Fencoded/uuid-1/updates.jsonl"),
+            summary: Some(
+                fixture
+                    .root()
+                    .join("sessions/%2Fencoded/uuid-1/summary.json"),
+            ),
+        };
+        let entries = parse_session_files(&files, None, CostMode::Calculate, None).unwrap();
+        assert_eq!(entries[0].project_path.as_ref(), "/Users/rk/Projects/real");
+        assert_eq!(entries[0].project.as_ref(), "real");
+    }
+
+    #[test]
+    fn reasoning_billed_as_output_for_cost_display_output_unchanged() {
+        let line = turn_line(
+            1_783_903_216,
+            "s",
+            "e",
+            r#"{"priced-model":{"inputTokens":0,"outputTokens":100,"reasoningTokens":50}}"#,
+        );
+        let fixture = fs_fixture!({
+            "s/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.root().join("s/updates.jsonl"),
+            summary: None,
+        };
+        let mut shared = crate::cli::SharedArgs {
+            mode: CostMode::Calculate,
+            offline: true,
+            ..crate::cli::SharedArgs::default()
+        };
+        shared.pricing_overrides.insert(
+            "priced-model".to_string(),
+            ccusage_cli::PricingOverride {
+                input_cost_per_token: Some(0.0),
+                output_cost_per_token: Some(1e-3),
+                ..Default::default()
+            },
+        );
+        let pricing = PricingMap::load_with_overrides(true, false, shared.pricing_overrides.iter());
+        let entries =
+            parse_session_files(&files, None, CostMode::Calculate, Some(&pricing)).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 100);
+        assert_eq!(entries[0].extra_total_tokens, 50);
+        // 150 output units * 0.001
+        assert!((entries[0].cost - 0.15).abs() < 1e-9);
+    }
+
+    #[test]
+    fn unknown_model_sets_missing_pricing() {
+        let line = turn_line(
+            1_783_903_216,
+            "s",
+            "e",
+            r#"{"totally-unknown-model-xyz":{"inputTokens":10,"outputTokens":5}}"#,
+        );
+        let fixture = fs_fixture!({
+            "s/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.root().join("s/updates.jsonl"),
+            summary: None,
+        };
+        let pricing = PricingMap::load_with_overrides(true, false, std::iter::empty());
+        let entries =
+            parse_session_files(&files, None, CostMode::Calculate, Some(&pricing)).unwrap();
+        assert_eq!(entries[0].cost, 0.0);
+        assert!(entries[0].missing_pricing_model.is_some());
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/paths.rs
+++ b/rust/crates/ccusage/src/adapter/grok/paths.rs
@@ -1,0 +1,189 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::Result;
+
+pub(super) const GROK_HOME_ENV: &str = "GROK_HOME";
+const UPDATES_FILE_NAME: &str = "updates.jsonl";
+const SUMMARY_FILE_NAME: &str = "summary.json";
+
+/// Resolve Grok home roots: custom path, else `GROK_HOME`, else `~/.grok`.
+/// Only existing directories are returned; comma-separated lists are supported.
+pub(super) fn paths(custom_path: Option<&str>) -> Vec<PathBuf> {
+    if let Some(custom_path) = custom_path.filter(|path| !path.trim().is_empty()) {
+        return existing_path_list(custom_path);
+    }
+    if let Ok(env_paths) = env::var(GROK_HOME_ENV)
+        && !env_paths.trim().is_empty()
+    {
+        return existing_path_list(&env_paths);
+    }
+    let Some(home) = crate::home::home_dir() else {
+        return Vec::new();
+    };
+    let path = home.join(".grok");
+    path.is_dir().then_some(path).into_iter().collect()
+}
+
+fn existing_path_list(raw: &str) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    raw.split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+        .map(PathBuf::from)
+        .filter_map(|path| {
+            let canonical = path.canonicalize().unwrap_or(path);
+            (canonical.is_dir() && seen.insert(canonical.clone())).then_some(canonical)
+        })
+        .collect()
+}
+
+/// Session file pair: required `updates.jsonl` plus optional sibling `summary.json`.
+#[derive(Debug, Clone)]
+pub(super) struct GrokSessionFiles {
+    pub(super) updates: PathBuf,
+    pub(super) summary: Option<PathBuf>,
+}
+
+/// Discover `sessions/**/updates.jsonl` under each root (skipping symlinks).
+pub(super) fn collect_session_files(root: &Path) -> Result<Vec<GrokSessionFiles>> {
+    let mut files = Vec::new();
+    let sessions = root.join("sessions");
+    if sessions.is_dir() {
+        collect_session_files_inner(&sessions, &mut files)?;
+    } else {
+        // Allow custom path that already points at a sessions tree or a single session dir.
+        collect_session_files_inner(root, &mut files)?;
+    }
+    files.sort_by(|left, right| left.updates.cmp(&right.updates));
+    Ok(files)
+}
+
+fn collect_session_files_inner(path: &Path, files: &mut Vec<GrokSessionFiles>) -> Result<()> {
+    let Ok(entries) = fs::read_dir(path) else {
+        return Ok(());
+    };
+    for entry in entries {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let path = entry.path();
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
+            collect_session_files_inner(&path, files)?;
+            continue;
+        }
+        if file_type.is_file()
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == UPDATES_FILE_NAME)
+        {
+            let summary = path
+                .parent()
+                .map(|parent| parent.join(SUMMARY_FILE_NAME))
+                .filter(|candidate| candidate.is_file());
+            files.push(GrokSessionFiles {
+                updates: path,
+                summary,
+            });
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    static GROK_HOME_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn discovers_nested_updates_under_grok_home() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-1/updates.jsonl": "",
+            "sessions/proj/sess-1/summary.json": "{}",
+        });
+        let _cleanup = EnvVarGuard::set(GROK_HOME_ENV, fixture.root());
+
+        let roots = paths(None);
+        assert_eq!(roots.len(), 1);
+        let files = collect_session_files(&roots[0]).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].updates.ends_with("updates.jsonl"));
+        assert!(files[0].summary.is_some());
+    }
+
+    #[test]
+    fn missing_home_or_empty_sessions_returns_empty() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "other/file.txt": "x",
+        });
+        let _cleanup = EnvVarGuard::set(GROK_HOME_ENV, fixture.root());
+
+        let roots = paths(None);
+        assert_eq!(roots.len(), 1);
+        let files = collect_session_files(&roots[0]).unwrap();
+        assert!(files.is_empty());
+    }
+
+    #[test]
+    fn custom_path_override_ignores_env() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let env_fixture = fs_fixture!({
+            "sessions/a/s1/updates.jsonl": "",
+        });
+        let custom_fixture = fs_fixture!({
+            "sessions/b/s2/updates.jsonl": "",
+        });
+        let _cleanup = EnvVarGuard::set(GROK_HOME_ENV, env_fixture.root());
+
+        let roots = paths(custom_fixture.root().to_str());
+        assert_eq!(roots.len(), 1);
+        let files = collect_session_files(&roots[0]).unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].updates.to_string_lossy().contains("s2"));
+    }
+
+    #[test]
+    fn comma_separated_roots_are_scanned_and_deduped() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let fixture_a = fs_fixture!({
+            "sessions/p/s/updates.jsonl": "",
+        });
+        let fixture_b = fs_fixture!({
+            "sessions/q/t/updates.jsonl": "",
+        });
+        let a = fixture_a.root().display().to_string();
+        let b = fixture_b.root().display().to_string();
+        // Same path twice should yield a single root after canonical dedupe.
+        let list = format!("{a},{b},{a}");
+        let roots = paths(Some(&list));
+        assert_eq!(roots.len(), 2);
+        let mut total = 0;
+        for root in &roots {
+            total += collect_session_files(root).unwrap().len();
+        }
+        assert_eq!(total, 2);
+    }
+
+    #[test]
+    fn empty_custom_path_falls_back_to_env() {
+        let _guard = GROK_HOME_LOCK.lock().unwrap();
+        let fixture = fs_fixture!({
+            "sessions/p/s/updates.jsonl": "x",
+        });
+        let _cleanup = EnvVarGuard::set(GROK_HOME_ENV, fixture.root());
+        let roots = paths(Some("   "));
+        assert_eq!(roots.len(), 1);
+    }
+}

--- a/rust/crates/ccusage/src/adapter/grok/report.rs
+++ b/rust/crates/ccusage/src/adapter/grok/report.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| {
+            super::super::opencode::agent_summary_json(row, kind, kind == AgentReportKind::Session)
+        })
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub(crate) fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(|group| group.into_summary())
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -12,6 +12,7 @@ pub(crate) mod copilot;
 pub(crate) mod droid;
 pub(crate) mod gemini;
 pub(crate) mod goose;
+pub(crate) mod grok;
 pub(crate) mod hermes;
 pub(crate) mod jsonl;
 pub(crate) mod kilo;

--- a/rust/crates/ccusage/src/adapter/opencode/parser.rs
+++ b/rust/crates/ccusage/src/adapter/opencode/parser.rs
@@ -6,7 +6,8 @@ use serde::Deserialize;
 use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, TokenUsageRaw, UsageEntry, UsageMessage, apply_total_token_fallback,
-    calculate_cost_for_usage, cli::CostMode, format_date_tz, missing_pricing_model_for_candidates,
+    calculate_cost_for_pricing_candidates, cli::CostMode, format_date_tz,
+    missing_pricing_model_for_pricing_candidates,
 };
 
 /// A single parsed OpenCode message. Only the fields ccusage consumes are
@@ -164,14 +165,14 @@ fn calculate_open_code_cost(
     if let Some(cost) = cost_usd.filter(|cost| *cost > 0.0) {
         return cost;
     }
-    for candidate in open_code_model_candidates(model, provider) {
-        let cost =
-            calculate_cost_for_usage(Some(&candidate), usage, None, CostMode::Calculate, pricing);
-        if cost > 0.0 {
-            return cost;
-        }
-    }
-    0.0
+    let candidates = open_code_model_candidates(model, provider);
+    calculate_cost_for_pricing_candidates(
+        candidates.iter().map(String::as_str),
+        usage,
+        None,
+        CostMode::Calculate,
+        pricing,
+    )
 }
 
 fn missing_open_code_pricing(
@@ -185,10 +186,13 @@ fn missing_open_code_pricing(
     if mode == CostMode::Display || cost_usd.is_some_and(|cost| cost > 0.0) {
         return None;
     }
-    missing_pricing_model_for_candidates(
+    let candidates = open_code_model_candidates(model, provider);
+    missing_pricing_model_for_pricing_candidates(
         model,
-        open_code_model_candidates(model, provider),
+        candidates.iter().map(String::as_str),
         crate::total_usage_tokens(usage),
+        cost_usd.filter(|cost| *cost > 0.0),
+        mode,
         pricing,
     )
 }
@@ -438,6 +442,51 @@ mod tests {
         .unwrap();
 
         assert_eq!(entry.cost, 0.000143);
+    }
+
+    #[test]
+    fn exact_provider_override_wins_over_builtin_raw_model_pricing() {
+        let mut pricing = PricingMap::load_embedded();
+        let overrides = std::collections::BTreeMap::from([(
+            "deepseek/deepseek-v4-pro".to_string(),
+            ccusage_cli::PricingOverride {
+                input_cost_per_token: Some(1.0),
+                output_cost_per_token: Some(0.0),
+                cache_creation_input_token_cost: Some(0.0),
+                cache_read_input_token_cost: Some(0.0),
+                input_cost_per_token_above_200k_tokens: None,
+                output_cost_per_token_above_200k_tokens: None,
+                cache_creation_input_token_cost_above_200k_tokens: None,
+                cache_read_input_token_cost_above_200k_tokens: None,
+                max_input_tokens: None,
+                fast_multiplier: None,
+            },
+        )]);
+        pricing.apply_overrides(overrides.iter());
+
+        let entry = message_value_to_entry(
+            &message(json!({
+                "id": "message-a",
+                "sessionID": "session-a",
+                "providerID": "deepseek",
+                "modelID": "deepseek-v4-pro",
+                "time": { "created": 0 },
+                "tokens": {
+                    "input": 100,
+                    "output": 10,
+                    "cache": { "read": 50 }
+                },
+                "cost": 0
+            })),
+            None,
+            None,
+            None,
+            CostMode::Auto,
+            Some(&pricing),
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 100.0);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/adapter/pi/parser.rs
+++ b/rust/crates/ccusage/src/adapter/pi/parser.rs
@@ -6,8 +6,8 @@ use serde::Deserialize;
 use super::super::jsonl;
 use crate::{
     LoadedEntry, PricingMap, Result, TokenUsageRaw, UsageEntry, UsageMessage,
-    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, fast::LinePrefilter,
-    format_date_tz, missing_pricing_model_for_usage,
+    apply_total_token_fallback, calculate_cost_for_pricing_candidates, cli::CostMode,
+    fast::LinePrefilter, format_date_tz, missing_pricing_model_for_pricing_candidates,
 };
 
 /// A single parsed pi session record. Only the fields ccusage consumes are
@@ -112,11 +112,27 @@ pub(crate) fn read_session_file(
         if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
             continue;
         }
-        let model = message.model.clone().map(|model| format!("[pi] {model}"));
+        let raw_model = message.model.clone();
+        let model = raw_model.as_ref().map(|model| format!("[pi] {model}"));
         let display_cost = usage_value.cost.as_ref().and_then(|cost| cost.total);
-        let cost = calculate_cost_for_usage(model.as_deref(), usage, display_cost, mode, pricing);
-        let missing_pricing_model =
-            missing_pricing_model_for_usage(model.as_deref(), usage, display_cost, mode, pricing);
+        let pricing_candidates = pi_pricing_candidates(model.as_deref(), raw_model.as_deref());
+        let cost = calculate_cost_for_pricing_candidates(
+            pricing_candidates.iter().map(String::as_str),
+            usage,
+            display_cost,
+            mode,
+            pricing,
+        );
+        let missing_pricing_model = model.as_deref().and_then(|model| {
+            missing_pricing_model_for_pricing_candidates(
+                model,
+                pricing_candidates.iter().map(String::as_str),
+                crate::total_usage_tokens(usage),
+                display_cost,
+                mode,
+                pricing,
+            )
+        });
         let data = UsageEntry {
             session_id: Some(session_id.clone()),
             timestamp: timestamp_text,
@@ -185,6 +201,18 @@ fn extract_project(path: &Path) -> String {
         previous_was_sessions = segment == "sessions";
     }
     "unknown".to_string()
+}
+
+fn pi_pricing_candidates(display_model: Option<&str>, raw_model: Option<&str>) -> Vec<String> {
+    let mut candidates = Vec::new();
+    if let Some(display_model) = display_model {
+        candidates.push(display_model.to_string());
+    }
+    if let Some(raw_model) = raw_model {
+        candidates.push(raw_model.to_string());
+    }
+    candidates.dedup();
+    candidates
 }
 
 pub(super) fn entry_id(entry: &LoadedEntry) -> String {
@@ -289,5 +317,55 @@ mod tests {
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.usage.input_tokens, 100);
         assert_eq!(entries[0].data.message.usage.output_tokens, 200);
+    }
+
+    #[test]
+    fn prices_glm_52_from_raw_model_key_but_keeps_pi_display_label() {
+        let fixture = fs_fixture!({
+            "sessions/project-a/agent_session-a.jsonl": r#"{"type":"message","timestamp":"2026-01-02T00:00:00.000Z","message":{"role":"assistant","model":"glm-5.2","usage":{"input":1000000,"output":1000000,"cacheRead":1000000}}}"#,
+        });
+        let file = fixture.path("sessions/project-a/agent_session-a.jsonl");
+        let pricing = PricingMap::load_embedded();
+
+        let entries = read_session_file(&file, None, CostMode::Calculate, Some(&pricing)).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("[pi] glm-5.2"));
+        assert_eq!(
+            entries[0].missing_pricing_model.as_deref(),
+            None,
+            "raw GLM-5.2 pricing should be usable without warning"
+        );
+        assert!((entries[0].cost - 6.06).abs() < 1e-9);
+    }
+
+    #[test]
+    fn exact_pi_display_override_wins_over_raw_model_override() {
+        let fixture = fs_fixture!({
+            "sessions/project-a/agent_session-a.jsonl": r#"{"type":"message","timestamp":"2026-01-02T00:00:00.000Z","message":{"role":"assistant","model":"glm-5.2","usage":{"input":100}}}"#,
+        });
+        let file = fixture.path("sessions/project-a/agent_session-a.jsonl");
+        let overrides = std::collections::BTreeMap::from([
+            (
+                "glm-5.2".to_string(),
+                ccusage_cli::PricingOverride {
+                    input_cost_per_token: Some(1.0),
+                    ..ccusage_cli::PricingOverride::default()
+                },
+            ),
+            (
+                "[pi] glm-5.2".to_string(),
+                ccusage_cli::PricingOverride {
+                    input_cost_per_token: Some(2.0),
+                    ..ccusage_cli::PricingOverride::default()
+                },
+            ),
+        ]);
+        let mut pricing = PricingMap::default();
+        pricing.apply_overrides(overrides.iter());
+
+        let entries = read_session_file(&file, None, CostMode::Calculate, Some(&pricing)).unwrap();
+
+        assert_eq!(entries[0].cost, 200.0);
     }
 }

--- a/rust/crates/ccusage/src/config.rs
+++ b/rust/crates/ccusage/src/config.rs
@@ -14,8 +14,8 @@ use crate::{
     config_schema::{
         BlocksSpecificOptions, CodexOptions, ConfigCodexSpeed, ConfigCostMode, ConfigCostSource,
         ConfigPricingOverride, ConfigSortOrder, ConfigVisualBurnRate, ConfigWeekDay,
-        DailySpecificOptions, OpenClawOptions, PiOptions, SharedOptions, StatuslineSpecificOptions,
-        WeeklySpecificOptions,
+        DailySpecificOptions, GrokOptions, OpenClawOptions, PiOptions, SharedOptions,
+        StatuslineSpecificOptions, WeeklySpecificOptions,
     },
 };
 
@@ -249,6 +249,7 @@ fn is_agent_command(command: &str) -> bool {
             | "gemini"
             | "kimi"
             | "openclaw"
+            | "grok"
     )
 }
 
@@ -358,6 +359,7 @@ pub(crate) fn apply_config_to_agent_args(
     codex_speed: &mut CodexSpeed,
     mut pi_path: Option<&mut Option<String>>,
     mut open_claw_path: Option<&mut Option<String>>,
+    mut grok_path: Option<&mut Option<String>>,
     config: &ConfigContext,
 ) {
     for options in config.option_maps() {
@@ -374,6 +376,11 @@ pub(crate) fn apply_config_to_agent_args(
             && let Some(path) = OpenClawOptions::from_map(options).open_claw_path
         {
             *open_claw_path = Some(path);
+        }
+        if let Some(grok_path) = grok_path.as_deref_mut()
+            && let Some(path) = GrokOptions::from_map(options).grok_path
+        {
+            *grok_path = Some(path);
         }
     }
 }
@@ -404,8 +411,9 @@ impl crate::cli::CliConfig for ConfigContext {
         codex_speed: &mut CodexSpeed,
         pi_path: Option<&mut Option<String>>,
         open_claw_path: Option<&mut Option<String>>,
+        grok_path: Option<&mut Option<String>>,
     ) {
-        apply_config_to_agent_args(codex_speed, pi_path, open_claw_path, self);
+        apply_config_to_agent_args(codex_speed, pi_path, open_claw_path, grok_path, self);
     }
 }
 
@@ -780,6 +788,7 @@ mod tests {
             &mut speed,
             None,
             None,
+            None,
             &context(
                 json!({
                     "codex": {
@@ -801,6 +810,7 @@ mod tests {
         apply_config_to_agent_args(
             &mut speed,
             Some(&mut pi_path),
+            None,
             None,
             &context(
                 json!({
@@ -824,6 +834,7 @@ mod tests {
             &mut speed,
             None,
             Some(&mut open_claw_path),
+            None,
             &context(
                 json!({
                     "openclaw": {

--- a/rust/crates/ccusage/src/config_schema.rs
+++ b/rust/crates/ccusage/src/config_schema.rs
@@ -38,6 +38,8 @@ pub(crate) struct CcusageConfig {
     pub(crate) goose: Option<GooseConfig>,
     /// OpenClaw configuration.
     pub(crate) openclaw: Option<OpenClawConfig>,
+    /// Grok Build CLI configuration.
+    pub(crate) grok: Option<GrokConfig>,
     /// Kilo configuration.
     pub(crate) kilo: Option<KiloConfig>,
     /// GitHub Copilot CLI configuration.
@@ -213,6 +215,21 @@ pub(crate) struct OpenClawCommandsConfig {
     pub(crate) daily: Option<OpenClawOptions>,
     pub(crate) monthly: Option<OpenClawOptions>,
     pub(crate) session: Option<OpenClawOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GrokConfig {
+    pub(crate) defaults: Option<GrokOptions>,
+    pub(crate) commands: Option<GrokCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GrokCommandsConfig {
+    pub(crate) daily: Option<GrokOptions>,
+    pub(crate) monthly: Option<GrokOptions>,
+    pub(crate) session: Option<GrokOptions>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -469,6 +486,15 @@ pub(crate) struct OpenClawOptions {
     pub(crate) open_claw_path: Option<String>,
 }
 
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct GrokOptions {
+    #[serde(flatten)]
+    pub(crate) shared: SharedOptions,
+    /// Path or comma-separated paths to Grok home directories (default: ~/.grok).
+    pub(crate) grok_path: Option<String>,
+}
+
 #[derive(Clone, Copy, Debug, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub(crate) enum ConfigCostMode {
@@ -634,6 +660,15 @@ impl OpenClawOptions {
         Self {
             shared: SharedOptions::from_map(map),
             open_claw_path: string_option(map, "openClawPath"),
+        }
+    }
+}
+
+impl GrokOptions {
+    pub(crate) fn from_map(map: &Map<String, Value>) -> Self {
+        Self {
+            shared: SharedOptions::from_map(map),
+            grok_path: string_option(map, "grokPath"),
         }
     }
 }
@@ -1103,8 +1138,8 @@ mod tests {
             "ccusage-config",
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi",
+                "qwen", "droid",
             ],
         );
         assert!(

--- a/rust/crates/ccusage/src/cost.rs
+++ b/rust/crates/ccusage/src/cost.rs
@@ -36,6 +36,21 @@ pub(crate) fn calculate_cost_for_usage(
     }
 }
 
+pub(crate) fn calculate_cost_for_pricing_candidates<'a>(
+    candidates: impl IntoIterator<Item = &'a str>,
+    usage: crate::TokenUsageRaw,
+    cost_usd: Option<f64>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> f64 {
+    match mode {
+        CostMode::Display => cost_usd.unwrap_or(0.0),
+        CostMode::Auto => cost_usd
+            .unwrap_or_else(|| calculate_cost_from_candidate_tokens(candidates, usage, pricing)),
+        CostMode::Calculate => calculate_cost_from_candidate_tokens(candidates, usage, pricing),
+    }
+}
+
 pub(crate) fn missing_pricing_model_for_usage(
     model: Option<&str>,
     usage: crate::TokenUsageRaw,
@@ -47,6 +62,27 @@ pub(crate) fn missing_pricing_model_for_usage(
         return None;
     }
     missing_pricing_model_for_token_total(model, crate::total_usage_tokens(usage), pricing)
+}
+
+pub(crate) fn missing_pricing_model_for_pricing_candidates<'a>(
+    display_model: &str,
+    candidates: impl IntoIterator<Item = &'a str>,
+    total_tokens: u64,
+    cost_usd: Option<f64>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<String> {
+    if total_tokens == 0
+        || mode == CostMode::Display
+        || (mode == CostMode::Auto && cost_usd.is_some())
+    {
+        return None;
+    }
+    let pricing = pricing?;
+    pricing
+        .find_for_candidates(candidates)
+        .is_none()
+        .then(|| crate::model_aliases::resolve_model_name(display_model).into_owned())
 }
 
 pub(crate) fn missing_pricing_model_for_token_total(
@@ -92,6 +128,24 @@ fn calculate_cost_from_tokens(
     let Some(pricing) = pricing.and_then(|pricing| pricing.find(model)) else {
         return 0.0;
     };
+    calculate_cost_from_pricing(usage, pricing)
+}
+
+fn calculate_cost_from_candidate_tokens<'a>(
+    candidates: impl IntoIterator<Item = &'a str>,
+    usage: crate::TokenUsageRaw,
+    pricing: Option<&PricingMap>,
+) -> f64 {
+    let Some(pricing) = pricing.and_then(|pricing| pricing.find_for_candidates(candidates)) else {
+        return 0.0;
+    };
+    calculate_cost_from_pricing(usage, pricing)
+}
+
+fn calculate_cost_from_pricing(
+    usage: crate::TokenUsageRaw,
+    pricing: crate::pricing::Pricing,
+) -> f64 {
     let multiplier = if matches!(usage.speed, Some(Speed::Fast)) {
         pricing.fast_multiplier
     } else {

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -30,7 +30,8 @@ pub(crate) use blocks::{
     identify_session_blocks, print_active_block_detail, print_blocks_table, sort_blocks,
 };
 pub(crate) use cost::{
-    calculate_cost, calculate_cost_for_usage, missing_pricing_model_for_candidates,
+    calculate_cost, calculate_cost_for_pricing_candidates, calculate_cost_for_usage,
+    missing_pricing_model_for_candidates, missing_pricing_model_for_pricing_candidates,
     missing_pricing_model_for_token_total, missing_pricing_model_for_usage,
 };
 pub(crate) use date_utils::*;
@@ -146,12 +147,14 @@ fn main() -> Result<()> {
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
+        Some(Command::Grok(args)) => adapter::grok::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
                 kind: AgentReportKind::Daily,
                 pi_path: None,
                 open_claw_path: None,
+                grok_path: None,
                 codex_speed: cli::CodexSpeed::Auto,
             };
             adapter::all::run(args)

--- a/rust/crates/ccusage/src/output.rs
+++ b/rust/crates/ccusage/src/output.rs
@@ -369,17 +369,40 @@ pub(crate) fn missing_pricing_warnings_for_models<'a>(
     models
         .into_iter()
         .map(|model| {
-            if offline {
+            if is_dynamic_router_model(model) {
                 format!(
-                    "WARN  Missing embedded pricing for {model}; cost excludes this model. Run without --offline or update ccusage after pricing is added."
+                    "WARN  No deterministic token rate for dynamic model router {model}; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model."
+                )
+            } else if is_unsupported_or_undetected_model(model) {
+                format!(
+                    "WARN  Unsupported or undetected usage source for {model}; cost excludes this usage. Capture a real-log fixture with the resolved model before adding pricing."
+                )
+            } else if offline {
+                format!(
+                    "WARN  Missing embedded pricing for fixed model {model}; cost excludes this model. Run without --offline, update ccusage, or configure pricingOverrides."
                 )
             } else {
                 format!(
-                    "WARN  Missing pricing for {model}; cost excludes this model. Update pricing or run again after LiteLLM has the model."
+                    "WARN  Missing pricing for fixed model {model}; cost excludes this model. Update pricing or configure pricingOverrides."
                 )
             }
         })
         .collect()
+}
+
+fn is_dynamic_router_model(model: &str) -> bool {
+    model == "openrouter/auto"
+        || model == "ark-code-latest"
+        || model == "antigravity-gemini-3-flash"
+        || model.starts_with("openrouter/fusion")
+        || model.starts_with("fusion-")
+}
+
+fn is_unsupported_or_undetected_model(model: &str) -> bool {
+    matches!(
+        model,
+        "unknown" | "unknown-model" | "unknown-model-xyz" | "<unknown>"
+    )
 }
 
 pub(crate) fn json_float(value: f64) -> Value {
@@ -662,8 +685,43 @@ mod tests {
         assert_eq!(
             missing_pricing_warnings(&[row], false),
             vec![
-                "WARN  Missing pricing for claude-sonnet-4-20250514; cost excludes this model. Update pricing or run again after LiteLLM has the model.",
-                "WARN  Missing pricing for gpt-5.2-codex; cost excludes this model. Update pricing or run again after LiteLLM has the model.",
+                "WARN  Missing pricing for fixed model claude-sonnet-4-20250514; cost excludes this model. Update pricing or configure pricingOverrides.",
+                "WARN  Missing pricing for fixed model gpt-5.2-codex; cost excludes this model. Update pricing or configure pricingOverrides.",
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_pricing_warnings_explain_dynamic_routers() {
+        assert_eq!(
+            missing_pricing_warnings_for_models(
+                [
+                    "openrouter/auto",
+                    "openrouter/fusion",
+                    "openrouter/fusion-alpha",
+                    "fusion-router",
+                    "ark-code-latest",
+                    "antigravity-gemini-3-flash",
+                ],
+                false,
+            ),
+            vec![
+                "WARN  No deterministic token rate for dynamic model router antigravity-gemini-3-flash; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+                "WARN  No deterministic token rate for dynamic model router ark-code-latest; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+                "WARN  No deterministic token rate for dynamic model router fusion-router; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+                "WARN  No deterministic token rate for dynamic model router openrouter/auto; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+                "WARN  No deterministic token rate for dynamic model router openrouter/fusion; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+                "WARN  No deterministic token rate for dynamic model router openrouter/fusion-alpha; cost excludes this usage. Configure pricingOverrides only if your logs expose the resolved underlying model.",
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_pricing_warnings_explain_unsupported_or_undetected_sources() {
+        assert_eq!(
+            missing_pricing_warnings_for_models(["unknown"], false),
+            vec![
+                "WARN  Unsupported or undetected usage source for unknown; cost excludes this usage. Capture a real-log fixture with the resolved model before adding pricing.",
             ]
         );
     }
@@ -676,7 +734,7 @@ mod tests {
         assert_eq!(
             missing_pricing_warnings(&[row], true),
             vec![
-                "WARN  Missing embedded pricing for gpt-5.2-codex; cost excludes this model. Run without --offline or update ccusage after pricing is added.",
+                "WARN  Missing embedded pricing for fixed model gpt-5.2-codex; cost excludes this model. Run without --offline, update ccusage, or configure pricingOverrides.",
             ]
         );
     }

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -9,7 +9,7 @@ use ccusage_cli::PricingOverride;
 use serde::Deserialize;
 use serde_json::Value;
 
-use crate::fast::FxHashMap;
+use crate::fast::{FxHashMap, FxHashSet};
 
 const BUILD_TIME_PRICING_JSON: &str =
     include_str!(concat!(env!("OUT_DIR"), "/litellm-pricing.json"));
@@ -60,6 +60,7 @@ impl Pricing {
 pub(crate) struct PricingMap {
     entries: FxHashMap<String, Pricing>,
     context_limits: FxHashMap<String, u64>,
+    override_keys: FxHashSet<String>,
     enable_models_dev_fallback: bool,
     enable_embedded_models_dev_fallback: bool,
 }
@@ -387,6 +388,62 @@ impl PricingMap {
             })
     }
 
+    pub(crate) fn find_for_candidates<'a>(
+        &self,
+        candidates: impl IntoIterator<Item = &'a str>,
+    ) -> Option<Pricing> {
+        let candidates = candidates.into_iter().collect::<Vec<_>>();
+        candidates
+            .iter()
+            .find_map(|candidate| self.find_override_entry(candidate))
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .find_map(|candidate| self.entries.get(*candidate).copied())
+            })
+            .or_else(|| {
+                candidates
+                    .iter()
+                    .find_map(|candidate| self.find_entry_or_alias(candidate))
+            })
+            .or_else(|| {
+                candidates.iter().find_map(|candidate| {
+                    let alias = crate::model_aliases::resolve_model_name(candidate);
+                    let resolved_alias = alias.as_ref();
+                    (resolved_alias != *candidate)
+                        .then(|| self.find_entry_or_alias(resolved_alias))
+                        .flatten()
+                })
+            })
+            .or_else(|| {
+                self.enable_models_dev_fallback
+                    .then(|| {
+                        models_dev_pricing().and_then(|pricing| {
+                            candidates
+                                .iter()
+                                .find_map(|candidate| pricing.find_entry_or_alias(candidate))
+                        })
+                    })
+                    .flatten()
+            })
+            .or_else(|| {
+                self.enable_embedded_models_dev_fallback
+                    .then(|| {
+                        candidates.iter().find_map(|candidate| {
+                            embedded_models_dev_pricing().find_entry_or_alias(candidate)
+                        })
+                    })
+                    .flatten()
+            })
+    }
+
+    fn find_override_entry(&self, model: &str) -> Option<Pricing> {
+        self.override_keys
+            .contains(model)
+            .then(|| self.entries.get(model).copied())
+            .flatten()
+    }
+
     fn find_entry_or_alias(&self, model: &str) -> Option<Pricing> {
         self.find_entry(model)
             .or_else(|| pricing_alias(model).and_then(|alias| self.find_entry(alias)))
@@ -546,6 +603,7 @@ impl PricingMap {
         };
 
         self.entries.insert(model.to_string(), pricing);
+        self.override_keys.insert(model.to_string());
         if let Some(limit) = override_value.max_input_tokens {
             self.context_limits.insert(model.to_string(), limit);
         }
@@ -781,21 +839,59 @@ impl PricingMap {
                     .unwrap_or(1.0),
             },
         );
+        let fixed_cached_input_pricing = |input: f64, output: f64, cache_read: f64| Pricing {
+            input,
+            output,
+            cache_create: input,
+            cache_read,
+            cache_read_explicit: true,
+            input_above_200k: None,
+            output_above_200k: None,
+            cache_create_above_200k: None,
+            cache_read_above_200k: None,
+            fast_multiplier: 1.0,
+        };
+        // Source: https://docs.x.ai/developers/pricing
+        self.entries.insert(
+            "grok-build-0.1".to_string(),
+            fixed_cached_input_pricing(1.0e-6, 2.0e-6, 0.2e-6),
+        );
         self.entries.insert(
             "grok-4.3".to_string(),
-            Pricing {
-                input: 1.25e-6,
-                output: 2.5e-6,
-                cache_create: 1.25e-6,
-                cache_read: 0.125e-6,
-                cache_read_explicit: false,
-                input_above_200k: None,
-                output_above_200k: None,
-                cache_create_above_200k: None,
-                cache_read_above_200k: None,
-                fast_multiplier: 1.0,
-            },
+            fixed_cached_input_pricing(1.25e-6, 2.5e-6, 0.2e-6),
         );
+        // Source: OpenRouter / LiteLLM list rates for x-ai/grok-4.5 (2026-07-13):
+        // $2/M input, $6/M output, $0.50/M cache read.
+        let grok_45 = fixed_cached_input_pricing(2.0e-6, 6.0e-6, 0.5e-6);
+        self.entries.insert("grok-4.5".to_string(), grok_45);
+        self.entries.insert("xai/grok-4.5".to_string(), grok_45);
+        self.entries.insert("x-ai/grok-4.5".to_string(), grok_45);
+        // Provisional: no public list price for grok-composer-2.5-fast at implement
+        // time; aligned with LiteLLM xai/grok-code-fast rates ($0.20/$1.50/$0.02 per M).
+        let grok_composer = fixed_cached_input_pricing(0.2e-6, 1.5e-6, 0.02e-6);
+        self.entries
+            .insert("grok-composer-2.5-fast".to_string(), grok_composer);
+        self.entries
+            .insert("xai/grok-composer-2.5-fast".to_string(), grok_composer);
+        self.entries
+            .insert("x-ai/grok-composer-2.5-fast".to_string(), grok_composer);
+        // Source: https://api-docs.deepseek.com/quick_start/pricing
+        let deepseek_v4_flash = fixed_cached_input_pricing(0.14e-6, 0.28e-6, 0.0028e-6);
+        self.entries
+            .insert("deepseek-v4-flash".to_string(), deepseek_v4_flash);
+        self.entries
+            .insert("deepseek/deepseek-v4-flash".to_string(), deepseek_v4_flash);
+        let deepseek_v4_pro = fixed_cached_input_pricing(0.435e-6, 0.87e-6, 0.003625e-6);
+        self.entries
+            .insert("deepseek-v4-pro".to_string(), deepseek_v4_pro);
+        self.entries
+            .insert("deepseek/deepseek-v4-pro".to_string(), deepseek_v4_pro);
+        // Source: https://platform.minimax.io/docs/guides/pricing-paygo
+        let minimax_m25 = fixed_cached_input_pricing(0.3e-6, 1.2e-6, 0.03e-6);
+        self.entries.insert("MiniMax-M2.5".to_string(), minimax_m25);
+        self.entries.insert("minimax-m2.5".to_string(), minimax_m25);
+        self.entries
+            .insert("minimax/minimax-m2.5".to_string(), minimax_m25);
         // Source: https://platform.kimi.ai/docs/pricing/chat-k25
         self.entries.insert(
             "moonshot/kimi-k2.5".to_string(),
@@ -982,9 +1078,21 @@ impl PricingMap {
                 ..glm_base
             },
         );
+        let glm_52 = Pricing {
+            input: 1.4e-6,
+            output: 4.4e-6,
+            cache_read: 0.26e-6,
+            ..glm_base
+        };
+        self.entries.insert("glm-5.2".to_string(), glm_52);
+        self.entries.insert("zai/glm-5.2".to_string(), glm_52);
         self.context_limits.insert("gpt-5.5".to_string(), 1_050_000);
         self.context_limits
             .insert("grok-4.3".to_string(), 1_000_000);
+        // OpenRouter context_length for x-ai/grok-4.5.
+        self.context_limits.insert("grok-4.5".to_string(), 500_000);
+        self.context_limits
+            .insert("grok-composer-2.5-fast".to_string(), 256_000);
         self.context_limits.insert("gpt-5.4".to_string(), 1_050_000);
         for model in [
             "claude-opus-4-8",
@@ -1153,6 +1261,7 @@ fn normalized_pricing_key(value: &str) -> Cow<'_, str> {
 fn pricing_alias(model: &str) -> Option<&'static str> {
     match model {
         "gpt-5.3-spark" => Some("gpt-5.3-codex-spark"),
+        "minimax-m2.5" => Some("MiniMax-M2.5"),
         _ => None,
     }
 }
@@ -1300,6 +1409,13 @@ mod tests {
     fn embedded_pricing_includes_z_ai_glm_models_for_offline_reports() {
         let pricing = PricingMap::load_embedded();
 
+        let glm_52 = pricing.find("glm-5.2").unwrap();
+        assert_eq!(glm_52.input, 1.4e-6);
+        assert_eq!(glm_52.output, 4.4e-6);
+        assert_eq!(glm_52.cache_create, 0.0);
+        assert_eq!(glm_52.cache_read, 0.26e-6);
+        assert!(glm_52.cache_read_explicit);
+
         let glm_51 = pricing.find("glm-5.1").unwrap();
         assert_eq!(glm_51.input, 1.4e-6);
         assert_eq!(glm_51.output, 4.4e-6);
@@ -1344,6 +1460,54 @@ mod tests {
         assert_eq!(zai_glm_45.cache_create, 0.0);
         assert_eq!(zai_glm_45.cache_read, 0.11e-6);
         assert_eq!(pricing.context_limit("zai/glm-4.5"), Some(128_000));
+    }
+
+    #[test]
+    fn embedded_pricing_includes_deterministic_coding_model_rates() {
+        let pricing = PricingMap::load_embedded();
+
+        let deepseek_flash = pricing.find("deepseek-v4-flash").unwrap();
+        assert_eq!(deepseek_flash.input, 0.14e-6);
+        assert_eq!(deepseek_flash.output, 0.28e-6);
+        assert_eq!(deepseek_flash.cache_read, 0.0028e-6);
+        assert!(deepseek_flash.cache_read_explicit);
+
+        let deepseek_pro = pricing.find("deepseek-v4-pro").unwrap();
+        assert_eq!(deepseek_pro.input, 0.435e-6);
+        assert_eq!(deepseek_pro.output, 0.87e-6);
+        assert_eq!(deepseek_pro.cache_read, 0.003625e-6);
+        assert!(deepseek_pro.cache_read_explicit);
+
+        let grok_build = pricing.find("grok-build-0.1").unwrap();
+        assert_eq!(grok_build.input, 1.0e-6);
+        assert_eq!(grok_build.output, 2.0e-6);
+        assert_eq!(grok_build.cache_read, 0.2e-6);
+        assert!(grok_build.cache_read_explicit);
+
+        let grok_43 = pricing.find("grok-4.3").unwrap();
+        assert_eq!(grok_43.input, 1.25e-6);
+        assert_eq!(grok_43.output, 2.5e-6);
+        assert_eq!(grok_43.cache_read, 0.2e-6);
+        assert!(grok_43.cache_read_explicit);
+
+        let grok_45 = pricing.find("grok-4.5").unwrap();
+        assert_eq!(grok_45.input, 2.0e-6);
+        assert_eq!(grok_45.output, 6.0e-6);
+        assert_eq!(grok_45.cache_read, 0.5e-6);
+        assert!(grok_45.cache_read_explicit);
+        assert_eq!(pricing.find("xai/grok-4.5").unwrap().input, grok_45.input);
+
+        let grok_composer = pricing.find("grok-composer-2.5-fast").unwrap();
+        assert_eq!(grok_composer.input, 0.2e-6);
+        assert_eq!(grok_composer.output, 1.5e-6);
+        assert_eq!(grok_composer.cache_read, 0.02e-6);
+
+        let minimax = pricing.find("MiniMax-M2.5").unwrap();
+        assert_eq!(minimax.input, 0.3e-6);
+        assert_eq!(minimax.output, 1.2e-6);
+        assert_eq!(minimax.cache_read, 0.03e-6);
+        assert!(minimax.cache_read_explicit);
+        assert_eq!(pricing.find("minimax-m2.5").unwrap().input, minimax.input);
     }
 
     #[test]
@@ -1796,7 +1960,12 @@ mod tests {
     fn embedded_pricing_includes_gpt_5_5_for_offline_codex_reports() {
         let pricing = PricingMap::load_embedded();
         let gpt_55 = pricing.find("gpt-5.5").unwrap();
+        let gpt_54 = pricing.find("gpt-5.4").unwrap();
 
+        assert_eq!(gpt_54.input, 2.5e-6);
+        assert_eq!(gpt_54.output, 15e-6);
+        assert_eq!(gpt_54.cache_read, 0.25e-6);
+        assert!(gpt_54.cache_read_explicit);
         assert_eq!(gpt_55.input, 5e-6);
         assert_eq!(gpt_55.output, 30e-6);
         assert_eq!(gpt_55.cache_read, 0.5e-6);

--- a/rust/crates/ccusage/src/progress.rs
+++ b/rust/crates/ccusage/src/progress.rs
@@ -30,6 +30,7 @@ pub(crate) enum UsageLoadAgent {
     Gemini,
     Kimi,
     OpenClaw,
+    Grok,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -60,6 +61,7 @@ fn agent_label(agent: UsageLoadAgent) -> &'static str {
         UsageLoadAgent::Gemini => "Gemini CLI",
         UsageLoadAgent::Kimi => "Kimi",
         UsageLoadAgent::OpenClaw => "OpenClaw",
+        UsageLoadAgent::Grok => "Grok",
     }
 }
 

--- a/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage/src/snapshots/ccusage__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -1134,6 +1133,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "droid",
     "gemini",
     "goose",
+    "grok",
     "hermes",
     "kilo",
     "kimi",


### PR DESCRIPTION
## Summary

Adds a first-class Grok Build CLI agent source so local Grok TUI usage appears in `ccusage grok …` and unified multi-agent reports (`ccusage daily`, etc.), with token totals and estimated USD cost.

## What changed

- New `adapter/grok` module: discover `~/.grok/sessions/**/updates.jsonl`, parse `turn_completed` usage / `modelUsage`, load into shared report paths
- CLI: `ccusage grok daily|monthly|session`, config schema (`grokPath` / `GROK_HOME` / `--grok-path`), all-agent rollup + progress label
- Pricing: candidate-key cost resolution and fixed rates for active Grok models (`grok-4.5`, `grok-composer-2.5-fast`, plus existing keys)
- Docs: VitePress guide, source-support Q&A, README agent table, config/cost-mode cross-links

## Why

Grok Build CLI already writes per-turn usage under `~/.grok`, but without an adapter those sessions never show up in ccusage. Users who run Grok heavily get incomplete multi-agent cost reports.

## Testing

- Adapter unit tests (paths/parser/loader) via cargo package tests during development
- Live smoke on a machine with `~/.grok/sessions`: `ccusage grok daily` and unified `ccusage daily` show Grok with model labels like `[grok] grok-4.5`

## Notes

- Default data root: `~/.grok` (override with `GROK_HOME` or `--grok-path`)
- Reasoning tokens billed at output rate; display output column stays raw output tokens
- Branch may need a rebase onto current `main` before merge (main has moved since the feature base)
- `LOCAL_PRICING_PATCH.md` and `docs/plans/…` are local/planning notes on the fork branch; happy to drop them from the PR if preferred

## Plan

See `docs/plans/2026-07-13-001-feat-grok-cli-usage-adapter-plan.md` for acceptance criteria and design notes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786629670&installation_id=139163553&pr_number=1447&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1447&signature=4c51d638d5e74844dd62896ab3611863239e84bb9a54f144c2402b150d25ebe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a first-class Grok Build CLI adapter so local sessions under `~/.grok` show up in `ccusage grok …` and unified daily/monthly/session reports with token totals and estimated USD cost. This expands multi-agent coverage and keeps Grok usage in the same views as other agents.

- **New Features**
  - Adapter: scans `~/.grok/sessions/**/updates.jsonl`, reads `turn_completed` `modelUsage`, and loads per-model rows with token totals.
  - CLI: new `ccusage grok daily|monthly|session` commands, Grok now included in `ccusage daily|monthly|session`, and a Grok progress label.
  - Config: path overrides via `--grok-path`, `GROK_HOME`, or `grok.defaults.grokPath`.
  - Pricing: candidate-key lookup for costs, fixed rates for active Grok models like `grok-4.5` and `grok-composer-2.5-fast`, and reasoning tokens billed at the output rate.
  - Docs: new Grok guide, updated agent tables, and cost-mode notes about token-based estimates.

- **Migration**
  - Default data root is `~/.grok`; override with `GROK_HOME` or `--grok-path`.
  - Run `ccusage grok daily|monthly|session` for focused reports, or `ccusage daily` for all agents.
  - If a model is missing from the snapshot or your contract differs, set `pricingOverrides` in config; token-based costs are estimates.

<sup>Written for commit c9f8a963c057ca0fee361ee8ed4fa9487ccda280. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1447?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grok Build CLI as a supported `ccusage` data source, including `ccusage grok daily|monthly|session` and `--grok-path` targeting.
  * Added automatic local discovery of Grok session `updates.jsonl` data and included Grok in combined/all reports.
* **Bug Fixes**
  * Improved model labeling and missing-pricing handling to provide clearer warnings for dynamic/unknown models.
* **Documentation**
  * Added a Grok Build CLI guide, updated navigation/examples, and clarified that token-list cost estimates may differ from invoices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->