### PR TITLE
feat(cli): add a `--from-json` option

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -143,6 +143,7 @@ bunx ccusage daily --by-agent --json
 # Filters and options
 bunx ccusage daily --since 2026-04-25 --until 2026-05-16
 bunx ccusage daily --json  # JSON output
+bunx ccusage daily --from-json report.json  # Render an existing ccusage daily JSON report
 bunx ccusage daily --no-cost  # Hide cost columns and JSON cost fields
 bunx ccusage daily --timezone UTC  # Use UTC timezone
 

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -128,7 +128,7 @@ Render a previously exported or externally combined ccusage daily report with
 the normal responsive table renderer:
 
 ```bash
-ccusage daily --from-json fleet-report.json
+ccusage daily --from-json combined-report.json
 ```
 
 The input file must use the same `daily` and `totals` structure emitted by

--- a/docs/guide/daily-reports.md
+++ b/docs/guide/daily-reports.md
@@ -124,28 +124,41 @@ Export data as JSON for further analysis:
 ccusage daily --json
 ```
 
+Render a previously exported or externally combined ccusage daily report with
+the normal responsive table renderer:
+
+```bash
+ccusage daily --from-json fleet-report.json
+```
+
+The input file must use the same `daily` and `totals` structure emitted by
+`ccusage daily --json`. This makes it possible to merge reports outside
+ccusage, then retain its standard colors, compact layout, model breakdowns, and
+totals display.
+
 ```json
 {
-	"type": "daily",
-	"data": [
+	"daily": [
 		{
-			"date": "2026-05-16",
-			"models": ["claude-opus-4-1-20250805", "claude-sonnet-4-5-20250929"],
+			"agent": "all",
+			"modelsUsed": ["claude-opus-4-1-20250805", "claude-sonnet-4-5-20250929"],
 			"inputTokens": 277,
 			"outputTokens": 31456,
 			"cacheCreationTokens": 512,
 			"cacheReadTokens": 1024,
 			"totalTokens": 33269,
-			"costUSD": 17.58
+			"totalCost": 17.58,
+			"modelBreakdowns": [],
+			"period": "2026-05-16"
 		}
 	],
-	"summary": {
-		"totalInputTokens": 277,
-		"totalOutputTokens": 31456,
-		"totalCacheCreationTokens": 512,
-		"totalCacheReadTokens": 1024,
+	"totals": {
+		"inputTokens": 277,
+		"outputTokens": 31456,
+		"cacheCreationTokens": 512,
+		"cacheReadTokens": 1024,
 		"totalTokens": 33269,
-		"totalCostUSD": 17.58
+		"totalCost": 17.58
 	}
 }
 ```

--- a/rust/crates/ccusage-cli/src/cli-commands.json
+++ b/rust/crates/ccusage-cli/src/cli-commands.json
@@ -1,5 +1,6 @@
 {
 	"combinedOptions": {
+		"all_daily_options": ["all_agent_options", "from_json_options"],
 		"all_agent_session_options": ["all_agent_options", "session_options"],
 		"blocks_combined_options": ["shared_claude_options", "blocks_options"],
 		"claude_daily_options": ["shared_claude_options", "daily_options"],
@@ -102,7 +103,7 @@
 			"path": ["daily"],
 			"description": "Show all detected coding (agent) CLI usage grouped by date",
 			"usage": "ccusage daily <OPTIONS>",
-			"options": "all_agent_options"
+			"options": "all_daily_options"
 		},
 		{
 			"path": ["monthly"],

--- a/rust/crates/ccusage-cli/src/cli-help.json
+++ b/rust/crates/ccusage-cli/src/cli-help.json
@@ -238,6 +238,12 @@
 			"description": "Comma-separated project aliases (e.g., 'ccusage=Usage Tracker,myproject=My Project')"
 		}
 	],
+	"from_json_options": [
+		{
+			"flags": "--from-json <file>",
+			"description": "Render a daily report from ccusage JSON instead of loading local usage data"
+		}
+	],
 	"pi_options": [
 		{
 			"flags": "--pi-path <pi-path>",

--- a/rust/crates/ccusage-cli/src/parser.rs
+++ b/rust/crates/ccusage-cli/src/parser.rs
@@ -39,6 +39,7 @@ impl RootAllOptions {
         AgentCommandArgs {
             shared,
             kind,
+            from_json: None,
             sections: self.sections,
             by_agent: self.by_agent,
             pi_path: None,
@@ -385,15 +386,28 @@ fn parse_all_command(
 ) -> Result<Command, String> {
     let mut sections = initial_options.sections;
     let mut by_agent = initial_options.by_agent;
+    let mut from_json = None;
     while parser.peek().is_some() {
         if parse_unified_report_arg(parser, &mut sections, &mut by_agent)?.is_some() {
             continue;
         }
+        if kind == AgentReportKind::Daily && matches!(parser.peek_name(), Some("--from-json")) {
+            parser.next_flag()?;
+            from_json = Some(PathBuf::from(parser.value_for("--from-json")?));
+            continue;
+        }
         parse_shared_arg(parser, &mut shared)?;
+    }
+    if from_json.is_some() && shared.json {
+        return Err("--from-json cannot be combined with --json".to_string());
+    }
+    if from_json.is_some() && sections.is_some() {
+        return Err("--from-json cannot be combined with --sections".to_string());
     }
     Ok(Command::All(AgentCommandArgs {
         shared,
         kind,
+        from_json,
         sections,
         by_agent,
         pi_path: None,
@@ -437,6 +451,7 @@ fn parse_top_level_session_command(
     Ok(Command::All(AgentCommandArgs {
         shared: args.shared,
         kind: AgentReportKind::Session,
+        from_json: None,
         sections,
         by_agent,
         pi_path: None,
@@ -594,6 +609,7 @@ fn parse_codex_command(
     Ok(Command::Codex(AgentCommandArgs {
         shared,
         kind,
+        from_json: None,
         sections: None,
         by_agent: false,
         pi_path: None,
@@ -623,6 +639,7 @@ fn parse_pi_command(
     Ok(Command::Pi(AgentCommandArgs {
         shared,
         kind,
+        from_json: None,
         sections: None,
         by_agent: false,
         pi_path,
@@ -652,6 +669,7 @@ fn parse_openclaw_command(
     Ok(Command::OpenClaw(AgentCommandArgs {
         shared,
         kind,
+        from_json: None,
         sections: None,
         by_agent: false,
         pi_path: None,
@@ -682,6 +700,7 @@ fn agent_command_args(shared: SharedArgs, kind: AgentReportKind) -> AgentCommand
     AgentCommandArgs {
         shared,
         kind,
+        from_json: None,
         sections: None,
         by_agent: false,
         pi_path: None,

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -26,6 +26,32 @@ fn parse_error(args: &[&str]) -> String {
     }
 }
 
+#[test]
+fn parses_daily_from_json_option() {
+    let cli = parse(&["ccusage", "daily", "--from-json", "fleet-report.json"]);
+
+    let Some(Command::All(args)) = cli.command else {
+        panic!("expected unified daily command");
+    };
+    assert_eq!(
+        args.from_json,
+        Some(std::path::PathBuf::from("fleet-report.json"))
+    );
+}
+
+#[test]
+fn rejects_json_output_when_rendering_from_json() {
+    let error = parse_error(&[
+        "ccusage",
+        "daily",
+        "--from-json",
+        "fleet-report.json",
+        "--json",
+    ]);
+
+    assert_eq!("--from-json cannot be combined with --json", error);
+}
+
 #[derive(Default)]
 struct TestConfig {
     shared_json: Option<bool>,
@@ -206,7 +232,11 @@ fn command_snapshot(command: Option<Command>) -> Value {
 }
 
 fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
-    json!({
+    let from_json = args
+        .from_json
+        .as_ref()
+        .map(|path| path.to_string_lossy().to_string());
+    let mut snapshot = json!({
         "type": agent,
         "shared": shared_snapshot(&args.shared),
         "kind": format!("{:?}", args.kind),
@@ -218,7 +248,11 @@ fn agent_command_snapshot(agent: &str, args: AgentCommandArgs) -> Value {
         "piPath": args.pi_path,
         "openClawPath": args.open_claw_path,
         "codexSpeed": format!("{:?}", args.codex_speed),
-    })
+    });
+    if let Some(from_json) = from_json {
+        snapshot["fromJson"] = json!(from_json);
+    }
+    snapshot
 }
 
 #[test]
@@ -586,6 +620,13 @@ fn contextual_all_agent_help_lists_color_options() {
 
     assert!(help.contains("--color"));
     assert!(help.contains("--no-color"));
+}
+
+#[test]
+fn contextual_daily_help_lists_from_json_option() {
+    let help = help_text_for_args(&["ccusage".to_string(), "daily".to_string()]);
+
+    assert!(help.contains("--from-json <file>"));
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/tests.rs
+++ b/rust/crates/ccusage-cli/src/tests.rs
@@ -28,14 +28,14 @@ fn parse_error(args: &[&str]) -> String {
 
 #[test]
 fn parses_daily_from_json_option() {
-    let cli = parse(&["ccusage", "daily", "--from-json", "fleet-report.json"]);
+    let cli = parse(&["ccusage", "daily", "--from-json", "combined-report.json"]);
 
     let Some(Command::All(args)) = cli.command else {
         panic!("expected unified daily command");
     };
     assert_eq!(
         args.from_json,
-        Some(std::path::PathBuf::from("fleet-report.json"))
+        Some(std::path::PathBuf::from("combined-report.json"))
     );
 }
 
@@ -45,7 +45,7 @@ fn rejects_json_output_when_rendering_from_json() {
         "ccusage",
         "daily",
         "--from-json",
-        "fleet-report.json",
+        "combined-report.json",
         "--json",
     ]);
 

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -121,6 +121,7 @@ pub struct StatuslineArgs {
 pub struct AgentCommandArgs {
     pub shared: SharedArgs,
     pub kind: AgentReportKind,
+    pub from_json: Option<PathBuf>,
     pub sections: Option<Vec<AgentReportKind>>,
     pub by_agent: bool,
     pub pi_path: Option<String>,

--- a/rust/crates/ccusage/src/adapter/all/from_json.rs
+++ b/rust/crates/ccusage/src/adapter/all/from_json.rs
@@ -242,7 +242,7 @@ mod tests {
     #[test]
     fn loads_daily_report_from_file() {
         let fixture = fs_fixture!({
-            "fleet-report.json": r#"{
+            "combined-report.json": r#"{
                 "daily": [],
                 "totals": {
                     "inputTokens": 0,
@@ -255,7 +255,7 @@ mod tests {
             }"#,
         });
 
-        let rows = load(&fixture.path("fleet-report.json")).unwrap();
+        let rows = load(&fixture.path("combined-report.json")).unwrap();
 
         assert!(rows.is_empty());
     }

--- a/rust/crates/ccusage/src/adapter/all/from_json.rs
+++ b/rust/crates/ccusage/src/adapter/all/from_json.rs
@@ -1,0 +1,293 @@
+use std::{fs, path::Path};
+
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{Context, ModelBreakdown, Result, cli_error};
+
+use super::{BUILT_IN_AGENT_NAMES, loader::leak_agent_name, types::AllRow};
+
+#[derive(Deserialize)]
+struct DailyReport {
+    daily: Vec<DailyRow>,
+    totals: ReportTotals,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DailyRow {
+    period: String,
+    agent: String,
+    models_used: Vec<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    total_tokens: u64,
+    total_cost: f64,
+    #[serde(default)]
+    metadata: Option<Value>,
+    #[serde(default)]
+    model_breakdowns: Vec<ImportedModelBreakdown>,
+    #[serde(default)]
+    agents: Vec<ImportedAgentRow>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportedAgentRow {
+    agent: String,
+    models_used: Vec<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    total_tokens: u64,
+    total_cost: f64,
+    #[serde(default)]
+    model_breakdowns: Vec<ImportedModelBreakdown>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ImportedModelBreakdown {
+    model_name: String,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    cost: f64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ReportTotals {
+    _input_tokens: u64,
+    _output_tokens: u64,
+    _cache_creation_tokens: u64,
+    _cache_read_tokens: u64,
+    _total_tokens: u64,
+    _total_cost: f64,
+}
+
+fn parse_report(json: &str) -> Result<Vec<AllRow>> {
+    let report: DailyReport = serde_json::from_str(json)?;
+    let _ = report.totals;
+    report.daily.into_iter().map(DailyRow::into_row).collect()
+}
+
+pub(super) fn load(path: &Path) -> Result<Vec<AllRow>> {
+    let json = fs::read_to_string(path).context(format!(
+        "failed to read daily report from {}",
+        path.display()
+    ))?;
+    parse_report(&json).context(format!(
+        "failed to parse daily report from {}",
+        path.display()
+    ))
+}
+
+impl DailyRow {
+    fn into_row(self) -> Result<AllRow> {
+        let metadata_agents = metadata_agents(self.metadata.as_ref())?;
+        let agent_breakdowns = self
+            .agents
+            .into_iter()
+            .map(|row| row.into_row(&self.period))
+            .collect::<Result<Vec<_>>>()?;
+        Ok(AllRow {
+            period: self.period,
+            agent: resolve_agent(&self.agent)?,
+            models_used: self.models_used,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            total_tokens: self.total_tokens,
+            total_cost: self.total_cost,
+            metadata: self.metadata,
+            metadata_agents,
+            agent_breakdowns: (!agent_breakdowns.is_empty()).then_some(agent_breakdowns),
+            model_breakdowns: convert_model_breakdowns(self.model_breakdowns),
+        })
+    }
+}
+
+impl ImportedAgentRow {
+    fn into_row(self, period: &str) -> Result<AllRow> {
+        let agent = resolve_agent(&self.agent)?;
+        Ok(AllRow {
+            period: period.to_string(),
+            agent,
+            models_used: self.models_used,
+            input_tokens: self.input_tokens,
+            output_tokens: self.output_tokens,
+            cache_creation_tokens: self.cache_creation_tokens,
+            cache_read_tokens: self.cache_read_tokens,
+            total_tokens: self.total_tokens,
+            total_cost: self.total_cost,
+            metadata: None,
+            metadata_agents: Some(vec![agent]),
+            agent_breakdowns: None,
+            model_breakdowns: convert_model_breakdowns(self.model_breakdowns),
+        })
+    }
+}
+
+fn convert_model_breakdowns(rows: Vec<ImportedModelBreakdown>) -> Vec<ModelBreakdown> {
+    rows.into_iter()
+        .map(|row| ModelBreakdown {
+            model_name: row.model_name,
+            input_tokens: row.input_tokens,
+            output_tokens: row.output_tokens,
+            cache_creation_tokens: row.cache_creation_tokens,
+            cache_read_tokens: row.cache_read_tokens,
+            cost: row.cost,
+            ..ModelBreakdown::default()
+        })
+        .collect()
+}
+
+fn metadata_agents(metadata: Option<&Value>) -> Result<Option<Vec<&'static str>>> {
+    let Some(agents) = metadata
+        .and_then(|value| value.get("agents"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(None);
+    };
+    agents
+        .iter()
+        .map(|value| {
+            value
+                .as_str()
+                .ok_or_else(|| cli_error("metadata.agents entries must be strings"))
+                .and_then(resolve_agent)
+        })
+        .collect::<Result<Vec<_>>>()
+        .map(Some)
+}
+
+fn resolve_agent(agent: &str) -> Result<&'static str> {
+    if agent == "all" {
+        return Ok("all");
+    }
+    Ok(BUILT_IN_AGENT_NAMES
+        .iter()
+        .copied()
+        .find(|known| *known == agent)
+        .unwrap_or_else(|| leak_agent_name(agent)))
+}
+
+#[cfg(test)]
+mod tests {
+    use ccusage_test_support::fs_fixture;
+
+    use super::*;
+
+    #[test]
+    fn parses_ccusage_daily_report_rows() {
+        let rows = parse_report(
+            r#"{
+                "daily": [{
+                    "agent": "all",
+                    "modelsUsed": ["claude-sonnet-4-20250514"],
+                    "inputTokens": 100,
+                    "outputTokens": 20,
+                    "cacheCreationTokens": 5,
+                    "cacheReadTokens": 10,
+                    "totalTokens": 135,
+                    "totalCost": 0.25,
+                    "metadata": {"agents": ["claude"]},
+                    "agents": [{
+                        "agent": "claude",
+                        "modelsUsed": ["claude-sonnet-4-20250514"],
+                        "inputTokens": 100,
+                        "outputTokens": 20,
+                        "cacheCreationTokens": 5,
+                        "cacheReadTokens": 10,
+                        "totalTokens": 135,
+                        "totalCost": 0.25,
+                        "modelBreakdowns": []
+                    }],
+                    "modelBreakdowns": [{
+                        "modelName": "claude-sonnet-4-20250514",
+                        "inputTokens": 100,
+                        "outputTokens": 20,
+                        "cacheCreationTokens": 5,
+                        "cacheReadTokens": 10,
+                        "cost": 0.25
+                    }],
+                    "period": "2026-07-26"
+                }],
+                "totals": {
+                    "inputTokens": 100,
+                    "outputTokens": 20,
+                    "cacheCreationTokens": 5,
+                    "cacheReadTokens": 10,
+                    "totalTokens": 135,
+                    "totalCost": 0.25
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].period, "2026-07-26");
+        assert_eq!(rows[0].total_tokens, 135);
+        assert_eq!(rows[0].model_breakdowns.len(), 1);
+        assert_eq!(rows[0].metadata_agents, Some(vec!["claude"]));
+        assert_eq!(rows[0].agent_breakdowns.as_ref().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn loads_daily_report_from_file() {
+        let fixture = fs_fixture!({
+            "fleet-report.json": r#"{
+                "daily": [],
+                "totals": {
+                    "inputTokens": 0,
+                    "outputTokens": 0,
+                    "cacheCreationTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalTokens": 0,
+                    "totalCost": 0
+                }
+            }"#,
+        });
+
+        let rows = load(&fixture.path("fleet-report.json")).unwrap();
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn parses_named_pi_store_agents_emitted_by_ccusage() {
+        let rows = parse_report(
+            r#"{
+                "daily": [{
+                    "agent": "omp",
+                    "modelsUsed": ["omp/gpt-5"],
+                    "inputTokens": 1,
+                    "outputTokens": 2,
+                    "cacheCreationTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalTokens": 3,
+                    "totalCost": 0,
+                    "modelBreakdowns": [],
+                    "period": "2026-07-26"
+                }],
+                "totals": {
+                    "inputTokens": 1,
+                    "outputTokens": 2,
+                    "cacheCreationTokens": 0,
+                    "cacheReadTokens": 0,
+                    "totalTokens": 3,
+                    "totalCost": 0
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(rows[0].agent, "omp");
+    }
+}

--- a/rust/crates/ccusage/src/adapter/all/loader.rs
+++ b/rust/crates/ccusage/src/adapter/all/loader.rs
@@ -433,7 +433,7 @@ fn append_agent_rows(
     rows.extend(agent_rows.rows);
 }
 
-fn leak_agent_name(name: &str) -> &'static str {
+pub(super) fn leak_agent_name(name: &str) -> &'static str {
     Box::leak(name.to_string().into_boxed_str())
 }
 

--- a/rust/crates/ccusage/src/adapter/all/mod.rs
+++ b/rust/crates/ccusage/src/adapter/all/mod.rs
@@ -1,3 +1,4 @@
+mod from_json;
 mod loader;
 mod report;
 mod types;
@@ -12,6 +13,10 @@ pub(crate) fn run(args: AgentCommandArgs) -> Result<()> {
     let kind = args.kind;
     let shared = args.shared;
     let include_agents = args.by_agent;
+    if let Some(path) = args.from_json.as_deref() {
+        let rows = from_json::load(path)?;
+        return report::print_table(&rows, AgentReportKind::Daily, &shared, &[]);
+    }
     if let Some(sections) = args.sections {
         let sections = requested_sections(kind, sections);
         let result = loader::load_sections(&sections, &shared)?;

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -152,6 +152,7 @@ fn main() -> Result<()> {
             let args = AgentCommandArgs {
                 shared: cli.shared,
                 kind: AgentReportKind::Daily,
+                from_json: None,
                 sections: None,
                 by_agent: false,
                 pi_path: None,


### PR DESCRIPTION
Adds a `--from-json` option to render output from json generated by the cli.

Meant to be used by aggregators like [fleet](https://github.com/extoci/fleet) for showing total usage across machines (by combining json files generated by ccusage on each machine).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787678284&installation_model_id=423687&pr_number=1490&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1490&signature=cf8a8aafbba31f6c4a691c16161b06aa9c43b81d419cb15a38b7a79a595baf47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--from-json` option to `ccusage daily` to render reports from ccusage-compatible JSON with the standard responsive table. This enables merging per-machine outputs and viewing the combined result in `ccusage`.

- **New Features**
  - `ccusage daily --from-json <file>` renders a report from a JSON file matching `ccusage daily --json`.
  - Preserves agent names (including named PI stores), model breakdowns, agents metadata, tokens, and costs.
  - Validates flags: cannot combine `--from-json` with `--json` or `--sections`; contextual help updated.

<sup>Written for commit 2014fde7ddeb60d99ccbe098579509112d72395c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `ccusage daily --from-json <file>` to render daily reports from existing JSON files.
  * Imported reports use the standard responsive daily table format.
  * Added validation for incompatible combinations with `--json` and `--sections`.

* **Documentation**
  * Updated CLI help, usage examples, and daily report documentation with the new workflow and required JSON format.

* **Tests**
  * Added coverage for parsing, validation, help text, and rendering imported reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->