### PR TITLE
docs: add TokenTab to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -26,6 +26,7 @@ These projects are maintained independently and are not affiliated with the ccus
 - [viberank](https://viberank.app) - A community-driven leaderboard for Claude Code usage. ([GitHub](https://github.com/sculptdotfun/viberank))
 - [CCWarriors](https://ccwarriors.xyz) - Live leaderboard of AI coding spend across Claude Code, Codex, Gemini, and other ccusage-readable agents, with per-tool filters and real-time updates. ([GitHub](https://github.com/distroinfinity/ccwarriors))
 - [Token Battle](https://tokenbattle.vercel.app) - AI coding cost leaderboard for comparing monthly ccusage exports from Claude Code, Codex CLI, and Gemini CLI, with dashboard uploads, public rankings, and shareable profiles.
+- [TokenTab](https://tokentab-two.vercel.app) - Turns a `ccusage --json` export into a cost report broken down by model and by CLI agent, plus a shareable link — built for sending clients or teammates a bill, not a leaderboard. Runs entirely client-side; no signup or upload.
 
 ## Contributing
 


### PR DESCRIPTION
Adds TokenTab to the Web Applications section of the community projects list.

TokenTab (https://tokentab-two.vercel.app) turns a `ccusage --json` export into
a cost report broken down by model and by CLI agent (Claude Code, Codex, etc.),
plus a shareable link for sending a client or teammate a bill. It's framed
around client-billing / cost-reporting specifically, which felt like a
different angle from the existing leaderboard-style entries (viberank,
CCWarriors, Token Battle) — happy to adjust wording/placement if you'd
prefer it elsewhere.

Runs entirely client-side (parses locally, encodes the report into the URL
for the share link) — no signup, no server-side storage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1470"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787156729&installation_model_id=423687&pr_number=1470&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1470&signature=a8c3b6262305750f5f9dc1e2d7cede3fcdc730ab22840a7b3bc8f034251d80fa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added TokenTab to the Community Projects (Web Applications) list to highlight a billing-focused ccusage report generator. It converts a `ccusage --json` export into a cost report by model and CLI agent, provides a shareable link, and runs fully client-side (no signup or uploads).

<sup>Written for commit 95c1b8e71f0538cb8b29fdebfd9e7437ea5678e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

