### PR TITLE
fix(codex): correct legacy token total fallback

### DIFF
--- a/rust/crates/ccusage/src/adapter/codex/types.rs
+++ b/rust/crates/ccusage/src/adapter/codex/types.rs
@@ -190,10 +190,11 @@ impl<'de> Deserialize<'de> for CodexRawUsage {
                 .unwrap_or(0),
             output_tokens: output,
             reasoning_output_tokens: reasoning,
-            total_tokens: fields
-                .total_tokens
-                .filter(|total| *total > 0 || input + output + reasoning == 0)
-                .unwrap_or(input + output + reasoning),
+            total_tokens: match fields.total_tokens {
+                None => input + output,
+                Some(0) => input + output + reasoning,
+                Some(total) => total,
+            },
         })
     }
 }
@@ -379,4 +380,38 @@ where
     }
 
     deserializer.deserialize_any(OptionalU64Visitor)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derives_total_tokens_without_double_counting_reasoning() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "reasoning_output_tokens": 20
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 150);
+    }
+
+    #[test]
+    fn derives_explicit_zero_total_tokens_from_all_nonzero_components() {
+        let usage: CodexRawUsage = serde_json::from_str(
+            r#"{
+                "input_tokens": 9,
+                "output_tokens": 4,
+                "reasoning_output_tokens": 1,
+                "total_tokens": 0
+            }"#,
+        )
+        .expect("usage should deserialize");
+
+        assert_eq!(usage.total_tokens, 14);
+    }
 }


### PR DESCRIPTION
## Summary

- derive a missing Codex `total_tokens` value as input plus output
- avoid adding reasoning a second time, since Codex reports reasoning as a subset of output
- keep the existing explicit-zero compatibility behavior unchanged
- add regression coverage with nonzero reasoning and no source total

The expected invariant and fixture/oracle method follow the [Logpile accounting review](https://github.com/MaxGhenis/logpile/blob/main/docs/reviews/2026-07-11-sol-full-review.md). The exact 2026-07-18 matrix behind this change is published as the [2026-07-18 ccusage verification](https://github.com/MaxGhenis/logpile/blob/main/docs/reviews/2026-07-18-ccusage-verification.md).

## Testing

- `cargo +1.96.0 test --manifest-path rust/Cargo.toml --workspace --offline` (445 passed)
- focused absent-total and explicit-zero regressions pass
- all six legacy rows across the patched harness/full-CLI matrix now report the oracle `totalTokens`

Prepared with AI assistance; I reviewed the implementation and test results.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1458"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787055796&installation_id=139163553&pr_number=1458&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1458&signature=0d092b88ea4913b8a3c8864028018bfb999228e7e8cb442ccf1345861a33ffa5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Codex legacy `total_tokens` fallback to compute correct totals and avoid double-counting reasoning tokens. Preserves explicit-zero behavior and adds regression tests for missing totals and explicit zero.

- Bug Fixes
  - If `total_tokens` is missing: derive as input + output (exclude reasoning).
  - If `total_tokens` is 0: derive as input + output + reasoning (keep legacy semantics).
  - Added focused tests for both cases.

<sup>Written for commit 705c85fc76262953041f66e98ecd0cfd5251cdd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected token usage totals when usage data omits a total, preventing reasoning tokens from being counted twice.
  * Improved handling of explicitly reported zero totals by calculating usage from the available input, output, and reasoning values.
  * Preserved explicitly provided nonzero totals without modification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->