### PR TITLE
feat(pricing): add Kimi K3 pricing

### DIFF
--- a/rust/crates/ccusage/src/pricing.rs
+++ b/rust/crates/ccusage/src/pricing.rs
@@ -948,6 +948,23 @@ impl PricingMap {
                 fast_multiplier: 1.0,
             },
         );
+        // Source: https://platform.kimi.ai/docs/pricing/chat-k3
+        self.entries.insert(
+            "moonshot/kimi-k3".to_string(),
+            Pricing {
+                input: 3e-6,
+                output: 15e-6,
+                cache_create: 0.0,
+                cache_read: 0.3e-6,
+                cache_read_explicit: true,
+                input_above_200k: None,
+                output_above_200k: None,
+                cache_create_above_200k: None,
+                cache_read_above_200k: None,
+                long_context_threshold: None,
+                fast_multiplier: 1.0,
+            },
+        );
         let gpt_5_1_pricing = Pricing {
             input: 1.25e-6,
             output: 10e-6,
@@ -1156,6 +1173,8 @@ impl PricingMap {
             .insert("moonshot/kimi-k2.5".to_string(), 262_144);
         self.context_limits
             .insert("moonshot/kimi-k2.6".to_string(), 262_144);
+        self.context_limits
+            .insert("moonshot/kimi-k3".to_string(), 1_048_576);
 
         for model in [
             "claude-opus-4-5",
@@ -1520,6 +1539,7 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         let kimi_k25 = pricing.find("moonshot/kimi-k2.5").unwrap();
         let kimi_k26 = pricing.find("moonshot/kimi-k2.6").unwrap();
+        let kimi_k3 = pricing.find("moonshot/kimi-k3").unwrap();
 
         assert_eq!(kimi_k25.input, 0.6e-6);
         assert_eq!(kimi_k25.output, 3e-6);
@@ -1529,8 +1549,13 @@ mod tests {
         assert_eq!(kimi_k26.output, 4e-6);
         assert_eq!(kimi_k26.cache_read, 0.16e-6);
         assert!(kimi_k26.cache_read_explicit);
+        assert_eq!(kimi_k3.input, 3e-6);
+        assert_eq!(kimi_k3.output, 15e-6);
+        assert_eq!(kimi_k3.cache_read, 0.3e-6);
+        assert!(kimi_k3.cache_read_explicit);
         assert_eq!(pricing.context_limit("moonshot/kimi-k2.5"), Some(262_144));
         assert_eq!(pricing.context_limit("moonshot/kimi-k2.6"), Some(262_144));
+        assert_eq!(pricing.context_limit("moonshot/kimi-k3"), Some(1_048_576));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add embedded pricing for the `moonshot/kimi-k3` model, released by Moonshot AI in July 2026. K3 is a 2.8T-parameter model with significantly different pricing from the existing K2.x models.

## Changes

- Add `moonshot/kimi-k3` pricing entry: input $3.00/M, output $15.00/M, cache read $0.30/M
- Add context window entry: 1,048,576 tokens (1M)
- Extend the existing Kimi pricing test to cover K3

## Pricing source

Official Moonshot platform: https://platform.kimi.ai/docs/pricing/chat-k3

## Notes

- K3 does not charge a separate cache creation fee (unlike K2.5/K2.6 which have 1.25× input), so `cache_create` is set to `0.0`. This matches the current pricing page which only lists cache miss (input) and cache hit (read) rates.
- The `kimi-for-coding` → K3 timestamp mapping is intentionally left unchanged; that cutoff should be added separately once Kimi Code's K3 rollout date is confirmed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787148313&installation_id=139163553&pr_number=1461&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1461&signature=76c14c4a209f6ff71697125a8397e36798c84e63eb52d6139d1b4ecf0dee5349"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for `moonshot/kimi-k3` pricing so costs and limits are handled correctly.

- **New Features**
  - Add `moonshot/kimi-k3` pricing: input $3.00/M, output $15.00/M, cache read $0.30/M; `cache_create` is $0.00.
  - Set context window to 1,048,576 tokens.
  - Extend Kimi pricing tests to cover K3.

<sup>Written for commit 6f17acea8076a452590bd6e3891655089d56c419. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1461?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in pricing support for the Moonshot Kimi K3 model.
  * Added its context-window limit and cache-read pricing details for accurate usage calculations.
* **Tests**
  * Added coverage to verify the model’s offline pricing and context-limit information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->