### PR TITLE
feat(claude): add CCUSAGE_CLAUDE_EXTRA_DIRS to aggregate multiple Claude installs

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -81,6 +81,17 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
+### Multiple Claude Code installs
+
+ccusage reads Claude Code data from `~/.claude` and `~/.config/claude` by default. If you run several Claude Code installs that each point `CLAUDE_CONFIG_DIR` at their own directory (for example, separate work/personal profiles), register those directories so their usage is included alongside the defaults:
+
+```bash
+export CCUSAGE_CLAUDE_EXTRA_DIRS="~/.claude-pessoal,~/.claude-work"
+ccusage daily
+```
+
+`CCUSAGE_CLAUDE_EXTRA_DIRS` is additive — it combines with the default locations (and with `CLAUDE_CONFIG_DIR` when set) instead of replacing them. See [Environment Variables](https://ccusage.com/guide/environment-variables) for details.
+
 ## Installation
 
 ### Package Runners

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -54,10 +54,11 @@ Claude Code exposes additional local data that enables features beyond the share
 
 ## Environment Variables
 
-| Variable            | Description                                  |
-| ------------------- | -------------------------------------------- |
-| `CLAUDE_CONFIG_DIR` | Override the root Claude Code data directory |
-| `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace)      |
+| Variable                   | Description                                       |
+| -------------------------- | ------------------------------------------------- |
+| `CLAUDE_CONFIG_DIR`        | Override the root Claude Code data directory      |
+| `CCUSAGE_CLAUDE_EXTRA_DIRS`| Add extra data directories to the resolved set    |
+| `LOG_LEVEL`                | Adjust verbosity (0 silent ... 5 trace)           |
 
 ### Custom Claude Code Paths
 
@@ -75,6 +76,13 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
+To keep the default locations and add more on top (for example, named Claude Code installs that each use their own `CLAUDE_CONFIG_DIR`), set `CCUSAGE_CLAUDE_EXTRA_DIRS`:
+
+```bash
+export CCUSAGE_CLAUDE_EXTRA_DIRS="~/.claude-pessoal,~/.claude-work"
+ccusage claude daily
+```
+
 For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
@@ -84,7 +92,7 @@ When `CLAUDE_CONFIG_DIR` is not set, ccusage searches in this order:
 1. `~/.config/claude/projects/`
 2. `~/.claude/projects/`
 
-Data from all valid directories is combined automatically.
+Data from all valid directories is combined automatically. Directories listed in `CCUSAGE_CLAUDE_EXTRA_DIRS` are appended to this set.
 
 ## Troubleshooting
 

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -50,6 +50,15 @@ Empty entries, directories that do not exist, and missing explicit files are ski
 
 Specifies where ccusage should look for Claude Code data. See [Claude Code](/guide/claude/) for default paths, multiple-directory behavior, and Claude-specific examples.
 
+## CCUSAGE_CLAUDE_EXTRA_DIRS
+
+Adds extra Claude Code data directories on top of the ones ccusage already resolves. Unlike `CLAUDE_CONFIG_DIR`, which replaces the default lookup, this variable is additive: the listed directories are combined with the defaults (or with `CLAUDE_CONFIG_DIR` when it is set). Accepts one directory or a comma-separated list; `~` is expanded, and entries without a `projects/` directory are skipped.
+
+```bash
+export CCUSAGE_CLAUDE_EXTRA_DIRS="~/.claude-pessoal,~/.claude-work"
+ccusage daily
+```
+
 ## LOG_LEVEL
 
 Controls the verbosity of log output.

--- a/rust/adapters/claude/README.md
+++ b/rust/adapters/claude/README.md
@@ -14,6 +14,7 @@ Anything that is not specific to this source belongs in `ccusage-core` or
 ## Data source
 
 - `~/.claude/projects/**/*.jsonl` and `~/.config/claude/projects/**/*.jsonl`
+- `CCUSAGE_CLAUDE_EXTRA_DIRS` appends extra Claude config directories (comma-separated) to the resolved set
 
 Record shapes, token mapping, and cost rules are documented in [`src/README.md`](src/README.md).
 

--- a/rust/adapters/claude/src/paths.rs
+++ b/rust/adapters/claude/src/paths.rs
@@ -13,34 +13,40 @@ pub fn claude_paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = FxHashSet::default();
     if let Ok(env_paths) = env::var("CLAUDE_CONFIG_DIR") {
-        for raw in env_paths
-            .split(',')
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-        {
-            let path = normalize_claude_config_path(raw);
+        append_config_dirs(&env_paths, &mut paths, &mut seen);
+        if paths.is_empty() {
+            return Err(cli_error(format!(
+                "No valid Claude data directories found in CLAUDE_CONFIG_DIR. Expected each path to be a Claude config directory containing 'projects/', or the 'projects/' directory itself: {env_paths}"
+            )));
+        }
+    } else {
+        let home = home::home_dir().ok_or_else(|| cli_error("home directory is not set"))?;
+        let xdg = env::var("XDG_CONFIG_HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|_| PathBuf::from(&home).join(".config"));
+        for path in [xdg.join("claude"), home.join(".claude")] {
             if path.join("projects").is_dir() && seen.insert(path.clone()) {
                 paths.push(path);
             }
         }
-        if !paths.is_empty() {
-            return Ok(paths);
-        }
-        return Err(cli_error(format!(
-            "No valid Claude data directories found in CLAUDE_CONFIG_DIR. Expected each path to be a Claude config directory containing 'projects/', or the 'projects/' directory itself: {env_paths}"
-        )));
     }
+    if let Ok(extra_dirs) = env::var("CCUSAGE_CLAUDE_EXTRA_DIRS") {
+        append_config_dirs(&extra_dirs, &mut paths, &mut seen);
+    }
+    Ok(paths)
+}
 
-    let home = home::home_dir().ok_or_else(|| cli_error("home directory is not set"))?;
-    let xdg = env::var("XDG_CONFIG_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from(&home).join(".config"));
-    for path in [xdg.join("claude"), home.join(".claude")] {
+fn append_config_dirs(raw: &str, paths: &mut Vec<PathBuf>, seen: &mut FxHashSet<PathBuf>) {
+    for entry in raw
+        .split(',')
+        .map(str::trim)
+        .filter(|path| !path.is_empty())
+    {
+        let path = normalize_claude_config_path(entry);
         if path.join("projects").is_dir() && seen.insert(path.clone()) {
             paths.push(path);
         }
     }
-    Ok(paths)
 }
 
 fn normalize_claude_config_path(raw: &str) -> PathBuf {

--- a/rust/crates/ccusage-adapter-all/src/report.rs
+++ b/rust/crates/ccusage-adapter-all/src/report.rs
@@ -199,6 +199,12 @@ pub(super) fn print_table(
     print_box_title(&all_report_title(kind, rows, detected_agents), shared);
     if rows.is_empty() {
         eprintln!("No usage data found.");
+        if std::env::var_os("CCUSAGE_CLAUDE_EXTRA_DIRS").is_none() {
+            eprintln!(
+                "Tip: Claude Code installs with a custom CLAUDE_CONFIG_DIR are not read by default. \
+                 List them in CCUSAGE_CLAUDE_EXTRA_DIRS (comma-separated) to include their usage."
+            );
+        }
         return Ok(());
     }
     let terminal_width = crate::terminal_width();

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -64,9 +64,9 @@ fn main() -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use std::{collections::HashMap, fs, sync::Arc};
+    use std::{collections::HashMap, ffi::OsString, fs, sync::Arc};
 
-    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+    use ccusage_test_support::{EnvVarGuard, EnvVarsGuard, fs_fixture};
     use serde_json::json;
 
     use super::*;
@@ -937,5 +937,88 @@ mod tests {
             )
             .is_none()
         );
+    }
+
+    fn extra_dirs_usage_line(message_id: &str) -> String {
+        format!(
+            r#"{{"timestamp":"2025-01-10T10:00:00.000Z","message":{{"id":"{message_id}","model":"claude-opus-4-6","usage":{{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}}}},"costUSD":0.001}}"#
+        )
+    }
+
+    fn display_shared_args() -> SharedArgs {
+        SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        }
+    }
+
+    #[test]
+    fn adds_extra_claude_dirs_to_default_sources() {
+        let default_dir = fs_fixture!({
+            ".claude/projects/default-project/session1/chat.jsonl": extra_dirs_usage_line("msg_default"),
+        });
+        let extra_dir = fs_fixture!({
+            "projects/extra-project/session2/chat.jsonl": extra_dirs_usage_line("msg_extra"),
+        });
+
+        let _env = EnvVarsGuard::set_many([
+            ("CLAUDE_CONFIG_DIR", None),
+            ("XDG_CONFIG_HOME", None),
+            ("HOME", Some(default_dir.root().as_os_str().to_os_string())),
+            (
+                "CCUSAGE_CLAUDE_EXTRA_DIRS",
+                Some(extra_dir.root().as_os_str().to_os_string()),
+            ),
+        ]);
+        let entries = load_entries(&display_shared_args(), None).unwrap();
+
+        let mut projects: Vec<&str> = entries.iter().map(|entry| &*entry.project).collect();
+        projects.sort();
+        assert_eq!(projects, vec!["default-project", "extra-project"]);
+    }
+
+    #[test]
+    fn ignores_extra_claude_dirs_without_projects() {
+        let default_dir = fs_fixture!({
+            ".claude/projects/default-project/session1/chat.jsonl": extra_dirs_usage_line("msg_default"),
+        });
+        let invalid_extra = fs_fixture!({
+            "not-projects/extra-project/session2/chat.jsonl": extra_dirs_usage_line("msg_extra"),
+        });
+
+        let _env = EnvVarsGuard::set_many([
+            ("CLAUDE_CONFIG_DIR", None),
+            ("XDG_CONFIG_HOME", None),
+            ("HOME", Some(default_dir.root().as_os_str().to_os_string())),
+            (
+                "CCUSAGE_CLAUDE_EXTRA_DIRS",
+                Some(invalid_extra.root().as_os_str().to_os_string()),
+            ),
+        ]);
+        let entries = load_entries(&display_shared_args(), None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_ref(), "default-project");
+    }
+
+    #[test]
+    fn dedupes_extra_claude_dir_matching_default() {
+        let default_dir = fs_fixture!({
+            ".claude/projects/default-project/session1/chat.jsonl": extra_dirs_usage_line("msg_default"),
+        });
+
+        let _env = EnvVarsGuard::set_many([
+            ("CLAUDE_CONFIG_DIR", None),
+            ("XDG_CONFIG_HOME", None),
+            ("HOME", Some(default_dir.root().as_os_str().to_os_string())),
+            (
+                "CCUSAGE_CLAUDE_EXTRA_DIRS",
+                Some(OsString::from(default_dir.path(".claude"))),
+            ),
+        ]);
+        let entries = load_entries(&display_shared_args(), None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].project.as_ref(), "default-project");
     }
 }


### PR DESCRIPTION
## Summary

`CLAUDE_CONFIG_DIR` replaces ccusage's default Claude data directories, so users running several Claude Code installs (each pointed at its own config directory) cannot aggregate them together with the defaults. This adds an additive `CCUSAGE_CLAUDE_EXTRA_DIRS` variable that appends comma-separated Claude config directories to whatever set is already resolved.

## What Changed

- `claude_paths()` now populates a single `paths`/`seen` collection from both the `CLAUDE_CONFIG_DIR` branch and the default branch, then appends any directories listed in `CCUSAGE_CLAUDE_EXTRA_DIRS` through a shared `append_config_dirs` helper. The helper normalizes each entry (`~` expansion, `projects/` suffix), validates the `projects/` directory, and dedupes. Invalid extra directories are skipped silently.
- When a report resolves to zero rows and `CCUSAGE_CLAUDE_EXTRA_DIRS` is unset, print a tip pointing at the variable so the omission is discoverable.
- Docs: README section for multiple Claude Code installs, an environment-variables reference section, Claude guide updates, and an adapter README note.

## Why

I run several named Claude Code installs (`claudeqwen`, etc.), each with its own `CLAUDE_CONFIG_DIR`. Detecting them by folder name is brittle; an explicit, deterministic env var that adds to the defaults fits the repo's existing `CCUSAGE_*` convention (`CCUSAGE_PRICING_JSON_PATH`, `CCUSAGE_MODEL_ALIASES`).

## Testing

- `cargo test -p ccusage` (53 passed), `cargo test -p ccusage-adapter-claude` (13 passed), `cargo test -p ccusage-adapter-all` (34 passed)
- Three new tests: extras combine with defaults, extras lacking `projects/` are ignored, and an extra matching a default is deduped
- End-to-end against real directories: combined run adds the extra installs' sessions/cost with no double-counting (listing a directory in both `CLAUDE_CONFIG_DIR` and `CCUSAGE_CLAUDE_EXTRA_DIRS` counts it once)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1504"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787781195&installation_model_id=423687&pr_number=1504&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1504&signature=4fd968e77783f7ec3e947a7ea21a5a67f865a8092f622fc645beb84a22ea3306"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `CCUSAGE_CLAUDE_EXTRA_DIRS` to let users aggregate multiple Claude Code installs by appending extra config directories to the resolved set. Also prints a tip when a report is empty and the variable isn’t set.

- **New Features**
  - `CCUSAGE_CLAUDE_EXTRA_DIRS` appends comma-separated Claude config dirs to those found via defaults or `CLAUDE_CONFIG_DIR`.
  - Paths are normalized (`~` expansion, accept config root or `projects/`), deduped, and invalid extras are skipped without error; `CLAUDE_CONFIG_DIR` still errors if it resolves to none.
  - Path resolution now shares a single helper inside `claude_paths()`.
  - When a report has no rows and the variable is unset, the CLI shows a tip to configure it.
  - Docs updated with examples and an environment variable reference.

<sup>Written for commit 5fb579818e5cadc4d7b057096dde14a86cf506e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1504?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for including usage data from additional Claude Code installation directories via `CCUSAGE_CLAUDE_EXTRA_DIRS`.
  * Supports comma-separated paths, home-directory expansion, and automatic duplicate removal.
  * Invalid directories without a `projects/` folder are ignored.
  * Displays a helpful tip when no usage data is found and extra directories may be needed.

* **Documentation**
  * Added setup instructions, examples, default path details, and environment-variable guidance across the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->