### PR TITLE
fix(pricing): correct claude-sonnet-5 $0 cost behind TLS-intercepting proxies

### DIFF
--- a/docs/guide/cost-modes.md
+++ b/docs/guide/cost-modes.md
@@ -311,6 +311,18 @@ ccusage daily --mode auto
 ccusage daily --mode calculate
 ```
 
+**Cause**: The online pricing fetch fails behind a TLS-intercepting proxy (Cloudflare WARP, Zscaler, and similar), so a model missing from the embedded pricing snapshot is costed at $0
+
+**Solution**:
+
+```bash
+# Point ccusage at a CA bundle that includes your proxy CA
+export SSL_CERT_FILE="/etc/ssl/cert.pem"
+ccusage daily --mode calculate
+```
+
+See [Environment Variables](/guide/environment-variables#ssl_cert_file) for details.
+
 ### Issue: Inconsistent cost calculations
 
 **Cause**: Mixed use of different modes or pricing changes

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -122,6 +122,17 @@ export CCUSAGE_OFFLINE=1
 ccusage daily  # Runs in offline mode
 ```
 
+### SSL_CERT_FILE
+
+Trust a custom CA bundle (PEM format) for the online pricing fetch instead of the built-in Mozilla root certificates. Set this when ccusage runs behind a TLS-intercepting proxy (Cloudflare WARP, Zscaler, Netskope, and similar corporate setups) whose CA is not publicly trusted:
+
+```bash
+export SSL_CERT_FILE="/etc/ssl/cert.pem"  # bundle that includes your proxy CA
+ccusage daily
+```
+
+If the fetch still fails, ccusage falls back to the pricing snapshot embedded in the binary.
+
 ### NO_COLOR
 
 Disable colored output (standard CLI convention):
@@ -210,7 +221,7 @@ To see which environment variables are being used:
 
 ```bash
 # Show all environment variables
-env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
+env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL|SSL_CERT_FILE"
 
 # Debug mode shows environment variable usage
 LOG_LEVEL=4 ccusage daily --debug

--- a/flake.lock
+++ b/flake.lock
@@ -137,11 +137,11 @@
     "litellm": {
       "flake": false,
       "locked": {
-        "lastModified": 1781152268,
-        "narHash": "sha256-s/jnp6sYuF2dM2zF/yfr5t8sdeQPWZrnkrwBad6aF3k=",
+        "lastModified": 1784162231,
+        "narHash": "sha256-5W2/5gXNYfzhPfHR41LgnoFXj0yi1gY3Sz2GEehspAo=",
         "owner": "BerriAI",
         "repo": "litellm",
-        "rev": "49ca04d8c3ddea336237ce6f3082dbc26d19e944",
+        "rev": "35e947198cfe406c55c8ef8b9587291478dd1ff7",
         "type": "github"
       },
       "original": {

--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -1461,10 +1461,12 @@ fn fetch_models_dev_json() -> std::io::Result<String> {
 }
 
 fn fetch_json_url(url: &str) -> std::io::Result<String> {
-    let agent = ureq::Agent::config_builder()
-        .timeout_global(Some(Duration::from_secs(PRICING_FETCH_TIMEOUT_SECONDS)))
-        .build()
-        .new_agent();
+    let mut config = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(PRICING_FETCH_TIMEOUT_SECONDS)));
+    if let Some(tls_config) = ssl_cert_file_tls_config()? {
+        config = config.tls_config(tls_config);
+    }
+    let agent = config.build().new_agent();
     let mut response = agent
         .get(url)
         .call()
@@ -1481,6 +1483,41 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
         .limit(PRICING_FETCH_MAX_BYTES)
         .read_to_string()
         .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))
+}
+
+/// Trust the CA bundle from `SSL_CERT_FILE` instead of the embedded Mozilla
+/// roots, so pricing fetches work behind TLS-intercepting proxies whose CA is
+/// not publicly trusted.
+fn ssl_cert_file_tls_config() -> std::io::Result<Option<ureq::tls::TlsConfig>> {
+    let Some(path) = std::env::var_os("SSL_CERT_FILE") else {
+        return Ok(None);
+    };
+    let path = std::path::PathBuf::from(path);
+    let pem = std::fs::read(&path)?;
+    let mut certs = Vec::new();
+    for item in ureq::tls::parse_pem(&pem) {
+        match item {
+            Ok(ureq::tls::PemItem::Certificate(cert)) => certs.push(cert),
+            Ok(_) => {}
+            Err(error) => {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("invalid PEM in SSL_CERT_FILE {}: {error}", path.display()),
+                ));
+            }
+        }
+    }
+    if certs.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("no certificates in SSL_CERT_FILE {}", path.display()),
+        ));
+    }
+    Ok(Some(
+        ureq::tls::TlsConfig::builder()
+            .root_certs(ureq::tls::RootCerts::new_with_certs(&certs))
+            .build(),
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1439.

## What Changed

Two independent fixes for `claude-sonnet-5` being costed at $0.00 when the online pricing fetch fails and ccusage falls back to embedded pricing:

1. **Bump the pinned LiteLLM revision** in `flake.lock` from 2026-06-11 to 2026-07-16. The old pin predates `claude-sonnet-5`, so the embedded snapshot resolved it to $0. The new snapshot includes the model ($2/M input, $10/M output). `build.rs` embeds pricing from this pin for both Nix and plain Cargo builds.
2. **Honor `SSL_CERT_FILE` in the pricing fetch.** The binary uses rustls with only the embedded Mozilla roots, so the fetch fails behind TLS-intercepting proxies (Cloudflare WARP, Zscaler, Netskope) with no way to trust a corporate CA. When `SSL_CERT_FILE` points at a PEM bundle, its certificates replace the embedded roots for the LiteLLM and models.dev fetches. A missing or invalid bundle surfaces as a fetch error and takes the existing warn-and-fall-back path.

Documented `SSL_CERT_FILE` in `docs/guide/environment-variables.md` and added the proxy cause to the "$0.00 costs" troubleshooting section in `docs/guide/cost-modes.md`.

Enabling ureq's `platform-verifier` (OS trust store) was considered but left as a possible follow-up; it needs a binary-size assessment across the six platform packages.

## Testing

- `cargo check -p ccusage` passes.
- Verified the new pinned snapshot and the generated build-time `litellm-pricing.json` both contain `claude-sonnet-5` with non-zero rates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1450"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786755504&installation_id=139163553&pr_number=1450&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1450&signature=4f404408fb0d3b6ab48f2f43cb07f8f63ef015b4206a77b1fbca5c66664c8789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `claude-sonnet-5` showing $0.00 cost when pricing fetch fails, especially behind TLS‑intercepting proxies. Updates embedded pricing and adds `SSL_CERT_FILE` support so online pricing works in corporate networks.

- **Bug Fixes**
  - Bumped embedded `litellm` snapshot to include `claude-sonnet-5` rates, fixing $0.00 fallback.
  - Pricing fetch now honors `SSL_CERT_FILE` to trust a custom CA bundle; failures still fall back to embedded pricing. Updated docs with setup and troubleshooting.

<sup>Written for commit 66ed321aee7ce12b2de5549720edcb92244b2108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring a custom CA certificate bundle with `SSL_CERT_FILE`, improving online pricing requests in TLS-intercepting proxy environments.

* **Bug Fixes**
  * Improved guidance for cases where costs show as `$0.00` when pricing data can’t be fetched, including the proxy/TLS cause.

* **Documentation**
  * Updated troubleshooting and environment-variable documentation for `SSL_CERT_FILE`, including remediation steps and noting fallback behavior when online pricing retrieval fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->