### PR TITLE
fix(amp): load server-backed thread usage

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -21,7 +21,7 @@
     <img src="https://cdn.jsdelivr.net/gh/ccusage/ccusage@main/docs/public/screenshot.png" alt="ccusage terminal report screenshot">
 </div>
 
-> Analyze coding (agent) CLI token usage and costs from local data.
+> Analyze coding (agent) CLI token usage and costs.
 
 ## Major Sponsors
 
@@ -59,7 +59,7 @@ npx ccusage@latest
 
 ## Supported Sources
 
-ccusage reads local usage data from coding agent CLIs and turns it into daily, weekly, monthly, and session reports.
+ccusage reads usage data from coding agent CLIs and turns it into daily, weekly, monthly, and session reports. Most sources use local files; current Amp threads are exported through the authenticated Amp CLI.
 
 | Source             | Focused command example  |
 | ------------------ | ------------------------ |

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects usage data from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. Most sources use local files; Amp also discovers current server-backed threads through the installed Amp CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |

--- a/docs/guide/amp/index.md
+++ b/docs/guide/amp/index.md
@@ -2,7 +2,7 @@
 
 > Amp support is experimental. Expect breaking changes while both ccusage and [Amp](https://ampcode.com/) continue to evolve.
 
-ccusage can read Amp thread files as one of its supported local data sources, using the same reporting experience as the rest of ccusage: responsive tables, JSON output, LiteLLM-based pricing, cache token accounting, and credit totals where Amp records them.
+ccusage reads both current server-backed Amp threads and legacy local thread files, using the same reporting experience as the rest of ccusage: responsive tables, JSON output, LiteLLM-based pricing, cache token accounting, and credit totals where Amp records them.
 
 ## Focused Views
 
@@ -24,7 +24,9 @@ pnpm dlx ccusage amp --help
 
 ## Data Source
 
-The CLI reads Amp thread JSON files from `AMP_DATA_DIR` (defaults to `~/.local/share/amp`). `AMP_DATA_DIR` can be one directory or a comma-separated list of directories.
+By default, ccusage uses the installed, authenticated `amp` CLI to list and export current server-backed threads. It also reads legacy thread JSON files from `~/.local/share/amp/threads/`. Older matching server snapshots are skipped; threads continued after local history stopped are merged without duplicating legacy usage or losing historical credit data.
+
+Set `AMP_DATA_DIR` to read only local archives instead. It can be one directory or a comma-separated list of directories. Explicitly setting it disables server discovery.
 
 ```bash
 AMP_DATA_DIR="$HOME/.local/share/amp,/backup/amp" ccusage amp session
@@ -44,26 +46,30 @@ AMP_DATA_DIR="$HOME/.local/share/amp,/backup/amp" ccusage amp session
 | `ccusage amp monthly` | Aggregate usage by month  | [Monthly Usage](/guide/monthly-reports) |
 | `ccusage amp session` | Group usage by Amp thread | [Session Usage](/guide/session-reports) |
 
-These views support `--json` for structured output, `--compact` for narrow terminals, and `--offline` for cached pricing data.
+These views support `--json` for structured output, `--compact` for narrow terminals, and `--offline` for embedded pricing data. `--since` also avoids exporting server threads that Amp reports as last updated before the requested range.
 
 ## What Gets Calculated
 
 - **Token usage** - Amp usage ledger events provide input and output token counts.
 - **Cache tokens** - Assistant message usage fields provide cache creation and cache read tokens when available.
-- **Credits** - Amp credit values are summed alongside token and cost totals.
+- **Credits** - Credit values from legacy Amp ledgers are summed alongside token and cost totals. Current server exports do not expose credits, so newer rows can show zero credits while still including tokens and estimated cost.
 - **Pricing** - Costs are calculated from LiteLLM pricing data for Claude and Anthropic model names, including provider-prefixed variants.
 
 ## Environment Variables
 
 | Variable       | Description                                                                           |
 | -------------- | ------------------------------------------------------------------------------------- |
-| `AMP_DATA_DIR` | Override the root directory, or comma-separated root directories, containing Amp data |
+| `AMP_DATA_DIR` | Use only the given local Amp archive root, or comma-separated roots, instead of server discovery |
 | `LOG_LEVEL`    | Adjust verbosity (0 silent ... 5 trace)                                               |
 
 ## Troubleshooting
 
 ::: details No Amp usage data found
-Ensure the data directory exists at `~/.local/share/amp/threads/`. Set `AMP_DATA_DIR` if your Amp data lives elsewhere or in multiple archive roots.
+Ensure `amp threads list --json` works and that Amp is authenticated. For legacy archives, ensure the data directory exists at `~/.local/share/amp/threads/`, or set `AMP_DATA_DIR` if the files live elsewhere.
+:::
+
+::: details Server-backed totals are incomplete
+ccusage prints a warning when the Amp CLI cannot list server threads or when one or more exports fail. Check that `amp` is installed, authenticated, and able to reach the Amp service. Results still include any readable legacy local files.
 :::
 
 ::: details Costs showing as $0.00

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -52,11 +52,12 @@ ccusage daily --mode display --timezone UTC
 export CODEX_HOME="$HOME/.codex"
 export GEMINI_DATA_DIR="$HOME/.gemini/tmp"
 export OPENCODE_DATA_DIR="$HOME/.local/share/opencode"
-export AMP_DATA_DIR="$HOME/.local/share/amp"
 export PI_AGENT_DIR="$HOME/.pi/agent/sessions"
 export KILO_DATA_DIR="$HOME/.local/share/kilo"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="$HOME/.copilot/otel/copilot-otel.jsonl"
 ```
+
+Leave `AMP_DATA_DIR` unset for current server-backed Amp threads. Set it only when you want Amp reports to read local archives without server discovery.
 
 Use comma-separated directories when you want reports to combine multiple profiles or archives:
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -6,6 +6,8 @@ ccusage supports several environment variables for configuration and customizati
 
 ccusage detects supported data source files from conventional locations by default. Set these variables when your data lives somewhere else. Directory variables can be one directory or a comma-separated list of directories; the Copilot variable points at one explicit JSONL export file:
 
+For Amp, leaving `AMP_DATA_DIR` unset combines server-backed threads from the authenticated Amp CLI with legacy files in `~/.local/share/amp`. Setting it switches Amp to local-archive-only mode and disables server discovery.
+
 | Variable                          | Agent        | Default                            |
 | --------------------------------- | ------------ | ---------------------------------- |
 | `CLAUDE_CONFIG_DIR`               | Claude Code  | `~/.config/claude` and `~/.claude` |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -165,7 +165,7 @@ If ccusage shows no data, check:
    - Claude Code: `~/.config/claude/projects/` or `~/.claude/projects/`
    - Codex: `${CODEX_HOME:-~/.codex}`
    - OpenCode: `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`
-   - Amp: `${AMP_DATA_DIR:-~/.local/share/amp}`
+   - Amp: authenticated `amp threads` commands plus legacy files in `${AMP_DATA_DIR:-~/.local/share/amp}`
    - Droid: `${DROID_SESSIONS_DIR:-~/.factory/sessions}`
    - Codebuff: `${CODEBUFF_DATA_DIR:-~/.config/manicode}`
    - Hermes Agent: `${HERMES_HOME:-~/.hermes}/state.db`
@@ -197,6 +197,8 @@ export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 ```
+
+Setting `AMP_DATA_DIR` selects local-archive-only mode. Leave it unset to combine the authenticated Amp CLI's server-backed threads with legacy files from the default directory.
 
 Each source-specific path variable can also contain comma-separated directories:
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -77,7 +77,7 @@ ccusage reads from local coding CLI data directories:
 | Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`        |
 | Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                         |
 | OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`   |
-| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`             |
+| Amp          | `amp`      | Amp CLI server exports + `~/.local/share/amp`     |
 | Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`      |
 | Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`        |
 | Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`              |

--- a/rust/crates/ccusage/src/adapter/amp/README.md
+++ b/rust/crates/ccusage/src/adapter/amp/README.md
@@ -1,12 +1,20 @@
 # Amp Source
 
-Data source:
+Data sources:
 
 ```text
-${AMP_DATA_DIR:-~/.local/share/amp}/threads/
+amp threads list --include-archived --json
+amp threads export <thread-id>
+${AMP_DATA_DIR:-~/.local/share/amp}/threads/ (legacy)
 ```
 
-Each thread is a JSON file named `T-{uuid}.json`.
+By default, ccusage loads legacy local JSON files first, then uses the installed
+and authenticated Amp CLI to discover and export server-backed threads. Remote
+server snapshots older than the local history are skipped. Threads
+updated after local history stopped are merged by usage identity so ccusage can
+include newer messages without duplicating legacy usage or losing its credits.
+Setting `AMP_DATA_DIR` explicitly selects only those local archive roots and
+disables server discovery.
 
 Usage comes from:
 
@@ -19,7 +27,9 @@ Usage comes from:
   `cacheReadInputTokens`, and `totalTokens` fields. `totalTokens` is only used
   as a fallback when the split fields are missing.
 
-Amp also reports `credits`; display credits alongside USD estimates when the command/report supports it.
+Legacy Amp ledgers also report `credits`; display credits alongside USD
+estimates when the command/report supports it. Current server exports do not
+include credits.
 
 Commands:
 

--- a/rust/crates/ccusage/src/adapter/amp/loader.rs
+++ b/rust/crates/ccusage/src/adapter/amp/loader.rs
@@ -1,17 +1,32 @@
+use std::collections::{HashMap, HashSet};
+
 use crate::{
     LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, debug_log,
     parse_tz, read_files_parallel,
 };
 
-use super::{parser, paths};
+use super::{parser, paths, server};
 
 pub(crate) fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Amp, shared.json, || {
-        load_entries_inner(shared, pricing)
+        load_entries_inner(shared, pricing, false)
     })
 }
 
-fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+pub(super) fn load_entries_for_amp_command(
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent::Amp, shared.json, || {
+        load_entries_inner(shared, pricing, true)
+    })
+}
+
+fn load_entries_inner(
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+    warn_server_failure: bool,
+) -> Result<Vec<LoadedEntry>> {
     let mut entries = Vec::new();
     let tz = parse_tz(shared.timezone.as_deref());
     for path in paths::paths()? {
@@ -33,6 +48,137 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
             entries.extend(file_entries);
         }
     }
+    // Unit tests frequently exercise unified loaders with synthetic fixtures;
+    // never let those test processes reach a developer's authenticated Amp
+    // account. Server parsing and selection are tested independently.
+    if !cfg!(test) && paths::uses_default_source() {
+        let mut local_latest_usage = HashMap::new();
+        for entry in &entries {
+            local_latest_usage
+                .entry(entry.session_id.to_string())
+                .and_modify(|timestamp: &mut crate::TimestampMs| {
+                    *timestamp = (*timestamp).max(entry.timestamp);
+                })
+                .or_insert(entry.timestamp);
+        }
+        match server::load_entries(
+            &local_latest_usage,
+            tz.as_ref(),
+            shared.mode,
+            pricing,
+            shared.single_thread,
+            shared.since.as_deref(),
+        ) {
+            Ok(server_entries) => {
+                if server_entries.list_truncated {
+                    eprintln!(
+                        "WARN  Amp's thread list did not advance past 500 threads; Amp totals may be incomplete."
+                    );
+                }
+                if server_entries.failed_exports > 0 {
+                    eprintln!(
+                        "WARN  Failed to export {} server-backed Amp thread(s); Amp totals are incomplete.",
+                        server_entries.failed_exports
+                    );
+                }
+                append_deduped_server_entries(&mut entries, server_entries.entries);
+            }
+            Err(error) => {
+                debug_log(
+                    shared,
+                    format!("Failed to load server-backed Amp threads: {error}"),
+                );
+                if warn_server_failure || !entries.is_empty() {
+                    eprintln!(
+                        "WARN  Server-backed Amp threads could not be loaded; showing legacy local Amp data only."
+                    );
+                }
+            }
+        }
+    }
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
+}
+
+fn append_deduped_server_entries(
+    entries: &mut Vec<LoadedEntry>,
+    mut server_entries: Vec<LoadedEntry>,
+) {
+    let mut seen_usage = entries.iter().map(usage_key).collect::<HashSet<_>>();
+    server_entries.retain(|entry| seen_usage.insert(usage_key(entry)));
+    entries.append(&mut server_entries);
+}
+
+fn usage_key(
+    entry: &LoadedEntry,
+) -> (
+    String,
+    crate::TimestampMs,
+    Option<String>,
+    u64,
+    u64,
+    u64,
+    u64,
+) {
+    let usage = entry.data.message.usage;
+    (
+        entry.session_id.to_string(),
+        entry.timestamp,
+        entry.model.clone(),
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.cache_creation_input_tokens,
+        usage.cache_read_input_tokens,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::CostMode;
+
+    #[test]
+    fn keeps_legacy_credits_when_server_export_repeats_usage() {
+        let mut local = parser::parse_thread(
+            br#"{
+                "id":"T-thread",
+                "usageLedger":{"events":[{
+                    "id":"event-1",
+                    "toMessageId":2,
+                    "timestamp":"2026-03-31T10:00:00.000Z",
+                    "model":"claude-sonnet-4-20250514",
+                    "tokens":{"input":12,"output":34},
+                    "credits":1.5
+                }]},
+                "messages":[{"role":"assistant","messageId":2,"usage":{
+                    "cacheCreationInputTokens":56,"cacheReadInputTokens":78
+                }}]
+            }"#,
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+        let server = parser::parse_server_thread(
+            br#"{
+                "id":"T-thread",
+                "messages":[{"role":"assistant","messageId":2,"usage":{
+                    "model":"claude-sonnet-4-20250514",
+                    "inputTokens":12,"outputTokens":34,
+                    "cacheCreationInputTokens":56,"cacheReadInputTokens":78,
+                    "timestamp":"2026-03-31T10:00:00.000Z"
+                }}]
+            }"#,
+            "T-thread",
+            None,
+            CostMode::Auto,
+            None,
+        )
+        .unwrap();
+
+        append_deduped_server_entries(&mut local, server);
+
+        assert_eq!(local.len(), 1);
+        assert_eq!(local[0].credits, Some(1.5));
+    }
 }

--- a/rust/crates/ccusage/src/adapter/amp/mod.rs
+++ b/rust/crates/ccusage/src/adapter/amp/mod.rs
@@ -2,6 +2,7 @@ mod loader;
 mod parser;
 mod paths;
 mod report;
+mod server;
 
 use crate::{
     PricingMap, Result, adapter::opencode, cli::AgentCommandArgs, filter_loaded_entries_by_date,
@@ -20,7 +21,7 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
         crate::log_level() != Some(0),
         shared.pricing_overrides.iter(),
     );
-    let mut entries = load_entries(&shared, &pricing)?;
+    let mut entries = loader::load_entries_for_amp_command(&shared, &pricing)?;
     filter_loaded_entries_by_date(&mut entries, &shared);
     let mut rows = summarize_entries(&entries, args.kind)?;
     sort_summaries(&mut rows, &shared.order, |row| {

--- a/rust/crates/ccusage/src/adapter/amp/parser.rs
+++ b/rust/crates/ccusage/src/adapter/amp/parser.rs
@@ -75,11 +75,45 @@ pub(crate) fn read_thread_file(
     pricing: Option<&PricingMap>,
 ) -> Result<Vec<LoadedEntry>> {
     let content = fs::read(path)?;
-    let Ok(thread) = serde_json::from_slice::<AmpThread>(&content) else {
+    parse_thread(&content, tz, mode, pricing)
+}
+
+pub(super) fn parse_thread(
+    content: &[u8],
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let Ok(thread) = serde_json::from_slice::<AmpThread>(content) else {
         return Ok(Vec::new());
     };
+    Ok(parse_deserialized_thread(thread, tz, mode, pricing))
+}
+
+pub(super) fn parse_server_thread(
+    content: &[u8],
+    expected_thread_id: &str,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Result<Vec<LoadedEntry>> {
+    let thread = serde_json::from_slice::<AmpThread>(content)?;
+    if thread.id.as_deref() != Some(expected_thread_id) {
+        return Err(crate::cli_error(format!(
+            "Amp exported an unexpected thread ID (expected {expected_thread_id})"
+        )));
+    }
+    Ok(parse_deserialized_thread(thread, tz, mode, pricing))
+}
+
+fn parse_deserialized_thread(
+    thread: AmpThread,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Vec<LoadedEntry> {
     let Some(thread_id) = thread.id else {
-        return Ok(Vec::new());
+        return Vec::new();
     };
     let messages = &thread.messages;
 
@@ -87,17 +121,10 @@ pub(crate) fn read_thread_file(
         && let Some(events) = ledger.events.as_ref()
     {
         let cache_tokens = cache_tokens_by_message_id(messages);
-        return Ok(parse_ledger_events(
-            events,
-            &cache_tokens,
-            &thread_id,
-            tz,
-            mode,
-            pricing,
-        ));
+        return parse_ledger_events(events, &cache_tokens, &thread_id, tz, mode, pricing);
     }
 
-    Ok(parse_message_usage(messages, &thread_id, tz, mode, pricing))
+    parse_message_usage(messages, &thread_id, tz, mode, pricing)
 }
 
 fn parse_ledger_events(
@@ -339,6 +366,46 @@ fn json_value_f64(value: Option<&Value>) -> Option<f64> {
 mod tests {
     use super::*;
     use ccusage_test_support::fs_fixture;
+
+    #[test]
+    fn reads_usage_from_server_export() {
+        let export = br#"{
+            "id":"T-server-thread",
+            "messages":[
+                {"role":"user","content":"hi","messageId":1},
+                {"role":"assistant","messageId":2,"usage":{
+                    "model":"claude-sonnet-4-20250514",
+                    "inputTokens":12,
+                    "outputTokens":34,
+                    "cacheCreationInputTokens":56,
+                    "cacheReadInputTokens":78,
+                    "totalInputTokens":146,
+                    "timestamp":"2026-07-20T10:11:12.000Z"
+                }}
+            ]
+        }"#;
+
+        let entries = parse_thread(export, None, CostMode::Auto, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "T-server-thread");
+        assert_eq!(entries[0].data.message.id.as_deref(), Some("2"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 12);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 34);
+        assert_eq!(
+            entries[0].data.message.usage.cache_creation_input_tokens,
+            56
+        );
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 78);
+    }
+
+    #[test]
+    fn rejects_invalid_server_export() {
+        let error = parse_server_thread(b"not json", "T-server-thread", None, CostMode::Auto, None)
+            .unwrap_err();
+
+        assert!(error.to_string().contains("expected"));
+    }
 
     #[test]
     fn falls_back_to_total_tokens_when_amp_parts_are_missing() {

--- a/rust/crates/ccusage/src/adapter/amp/paths.rs
+++ b/rust/crates/ccusage/src/adapter/amp/paths.rs
@@ -4,6 +4,10 @@ use crate::Result;
 
 const AMP_DATA_DIR_ENV: &str = "AMP_DATA_DIR";
 
+pub(super) fn uses_default_source() -> bool {
+    env::var_os(AMP_DATA_DIR_ENV).is_none()
+}
+
 pub(super) fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();

--- a/rust/crates/ccusage/src/adapter/amp/server.rs
+++ b/rust/crates/ccusage/src/adapter/amp/server.rs
@@ -1,0 +1,304 @@
+use std::{
+    collections::{HashMap, HashSet},
+    process::Command,
+    thread,
+};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
+
+use crate::{LoadedEntry, PricingMap, Result, cli::CostMode};
+
+use super::parser;
+
+const THREAD_LIST_PAGE_SIZE: usize = 500;
+const MAX_EXPORT_WORKERS: usize = 8;
+
+#[derive(Debug, Default)]
+pub(super) struct ServerEntries {
+    pub(super) entries: Vec<LoadedEntry>,
+    pub(super) failed_exports: usize,
+    pub(super) list_truncated: bool,
+}
+
+#[derive(Deserialize)]
+struct ThreadListItem {
+    id: Option<String>,
+    updated: Option<String>,
+}
+
+pub(super) fn load_entries(
+    local_latest_usage: &HashMap<String, crate::TimestampMs>,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+    single_thread: bool,
+    since: Option<&str>,
+) -> Result<ServerEntries> {
+    let (remote, list_truncated) = list_threads()?;
+    let thread_ids = select_remote_thread_items(remote, local_latest_usage, since, tz);
+    let mut loaded = export_threads(&thread_ids, tz, mode, pricing, single_thread)?;
+    loaded.list_truncated = list_truncated;
+    Ok(loaded)
+}
+
+fn list_threads() -> Result<(Vec<ThreadListItem>, bool)> {
+    let mut threads = Vec::new();
+    let mut seen = HashSet::new();
+    let mut offset = 0;
+    loop {
+        let limit = THREAD_LIST_PAGE_SIZE.to_string();
+        let offset_text = offset.to_string();
+        let output = run_amp(&[
+            "threads",
+            "list",
+            "--include-archived",
+            "--limit",
+            &limit,
+            "--offset",
+            &offset_text,
+            "--json",
+        ])?;
+        let page = serde_json::from_slice::<Vec<ThreadListItem>>(&output)?;
+        let raw_page_len = page.len();
+        let previous_len = threads.len();
+        for item in page {
+            if let Some(id) = item.id.as_ref()
+                && seen.insert(id.clone())
+            {
+                threads.push(item);
+            }
+        }
+        if raw_page_len < THREAD_LIST_PAGE_SIZE {
+            break;
+        }
+        if threads.len() == previous_len {
+            return Ok((threads, true));
+        }
+        offset += raw_page_len;
+    }
+    Ok((threads, false))
+}
+
+#[cfg(test)]
+fn parse_thread_list(output: &[u8]) -> Result<Vec<String>> {
+    parse_thread_list_since(output, None)
+}
+
+#[cfg(test)]
+fn parse_thread_list_since(output: &[u8], since: Option<&str>) -> Result<Vec<String>> {
+    let items = serde_json::from_slice::<Vec<ThreadListItem>>(output)?;
+    Ok(items
+        .into_iter()
+        .filter(|item| {
+            since.is_none_or(|since| {
+                thread_updated_date(item, None)
+                    .as_deref()
+                    .map(|date| date >= since)
+                    .unwrap_or(true)
+            })
+        })
+        .filter_map(|item| item.id)
+        .collect())
+}
+
+fn select_remote_thread_items(
+    remote: Vec<ThreadListItem>,
+    local_latest_usage: &HashMap<String, crate::TimestampMs>,
+    since: Option<&str>,
+    tz: Option<&JiffTimeZone>,
+) -> Vec<String> {
+    remote
+        .into_iter()
+        .filter(|item| {
+            since.is_none_or(|since| {
+                thread_updated_date(item, tz)
+                    .as_deref()
+                    .map(|date| date >= since)
+                    .unwrap_or(true)
+            })
+        })
+        .filter_map(|item| {
+            let updated = item.updated.as_deref().and_then(crate::parse_ts_timestamp);
+            let id = item.id?;
+            if local_latest_usage
+                .get(&id)
+                .is_none_or(|local| updated.is_none_or(|updated| updated > *local))
+            {
+                Some(id)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+fn thread_updated_date(item: &ThreadListItem, tz: Option<&JiffTimeZone>) -> Option<String> {
+    let timestamp = crate::parse_ts_timestamp(item.updated.as_deref()?)?;
+    Some(crate::format_date_tz(timestamp, tz).replace('-', ""))
+}
+
+#[cfg(test)]
+fn select_remote_threads_updated(
+    output: &[u8],
+    local_latest_usage: &HashMap<String, crate::TimestampMs>,
+) -> Result<Vec<String>> {
+    let items = serde_json::from_slice::<Vec<ThreadListItem>>(output)?;
+    Ok(select_remote_thread_items(
+        items,
+        local_latest_usage,
+        None,
+        None,
+    ))
+}
+
+fn export_threads(
+    thread_ids: &[String],
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+    single_thread: bool,
+) -> Result<ServerEntries> {
+    let worker_count = if single_thread {
+        1
+    } else {
+        thread::available_parallelism()
+            .map(usize::from)
+            .unwrap_or(1)
+            .min(MAX_EXPORT_WORKERS)
+            .min(thread_ids.len())
+    };
+    if worker_count <= 1 {
+        return collect_exports(
+            thread_ids
+                .iter()
+                .map(|thread_id| export_thread(thread_id, tz, mode, pricing)),
+        );
+    }
+
+    let chunk_size = thread_ids.len().div_ceil(worker_count);
+    thread::scope(|scope| {
+        let handles = thread_ids
+            .chunks(chunk_size)
+            .map(|chunk| {
+                scope.spawn(move || {
+                    chunk
+                        .iter()
+                        .map(|thread_id| export_thread(thread_id, tz, mode, pricing))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .collect::<Vec<_>>();
+        collect_exports(
+            handles
+                .into_iter()
+                .flat_map(|handle| handle.join().expect("Amp export worker panicked")),
+        )
+    })
+}
+
+fn export_thread(
+    thread_id: &str,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Result<Vec<LoadedEntry>> {
+    let output = run_amp(&["threads", "export", thread_id])?;
+    parser::parse_server_thread(&output, thread_id, tz, mode, Some(pricing))
+}
+
+fn collect_exports(
+    exports: impl IntoIterator<Item = Result<Vec<LoadedEntry>>>,
+) -> Result<ServerEntries> {
+    let mut loaded = ServerEntries::default();
+    for export in exports {
+        match export {
+            Ok(mut entries) => loaded.entries.append(&mut entries),
+            Err(_) => loaded.failed_exports += 1,
+        }
+    }
+    Ok(loaded)
+}
+
+fn run_amp(args: &[&str]) -> Result<Vec<u8>> {
+    let output = Command::new("amp").args(args).output()?;
+    if !output.status.success() {
+        let detail = String::from_utf8_lossy(&output.stderr);
+        return Err(crate::cli_error(format!(
+            "amp {} failed: {}",
+            args.join(" "),
+            detail.trim()
+        )));
+    }
+    Ok(output.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use super::*;
+
+    #[test]
+    fn parses_server_thread_list() {
+        let output = br#"[
+            {"id":"T-new","updated":"2026-07-20T10:00:00.000Z"},
+            {"id":"T-old","updated":"2026-03-31T10:00:00.000Z"},
+            {"title":"missing id"}
+        ]"#;
+
+        let threads = parse_thread_list(output).unwrap();
+
+        assert_eq!(threads, vec!["T-new", "T-old"]);
+    }
+
+    #[test]
+    fn exports_only_threads_missing_from_legacy_files() {
+        let output = br#"[
+            {"id":"T-new","updated":"2026-07-20T10:00:00.000Z"},
+            {"id":"T-old","updated":"2026-01-20T10:00:00.000Z"}
+        ]"#;
+        let local = HashMap::from([(
+            "T-old".to_string(),
+            crate::parse_ts_timestamp("2026-01-21T10:00:00.000Z").unwrap(),
+        )]);
+
+        let selected = select_remote_threads_updated(output, &local).unwrap();
+
+        assert_eq!(selected, vec!["T-new"]);
+    }
+
+    #[test]
+    fn skips_threads_last_updated_before_since() {
+        let output = br#"[
+            {"id":"T-current","updated":"2026-07-20T10:00:00.000Z"},
+            {"id":"T-stale","updated":"2026-06-29T23:59:59.000Z"}
+        ]"#;
+
+        let threads = parse_thread_list_since(output, Some("20260701")).unwrap();
+
+        assert_eq!(threads, vec!["T-current"]);
+    }
+
+    #[test]
+    fn exports_legacy_thread_continued_after_local_history_stopped() {
+        let output = br#"[
+            {"id":"T-continued","updated":"2026-07-20T10:00:00.000Z"},
+            {"id":"T-complete","updated":"2026-01-20T10:00:00.000Z"}
+        ]"#;
+        let local = HashMap::from([
+            (
+                "T-continued".to_string(),
+                crate::parse_ts_timestamp("2026-03-31T10:00:00.000Z").unwrap(),
+            ),
+            (
+                "T-complete".to_string(),
+                crate::parse_ts_timestamp("2026-01-21T10:00:00.000Z").unwrap(),
+            ),
+        ]);
+
+        let selected = select_remote_threads_updated(output, &local).unwrap();
+
+        assert_eq!(selected, vec!["T-continued"]);
+    }
+}


### PR DESCRIPTION
Discover active and archived Amp threads through the installed Amp CLI and parse usage from exported messages. Merge server usage with legacy local ledgers while preserving historical credits and avoiding duplicate entries.

Warn when thread discovery or exports are incomplete, and keep AMP_DATA_DIR as an explicit local-archive-only override.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787189425&installation_model_id=423687&pr_number=1472&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1472&signature=b116825a612c85aa4aa71065830665f2fce691ff5dd9132b7e67ab3e54d81a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load server-backed Amp thread usage via the authenticated `amp` CLI and merge it with legacy local ledgers to preserve historical credits and prevent duplicate rows. Warn when discovery or exports are incomplete; `AMP_DATA_DIR` now explicitly forces local-archive-only mode.

- New Features
  - Discover active and archived threads via `amp threads list --include-archived`, export with `amp threads export`, and parse usage from messages.
  - Merge with legacy files without duplicates and keep legacy credits; skip remote snapshots older than local history.
  - Honor `--since` to avoid exporting threads updated before the range; parallelize exports (up to 8 workers), with single-thread mode using 1 worker.
  - Show warnings for a truncated thread list or failed exports and fall back to legacy-only if server loading fails; leaving `AMP_DATA_DIR` unset combines server-backed threads with legacy files.

<sup>Written for commit f3d6653985561c7397444c78dbdd90bc77f9019f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Amp reports can now include authenticated server-backed threads alongside legacy local archives.
  - Usage is merged without duplicating records, while supported legacy credit information is preserved.
  - Date filtering can exclude older server threads from exports.
  - Added clearer handling and warnings for incomplete server data.

- **Documentation**
  - Expanded Amp setup, data-source, environment-variable, reporting, and troubleshooting guidance.
  - Clarified that setting `AMP_DATA_DIR` enables local-archive-only mode; leaving it unset allows server discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->