### PR TITLE
feat(grok): add Grok Build CLI usage adapter

### DIFF
--- a/.agents/skills/agent-sources/SKILL.md
+++ b/.agents/skills/agent-sources/SKILL.md
@@ -44,6 +44,7 @@ flags:
 - OpenCode: `rust/adapters/opencode/src/README.md`
 - Amp: `rust/adapters/amp/src/README.md`
 - pi-agent: `rust/adapters/pi/src/README.md`
+- Grok Build CLI: `rust/adapters/grok/README.md`
 
 ## Implementation Notes
 

--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -78,6 +78,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
+| Grok Build CLI     | `ccusage grok daily`     |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
@@ -132,6 +133,7 @@ bunx ccusage kimi daily
 bunx ccusage qwen daily
 bunx ccusage copilot daily
 bunx ccusage gemini daily
+bunx ccusage grok daily
 bunx ccusage pi daily --pi-path /path/to/sessions
 bunx ccusage pi daily --pi-path /path/to/sessions,/archive/pi/sessions
 
@@ -164,7 +166,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -7027,6 +7027,684 @@
 					},
 					"type": "object"
 				},
+				"grok": {
+					"additionalProperties": false,
+					"description": "Grok Build CLI configuration.",
+					"markdownDescription": "Grok Build CLI configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"default": false,
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
 				"hermes": {
 					"additionalProperties": false,
 					"description": "Hermes Agent configuration.",

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Grok Build CLI', link: '/guide/grok/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/grok/index.md
+++ b/docs/guide/grok/index.md
@@ -1,0 +1,104 @@
+# Grok Build CLI Data Source
+
+ccusage can read local Grok Build CLI session logs as a supported data source. Grok uses the same unified and focused report model as other agents.
+
+## Focused Views
+
+```bash
+# Daily Grok usage
+ccusage grok daily
+
+# Monthly Grok usage
+ccusage grok monthly
+
+# Grok sessions
+ccusage grok session
+```
+
+Most users can start with unified reports such as `ccusage daily`. Add the `grok` namespace only when you want to focus the same report shape on Grok usage.
+
+## Data Source
+
+The CLI reads completed turns from `updates.jsonl` under the Grok home directory.
+
+Root resolution (highest first):
+
+1. A non-empty `GROK_HOME` (official Grok environment variable)
+2. `~/.grok`
+
+```bash
+GROK_HOME="$HOME/.grok" ccusage grok daily
+```
+
+```text
+$GROK_HOME/   # or ~/.grok
+└── sessions/
+    └── <url-encoded-cwd>/
+        └── <session-uuid>/
+            ├── updates.jsonl  # PRIMARY (turn_completed + usage)
+            └── summary.json   # optional metadata
+```
+
+Only rows with `sessionUpdate == "turn_completed"` and a usable usage breakdown are counted. In-progress turns are not included until they complete. `logs/unified.jsonl` is not used in this version.
+
+## Report Views
+
+| Focused view           | Description                     | See also                                |
+| ---------------------- | ------------------------------- | --------------------------------------- |
+| `ccusage grok daily`   | Aggregate usage by date         | [Daily Usage](/guide/daily-reports)     |
+| `ccusage grok monthly` | Aggregate usage by month        | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage grok session` | Group usage by Grok session     | [Session Usage](/guide/session-reports) |
+
+These views support `--json`, `--compact`, `--mode`, and `--offline`.
+
+## What Gets Calculated
+
+- **Token usage** - Grok records OpenAI-style usage where `inputTokens` includes cache. ccusage stores uncached input as `input − cachedRead`, cache as cache read, and full `outputTokens` as output.
+- **Reasoning tokens** - `reasoningTokens` are included in total tokens (`extra_total`) only. They are **not** billed separately and are **not** added on top of output for cost.
+- **Precomputed cost** - Grok `costUsdTicks` are ignored. `cost_usd` is never set from session files.
+- **Pricing** - Costs are LiteLLM-based estimates. Model ids such as `grok-4.5-build` try candidates with the trailing `-build` stripped and `xai/` / `x-ai/` prefixes. Display mode shows `$0` for Grok.
+- **Model labels** - Display form is the raw `modelUsage` key (e.g. `grok-4.5-build`). The Agent column identifies the Grok source in unified reports.
+
+## Environment Variables
+
+| Variable    | Description                                  |
+| ----------- | -------------------------------------------- |
+| `GROK_HOME` | Official Grok config/data home (single root) |
+| `LOG_LEVEL` | Adjust verbosity (0 silent ... 5 trace)      |
+
+## Configuration
+
+```json
+{
+  "grok": {
+    "defaults": {
+      "offline": true
+    },
+    "commands": {
+      "session": {
+        "json": true
+      }
+    }
+  }
+}
+```
+
+The `grok` namespace supports the same shared report options as other focused
+sources. Use `grok.defaults` for all Grok reports and a matching
+`grok.commands.daily`, `grok.commands.monthly`, or `grok.commands.session`
+object for report-specific overrides. The data root is discovered from
+`GROK_HOME` or `~/.grok`, not from ccusage configuration.
+
+## Troubleshooting
+
+::: details No Grok usage data found
+Ensure completed turns exist under `~/.grok/sessions/**/updates.jsonl`. In-progress turns do not appear until `turn_completed` is written. Set `GROK_HOME` if your data lives elsewhere.
+:::
+
+::: details Costs showing as $0.00
+Grok has no precomputed USD in ccusage. Use default `auto` or `--mode calculate` with offline/online LiteLLM pricing. Display mode intentionally shows `$0`. If a model is missing from pricing, cost stays `$0` and a missing-pricing warning may appear.
+:::
+
+::: details Totals lower than expected while a turn is open
+v1 only counts completed turns. Finish the turn (or wait for `turn_completed`) and re-run the report.
+:::

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -89,11 +89,12 @@ ccusage reads from local coding CLI data directories:
 | Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
 | Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
 | Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
+| Grok Build CLI | `grok`   | `${GROK_HOME:-~/.grok}`                                       |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
-Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
+Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, Grok CLI, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI and Devin CLI.
 
 ## Report Shape
 
@@ -124,6 +125,7 @@ ccusage kimi daily
 ccusage qwen daily
 ccusage copilot daily
 ccusage gemini daily
+ccusage grok daily
 ```
 
 Use `ccusage <source> <report>` only when you want to narrow a report to one source.

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -29,8 +29,8 @@ The CLI log files include operational events such as conversation creation, stre
 Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
 :::
 
-::: details Why is Grok CLI not supported?
-Grok CLI was investigated, but its local SQLite data did not contain usable token accounting. Without token counts, model usage, or recorded costs in the local database, ccusage has nothing reliable to aggregate.
+::: details Is Grok Build CLI supported?
+Yes. Use `ccusage grok daily|monthly|session` (or unified `ccusage daily` when local Grok data exists). ccusage reads completed turns from `~/.grok/sessions/**/updates.jsonl` (`GROK_HOME` overrides the default home). Costs are LiteLLM token estimates; Grok `costUsdTicks` are not used as invoice USD. In-progress turns are counted only after `turn_completed`.
 
 Estimating tokens from message text would ignore provider-side context, hidden prompts, tool-call payloads, cached input, and tokenizer differences, so ccusage does not do that.
 :::

--- a/docs/superpowers/specs/2026-07-28-grok-env-only-path-design.md
+++ b/docs/superpowers/specs/2026-07-28-grok-env-only-path-design.md
@@ -1,0 +1,90 @@
+# Grok Env-Only Path Discovery Design
+
+## Context
+
+The Grok adapter currently exposes an explicit path through `--grok-path`,
+`grokPath`, and internal command/config plumbing. Carrying that value into every
+report path also led to a change where a bare `ccusage` invocation is parsed as
+an explicit unified daily command instead of retaining the existing
+`command: None` representation.
+
+Other adapters do not establish one universal path-configuration pattern. Pi
+supports an explicit focused-command path, while Gemini discovers its data
+directory from an environment variable or a default location. Grok only needs
+one data root and does not need a second ccusage-specific override mechanism.
+
+## Decision
+
+The Grok adapter will resolve its home directory using this precedence:
+
+1. A non-empty `GROK_HOME` environment variable.
+2. The default `~/.grok` directory.
+
+There will be no `--grok-path` CLI option, `grokPath` configuration property,
+`CCUSAGE_GROK_PATH` variable, or internal Grok path argument. Focused Grok
+reports and all unified report entry points will use the same adapter-owned
+discovery logic.
+
+The `grok` configuration namespace remains available for shared report options,
+such as JSON or offline behavior, just as other agent namespaces are.
+
+## Data Flow
+
+For `ccusage grok`, explicit `ccusage all` commands, bare `ccusage`, and unified
+session reports, command handling selects the Grok adapter without supplying a
+path. The adapter reads `GROK_HOME`; after rejecting an empty value, it falls
+back to `~/.grok`, then loads the adapter's expected session data beneath that
+root.
+
+Because no path value needs to be injected into the default command, bare
+`ccusage` parsing returns `command: None` as it did before Grok support. The
+existing application entry point remains responsible for interpreting that as
+the unified daily report.
+
+## Required Changes
+
+- Remove `--grok-path` and its help text and snapshots.
+- Remove `grokPath` from configuration types, generated schema, examples, and
+  tests.
+- Remove the Grok path field from agent command arguments and from focused and
+  unified loader plumbing.
+- Remove any remaining `CCUSAGE_GROK_PATH` handling or regression references.
+- Keep only `GROK_HOME` and `~/.grok` resolution in the Grok adapter.
+- Restore the pre-feature bare-command parser representation.
+
+## Validation
+
+Tests will verify that:
+
+- a non-empty `GROK_HOME` selects that directory;
+- an unset or empty `GROK_HOME` falls back to `~/.grok`;
+- focused, explicit unified, bare unified daily, and unified session reports can
+  load Grok data through the same discovery path;
+- bare parsing again yields no explicit command;
+- generated configuration schema, CLI help, and snapshots contain neither
+  `grokPath` nor `--grok-path`;
+- existing workspace formatting, tests, and lint checks continue to pass.
+
+Environment-mutating tests must use the repository's environment guard pattern
+so their state is restored and they do not race with unrelated tests.
+
+## Documentation Impact
+
+User-facing documentation will describe `GROK_HOME` and the `~/.grok` default.
+Any mention of `grokPath` or `--grok-path` introduced by this feature will be
+removed. The generated configuration schema will be regenerated from the
+updated configuration types.
+
+## Out of Scope
+
+- Changing Pi, Gemini, or other adapters' path behavior.
+- Introducing a generalized path configuration abstraction.
+- Supporting multiple Grok roots.
+- Adding another Grok-specific environment variable.
+- Refactoring unrelated unified report or configuration behavior.
+
+## Compatibility
+
+The Grok feature has not been merged or released, so removing its provisional
+path option and configuration property does not require a deprecation period or
+backward-compatibility shim.

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "ccusage-adapter-droid",
  "ccusage-adapter-gemini",
  "ccusage-adapter-goose",
+ "ccusage-adapter-grok",
  "ccusage-adapter-hermes",
  "ccusage-adapter-kilo",
  "ccusage-adapter-kimi",
@@ -154,6 +155,7 @@ dependencies = [
  "ccusage-adapter-droid",
  "ccusage-adapter-gemini",
  "ccusage-adapter-goose",
+ "ccusage-adapter-grok",
  "ccusage-adapter-hermes",
  "ccusage-adapter-kilo",
  "ccusage-adapter-kimi",
@@ -278,6 +280,18 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlite",
+]
+
+[[package]]
+name = "ccusage-adapter-grok"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -26,6 +26,7 @@ ccusage-adapter-copilot = { path = "adapters/copilot" }
 ccusage-adapter-droid = { path = "adapters/droid" }
 ccusage-adapter-gemini = { path = "adapters/gemini" }
 ccusage-adapter-goose = { path = "adapters/goose" }
+ccusage-adapter-grok = { path = "adapters/grok" }
 ccusage-adapter-hermes = { path = "adapters/hermes" }
 ccusage-adapter-kilo = { path = "adapters/kilo" }
 ccusage-adapter-kimi = { path = "adapters/kimi" }

--- a/rust/adapters/grok/Cargo.toml
+++ b/rust/adapters/grok/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccusage-adapter-grok"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/grok/README.md
+++ b/rust/adapters/grok/README.md
@@ -1,0 +1,76 @@
+# ccusage-adapter-grok
+
+The Grok Build CLI adapter: it turns session `updates.jsonl` files under
+`~/.grok` into the usage entries the reports render.
+
+## Owns
+
+- `loader.rs` — reading sessions, progress, global dedupe, `has_data`
+- `parser.rs` — `turn_completed` admission, token split, pricing candidates
+- `paths.rs` — root resolution and `sessions/**/updates.jsonl` discovery
+- `report.rs` — daily / monthly / session summary shapes
+
+Anything that is not specific to this source belongs in `ccusage-core` or
+`ccusage-adapter-common` instead.
+
+## Data source
+
+Only completed turns:
+
+```text
+$GROK_HOME/   # or ~/.grok
+└── sessions/
+    └── <url-encoded-cwd>/
+        └── <session-uuid>/
+            ├── updates.jsonl  # PRIMARY (turn_completed + usage)
+            └── summary.json   # optional metadata
+```
+
+Runtime root priority: a non-empty `GROK_HOME` → `~/.grok`.
+Path discovery stays inside the adapter, matching Grok Build CLI's official
+environment variable and default home.
+
+In-progress turns are not counted until `turn_completed` is written.
+`logs/unified.jsonl` is not used in v1.
+
+## Token mapping
+
+Grok records OpenAI-style usage where `inputTokens` includes cache:
+
+| Grok field | ccusage field | Rule |
+| --- | --- | --- |
+| `inputTokens − cachedReadTokens` | `input_tokens` | cache clamped ≤ input |
+| `cachedReadTokens` | `cache_read_input_tokens` | |
+| `outputTokens` | `output_tokens` | as recorded |
+| `reasoningTokens` | `extra_total_tokens` only | **not** billed separately |
+| — | `cache_creation_input_tokens` | always `0` |
+| `costUsdTicks` | ignored | `cost_usd` always unset |
+
+Costs are token × LiteLLM pricing estimates. Display mode shows `$0` for Grok.
+
+## Model display and pricing
+
+- Display label: raw `modelUsage` key (e.g. `grok-4.5-build`)
+- Pricing candidates strip trailing `-build` and try `xai/` / `x-ai/` forms
+
+## Public surface
+
+- `loader::load_entries`
+- `loader::has_data`
+- `report::report_from_rows`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde`
+- `serde_json`
+
+## Live smoke
+
+```powershell
+cargo test -p ccusage-adapter-grok smoke_real_grok_home_loads_without_error -- --ignored --nocapture
+```

--- a/rust/adapters/grok/src/lib.rs
+++ b/rust/adapters/grok/src/lib.rs
@@ -1,0 +1,67 @@
+use ccusage_adapter_common::{
+    collect_files_with_extension, filter_loaded_entries_by_date, read_files_parallel,
+};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::{has_data, load_entries};
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        ccusage_core::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Grok Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod smoke_tests {
+    use super::*;
+    use crate::cli::SharedArgs;
+
+    #[test]
+    #[ignore = "requires real Grok home with sessions/**/updates.jsonl"]
+    fn smoke_real_grok_home_loads_without_error() {
+        let shared = SharedArgs {
+            timezone: Some("UTC".into()),
+            ..SharedArgs::default()
+        };
+        let pricing = PricingMap::load_embedded();
+        let entries = load_entries(&shared, &pricing).unwrap();
+        let _ = entries.len();
+    }
+}

--- a/rust/adapters/grok/src/loader.rs
+++ b/rust/adapters/grok/src/loader.rs
@@ -1,0 +1,120 @@
+use std::collections::HashSet;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
+
+use super::{
+    parser::parse_session_files,
+    paths::{GrokSessionFiles, discover_session_files},
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(crate::progress::UsageLoadAgent("Grok"), shared.json, || {
+        load_entries_inner(shared, pricing)
+    })
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let sessions = discover_session_files()?;
+    let updates_paths: Vec<_> = sessions
+        .iter()
+        .map(|session| session.updates.clone())
+        .collect();
+    let loaded = read_files_parallel(&updates_paths, shared.single_thread, |updates| {
+        let session = GrokSessionFiles {
+            updates: updates.to_path_buf(),
+            summary: {
+                let summary = updates.with_file_name("summary.json");
+                summary.is_file().then_some(summary)
+            },
+        };
+        parse_session_files(&session, tz.as_ref(), shared.mode, pricing).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to read Grok session file {}: {error}",
+                    session.updates.display()
+                ),
+            );
+            Vec::new()
+        })
+    });
+
+    let mut entries: Vec<_> = loaded.into_iter().flatten().collect();
+    // Global dedupe across files (same eventId+model should not double-count).
+    let mut seen = HashSet::new();
+    entries.retain(|entry| {
+        let usage = entry.data.message.usage;
+        let key = entry
+            .data
+            .message
+            .id
+            .as_deref()
+            .map(|event_id| format!("{event_id}|{}", entry.model.as_deref().unwrap_or_default()))
+            .unwrap_or_else(|| {
+                format!(
+                    "{}|{}|{}|{}|{}|{}|{}",
+                    entry.session_id.as_ref(),
+                    entry.timestamp.as_millis(),
+                    entry.model.as_deref().unwrap_or_default(),
+                    usage.input_tokens,
+                    usage.output_tokens,
+                    usage.cache_read_input_tokens,
+                    entry.extra_total_tokens,
+                )
+            });
+        seen.insert(key)
+    });
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+pub fn has_data() -> bool {
+    discover_session_files().is_ok_and(|files| !files.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
+    use std::ffi::OsString;
+
+    #[test]
+    fn loads_session_tree_with_uncached_split() {
+        let line = r#"{"timestamp":1750000000,"params":{"sessionId":"sess-load","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"totalTokens":120,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"totalTokens":120}}}},"_meta":{"eventId":"evt-load"}}}"#;
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-load/updates.jsonl": line,
+            "sessions/proj/sess-load/summary.json": r#"{"info":{"id":"sess-load","cwd":"/tmp/proj"}}"#,
+        });
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let _guard = EnvVarsGuard::set_many([(
+            super::super::paths::GROK_HOME_ENV,
+            Some(OsString::from(fixture.root().as_os_str())),
+        )]);
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2025-06-15");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 60);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 40);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 20);
+        assert_eq!(entries[0].extra_total_tokens, 10);
+        assert_eq!(entries[0].model.as_deref(), Some("grok-4.5-build"));
+    }
+
+    #[test]
+    fn has_data_detects_updates_jsonl() {
+        let fixture = fs_fixture!({
+            "sessions/proj/sess/updates.jsonl": "{}\n",
+        });
+        let _guard = EnvVarsGuard::set_many([(
+            super::super::paths::GROK_HOME_ENV,
+            Some(OsString::from(fixture.root().as_os_str())),
+        )]);
+        assert!(has_data());
+    }
+}

--- a/rust/adapters/grok/src/parser.rs
+++ b/rust/adapters/grok/src/parser.rs
@@ -1,0 +1,618 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fs,
+    sync::Arc,
+};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
+use serde_json::Value;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
+    missing_pricing_model_for_candidates, total_usage_tokens,
+};
+use ccusage_adapter_common::jsonl;
+use ccusage_core::fast::LinePrefilter;
+
+use super::paths::GrokSessionFiles;
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokUpdateLine {
+    #[serde(default)]
+    timestamp: Option<Value>,
+    #[serde(default)]
+    params: Option<GrokParams>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokParams {
+    #[serde(
+        default,
+        rename = "sessionId",
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    session_id: Option<String>,
+    #[serde(default)]
+    update: Option<GrokUpdate>,
+    #[serde(default, rename = "_meta")]
+    meta: Option<GrokMeta>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokUpdate {
+    #[serde(
+        default,
+        rename = "sessionUpdate",
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    session_update: Option<String>,
+    #[serde(default)]
+    usage: Option<GrokUsage>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokMeta {
+    #[serde(
+        default,
+        rename = "eventId",
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    event_id: Option<String>,
+    #[serde(default, rename = "agentTimestampMs")]
+    agent_timestamp_ms: Option<Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GrokUsage {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cached_read_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    reasoning_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total_tokens: u64,
+    #[serde(default)]
+    model_usage: Option<HashMap<String, GrokModelUsage>>,
+}
+
+#[derive(Debug, Default, Clone, Copy, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct GrokModelUsage {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cached_read_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    reasoning_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total_tokens: u64,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummary {
+    #[serde(default)]
+    info: Option<GrokSummaryInfo>,
+    #[serde(
+        default,
+        rename = "git_root_dir",
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    git_root_dir: Option<String>,
+    #[serde(
+        default,
+        rename = "current_model_id",
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    current_model_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct GrokSummaryInfo {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    cwd: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SessionMeta {
+    session_id: String,
+    project_path: String,
+    default_model: Option<String>,
+}
+
+/// Split OpenAI-style input that includes cache: uncached = input − cache.
+pub(super) fn split_tokens(input: u64, cached: u64) -> (u64, u64) {
+    let cache = cached.min(input);
+    let uncached = input.saturating_sub(cache);
+    (uncached, cache)
+}
+
+/// Pricing lookup candidates for a raw Grok model id (e.g. `grok-4.5-build`).
+pub(super) fn pricing_candidates(raw_model: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    let mut push = |value: String| {
+        if !candidates.iter().any(|existing| existing == &value) {
+            candidates.push(value);
+        }
+    };
+
+    let stripped = raw_model
+        .strip_prefix("[grok] ")
+        .unwrap_or(raw_model)
+        .trim();
+    if stripped.is_empty() {
+        return candidates;
+    }
+
+    let normalized = stripped
+        .strip_suffix("-build")
+        .unwrap_or(stripped)
+        .to_string();
+
+    push(stripped.to_string());
+    push(format!("xai/{stripped}"));
+    push(format!("x-ai/{stripped}"));
+    push(normalized.clone());
+    push(format!("xai/{normalized}"));
+    push(format!("x-ai/{normalized}"));
+    candidates
+}
+
+pub(super) fn parse_session_files(
+    files: &GrokSessionFiles,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Result<Vec<LoadedEntry>> {
+    let meta = load_session_meta(files);
+    let content = fs::read(&files.updates)?;
+    let prefilter = LinePrefilter::all(&[br#""turn_completed""#]);
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+
+    for line in jsonl::records::<GrokUpdateLine>(&content, Some(&prefilter)) {
+        let Some(params) = line.params.as_ref() else {
+            continue;
+        };
+        let Some(update) = params.update.as_ref() else {
+            continue;
+        };
+        if update.session_update.as_deref() != Some("turn_completed") {
+            continue;
+        }
+        let Some(usage) = update.usage.as_ref() else {
+            continue;
+        };
+
+        let event_id = params.meta.as_ref().and_then(|meta| meta.event_id.clone());
+        let timestamp_ms = resolve_timestamp_ms(&line, params.meta.as_ref());
+        let session_id = params
+            .session_id
+            .clone()
+            .unwrap_or_else(|| meta.session_id.clone());
+
+        let model_rows = model_usage_rows(usage, meta.default_model.as_deref());
+        for (raw_model, model_usage) in model_rows {
+            let (uncached, cache) =
+                split_tokens(model_usage.input_tokens, model_usage.cached_read_tokens);
+            let output_tokens = model_usage.output_tokens;
+            let reasoning_tokens = model_usage.reasoning_tokens;
+            if uncached == 0 && cache == 0 && output_tokens == 0 && reasoning_tokens == 0 {
+                continue;
+            }
+            let usage_raw = TokenUsageRaw {
+                input_tokens: uncached,
+                output_tokens,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: cache,
+                speed: None,
+                cache_creation: None,
+            };
+
+            let dedupe_key = dedupe_key(
+                event_id.as_deref(),
+                &session_id,
+                timestamp_ms,
+                &raw_model,
+                usage_raw,
+                reasoning_tokens,
+            );
+            if !seen.insert(dedupe_key) {
+                continue;
+            }
+
+            // Display the raw modelUsage key (e.g. grok-4.5-build); Agent column already
+            // identifies the source in unified reports.
+            let display_model = raw_model.clone();
+            // Cost bills full output_tokens only; reasoning is never added to billable output.
+            let cost = calculate_grok_cost(&raw_model, usage_raw, mode, pricing);
+            let missing_pricing_model = missing_grok_pricing(&raw_model, usage_raw, mode, pricing);
+            let timestamp_text = format_rfc3339_millis(timestamp_ms);
+            let data = UsageEntry {
+                session_id: Some(session_id.clone()),
+                timestamp: timestamp_text,
+                version: None,
+                message: UsageMessage {
+                    usage: usage_raw,
+                    model: Some(display_model.clone()),
+                    id: event_id.clone(),
+                },
+                cost_usd: None,
+                request_id: event_id.clone(),
+                is_api_error_message: None,
+                is_sidechain: None,
+            };
+            entries.push(LoadedEntry {
+                data,
+                timestamp: timestamp_ms,
+                date: format_date_tz(timestamp_ms, tz),
+                project: Arc::from("grok"),
+                session_id: Arc::from(session_id.clone()),
+                project_path: Arc::from(meta.project_path.as_str()),
+                cost,
+                credits: None,
+                model: Some(display_model),
+                message_count: None,
+                usage_limit_reset_time: None,
+                missing_pricing_model,
+                extra_total_tokens: reasoning_tokens,
+            });
+            let _ = model_usage.total_tokens;
+        }
+    }
+
+    Ok(entries)
+}
+
+fn model_usage_rows(
+    usage: &GrokUsage,
+    default_model: Option<&str>,
+) -> Vec<(String, GrokModelUsage)> {
+    if let Some(map) = usage.model_usage.as_ref()
+        && !map.is_empty()
+    {
+        let mut rows: Vec<_> = map
+            .iter()
+            .map(|(model, usage)| (model.clone(), *usage))
+            .collect();
+        rows.sort_by(|a, b| a.0.cmp(&b.0));
+        return rows;
+    }
+
+    let model = default_model
+        .map(str::to_string)
+        .unwrap_or_else(|| "unknown".to_string());
+    vec![(
+        model,
+        GrokModelUsage {
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cached_read_tokens: usage.cached_read_tokens,
+            reasoning_tokens: usage.reasoning_tokens,
+            total_tokens: usage.total_tokens,
+        },
+    )]
+}
+
+fn load_session_meta(files: &GrokSessionFiles) -> SessionMeta {
+    let session_dir_name = files
+        .updates
+        .parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let project_from_path = files
+        .updates
+        .parent()
+        .and_then(|session| session.parent())
+        .and_then(|project| project.file_name())
+        .and_then(|name| name.to_str())
+        .map(url_decode_lightweight)
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let mut session_id = session_dir_name;
+    let mut project_path = project_from_path;
+    let mut default_model = None;
+
+    if let Some(summary_path) = files.summary.as_ref()
+        && let Ok(content) = fs::read_to_string(summary_path)
+        && let Ok(summary) = serde_json::from_str::<GrokSummary>(&content)
+    {
+        if let Some(id) = summary.info.as_ref().and_then(|info| info.id.clone()) {
+            session_id = id;
+        }
+        if let Some(cwd) = summary
+            .info
+            .as_ref()
+            .and_then(|info| info.cwd.clone())
+            .or(summary.git_root_dir)
+        {
+            project_path = cwd;
+        }
+        default_model = summary.current_model_id;
+    }
+
+    SessionMeta {
+        session_id,
+        project_path,
+        default_model,
+    }
+}
+
+fn resolve_timestamp_ms(line: &GrokUpdateLine, meta: Option<&GrokMeta>) -> TimestampMs {
+    if let Some(ms) = meta
+        .and_then(|meta| meta.agent_timestamp_ms.as_ref())
+        .and_then(value_as_i64)
+        && ms > 0
+    {
+        return TimestampMs::from_millis(ms);
+    }
+    if let Some(seconds) = line.timestamp.as_ref().and_then(value_as_i64)
+        && seconds > 0
+    {
+        // Grok writes Unix seconds on the envelope timestamp field.
+        return TimestampMs::from_millis(seconds.saturating_mul(1000));
+    }
+    TimestampMs::UNIX_EPOCH
+}
+
+fn value_as_i64(value: &Value) -> Option<i64> {
+    value
+        .as_i64()
+        .or_else(|| value.as_u64().and_then(|n| i64::try_from(n).ok()))
+        .or_else(|| value.as_f64().map(|n| n as i64))
+}
+
+fn dedupe_key(
+    event_id: Option<&str>,
+    session_id: &str,
+    timestamp: TimestampMs,
+    model: &str,
+    usage: TokenUsageRaw,
+    reasoning: u64,
+) -> String {
+    if let Some(event_id) = event_id {
+        return format!("{event_id}|{model}");
+    }
+    format!(
+        "{session_id}|{}|{model}|{}|{}|{}|{reasoning}",
+        timestamp.as_millis(),
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.cache_read_input_tokens,
+    )
+}
+
+fn calculate_grok_cost(
+    raw_model: &str,
+    usage: TokenUsageRaw,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> f64 {
+    match mode {
+        CostMode::Display => 0.0,
+        CostMode::Auto | CostMode::Calculate => {
+            for candidate in pricing_candidates(raw_model) {
+                if pricing.find(&candidate).is_some() {
+                    return calculate_cost_for_usage(
+                        Some(&candidate),
+                        usage,
+                        None,
+                        CostMode::Calculate,
+                        Some(pricing),
+                    );
+                }
+            }
+            0.0
+        }
+    }
+}
+
+fn missing_grok_pricing(
+    raw_model: &str,
+    usage: TokenUsageRaw,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Option<String> {
+    if mode == CostMode::Display {
+        return None;
+    }
+    missing_pricing_model_for_candidates(
+        raw_model,
+        pricing_candidates(raw_model),
+        total_usage_tokens(usage),
+        Some(pricing),
+    )
+}
+
+fn url_decode_lightweight(value: &str) -> String {
+    // Session parents are URL-encoded cwd paths (e.g. `D%3A%5Cproj`).
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%'
+            && i + 2 < bytes.len()
+            && let (Some(hi), Some(lo)) = (from_hex(bytes[i + 1]), from_hex(bytes[i + 2]))
+        {
+            out.push(char::from(hi * 16 + lo));
+            i += 3;
+            continue;
+        }
+        out.push(char::from(bytes[i]));
+        i += 1;
+    }
+    out
+}
+
+fn from_hex(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    fn sample_turn_completed_line() -> String {
+        r#"{"timestamp":1750000000,"method":"_x.ai/session/update","params":{"sessionId":"sess-1","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"totalTokens":120,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"totalTokens":120}}}},"_meta":{"eventId":"evt-1"}}}"#.to_string()
+    }
+
+    #[test]
+    fn splits_uncached_input_from_cache() {
+        assert_eq!(split_tokens(100, 40), (60, 40));
+        assert_eq!(split_tokens(10, 40), (0, 10));
+        assert_eq!(split_tokens(0, 5), (0, 0));
+    }
+
+    #[test]
+    fn pricing_candidates_strip_build_and_add_xai() {
+        assert_eq!(
+            pricing_candidates("grok-4.5-build"),
+            vec![
+                "grok-4.5-build".to_string(),
+                "xai/grok-4.5-build".to_string(),
+                "x-ai/grok-4.5-build".to_string(),
+                "grok-4.5".to_string(),
+                "xai/grok-4.5".to_string(),
+                "x-ai/grok-4.5".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn exact_raw_model_pricing_override_beats_normalized_fallback() {
+        let model = "grok-4.3-build".to_string();
+        let pricing_override = crate::cli::PricingOverride {
+            input_cost_per_token: Some(1.0),
+            output_cost_per_token: Some(2.0),
+            ..crate::cli::PricingOverride::default()
+        };
+        let pricing = PricingMap::load_with_overrides(true, false, [(&model, &pricing_override)]);
+        let usage = TokenUsageRaw {
+            input_tokens: 1,
+            output_tokens: 1,
+            ..TokenUsageRaw::default()
+        };
+
+        assert_eq!(
+            calculate_grok_cost(&model, usage, CostMode::Calculate, &pricing),
+            3.0
+        );
+    }
+
+    #[test]
+    fn turn_completed_model_usage_maps_tokens_without_double_count() {
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-1/updates.jsonl": sample_turn_completed_line(),
+            "sessions/proj/sess-1/summary.json": r#"{"info":{"id":"sess-1","cwd":"D:\\work\\proj"},"current_model_id":"grok-4.5"}"#,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.path("sessions/proj/sess-1/updates.jsonl"),
+            summary: Some(fixture.path("sessions/proj/sess-1/summary.json")),
+        };
+        let pricing = PricingMap::load_embedded();
+        let entries = parse_session_files(&files, None, CostMode::Calculate, &pricing).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.model.as_deref(), Some("grok-4.5-build"));
+        assert_eq!(entry.data.message.usage.input_tokens, 60);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 40);
+        assert_eq!(entry.data.message.usage.output_tokens, 20);
+        assert_eq!(entry.extra_total_tokens, 10);
+        assert!(entry.data.cost_usd.is_none());
+        assert_eq!(entry.session_id.as_ref(), "sess-1");
+        assert_eq!(entry.project_path.as_ref(), "D:\\work\\proj");
+    }
+
+    #[test]
+    fn skips_turn_completed_without_usage_and_zero_rows() {
+        let lines = [
+            r#"{"timestamp":1750000001,"params":{"update":{"sessionUpdate":"tool_call"}}}"#,
+            r#"{"timestamp":1750000002,"params":{"update":{"sessionUpdate":"turn_completed"},"_meta":{"eventId":"no-usage"}}}"#,
+            r#"{"timestamp":1750000003,"params":{"update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":0,"outputTokens":0,"cachedReadTokens":0,"reasoningTokens":0,"modelUsage":{"grok-4.5":{"inputTokens":0,"outputTokens":0,"cachedReadTokens":0,"reasoningTokens":0}}}},"_meta":{"eventId":"zero"}}}"#,
+            &sample_turn_completed_line(),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-1/updates.jsonl": lines,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.path("sessions/proj/sess-1/updates.jsonl"),
+            summary: None,
+        };
+        let pricing = PricingMap::load_embedded();
+        let entries = parse_session_files(&files, None, CostMode::Display, &pricing).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 60);
+    }
+
+    #[test]
+    fn multi_model_turn_emits_one_entry_per_model() {
+        let line = r#"{"timestamp":1750000100,"params":{"sessionId":"sess-m","update":{"sessionUpdate":"turn_completed","usage":{"modelUsage":{"model-a":{"inputTokens":10,"outputTokens":2,"cachedReadTokens":0,"reasoningTokens":1},"model-b":{"inputTokens":20,"outputTokens":4,"cachedReadTokens":5,"reasoningTokens":0}}}},"_meta":{"eventId":"evt-multi"}}}"#;
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-m/updates.jsonl": line,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.path("sessions/proj/sess-m/updates.jsonl"),
+            summary: None,
+        };
+        let pricing = PricingMap::load_embedded();
+        let mut entries = parse_session_files(&files, None, CostMode::Display, &pricing).unwrap();
+        entries.sort_by(|a, b| a.model.cmp(&b.model));
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].model.as_deref(), Some("model-a"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 10);
+        assert_eq!(entries[0].extra_total_tokens, 1);
+        assert_eq!(entries[1].model.as_deref(), Some("model-b"));
+        assert_eq!(entries[1].data.message.usage.input_tokens, 15);
+        assert_eq!(entries[1].data.message.usage.cache_read_input_tokens, 5);
+    }
+
+    #[test]
+    fn dedupes_same_event_id_and_model() {
+        let line = sample_turn_completed_line();
+        let content = format!("{line}\n{line}\n");
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-1/updates.jsonl": content,
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.path("sessions/proj/sess-1/updates.jsonl"),
+            summary: None,
+        };
+        let pricing = PricingMap::load_embedded();
+        let entries = parse_session_files(&files, None, CostMode::Display, &pricing).unwrap();
+        assert_eq!(entries.len(), 1);
+    }
+
+    #[test]
+    fn display_mode_cost_is_zero() {
+        let fixture = fs_fixture!({
+            "sessions/proj/sess-1/updates.jsonl": sample_turn_completed_line(),
+        });
+        let files = GrokSessionFiles {
+            updates: fixture.path("sessions/proj/sess-1/updates.jsonl"),
+            summary: None,
+        };
+        let pricing = PricingMap::load_embedded();
+        let entries = parse_session_files(&files, None, CostMode::Display, &pricing).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].cost, 0.0);
+    }
+}

--- a/rust/adapters/grok/src/paths.rs
+++ b/rust/adapters/grok/src/paths.rs
@@ -1,0 +1,131 @@
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
+
+use crate::{Result, collect_files_with_extension};
+
+/// Official Grok CLI home override (single root).
+pub(crate) const GROK_HOME_ENV: &str = "GROK_HOME";
+
+#[derive(Debug, Clone)]
+pub(super) struct GrokSessionFiles {
+    pub updates: PathBuf,
+    pub summary: Option<PathBuf>,
+}
+
+/// Resolve the Grok data root from `GROK_HOME`, then `~/.grok`.
+pub(super) fn resolve_root() -> Option<PathBuf> {
+    if let Ok(home) = env::var(GROK_HOME_ENV)
+        && !home.trim().is_empty()
+    {
+        let path = PathBuf::from(home.trim());
+        return path.is_dir().then_some(path);
+    }
+
+    let home = crate::home::home_dir()?;
+    let path = home.join(".grok");
+    path.is_dir().then_some(path)
+}
+
+/// Discover every `sessions/**/updates.jsonl` under the resolved root.
+pub(super) fn discover_session_files() -> Result<Vec<GrokSessionFiles>> {
+    let mut files = Vec::new();
+    if let Some(root) = resolve_root() {
+        let sessions = root.join("sessions");
+        if sessions.is_dir() {
+            let mut updates = Vec::new();
+            collect_files_with_extension(&sessions, "jsonl", &mut updates);
+            updates.retain(|path| {
+                path.file_name().and_then(|name| name.to_str()) == Some("updates.jsonl")
+            });
+            for updates_path in updates {
+                let summary = sibling_summary(&updates_path);
+                files.push(GrokSessionFiles {
+                    updates: updates_path,
+                    summary,
+                });
+            }
+        }
+    }
+    files.sort_by(|a, b| a.updates.cmp(&b.updates));
+    Ok(files)
+}
+
+fn sibling_summary(updates: &Path) -> Option<PathBuf> {
+    let summary = updates.with_file_name("summary.json");
+    summary.is_file().then_some(summary)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
+    use std::ffi::OsString;
+
+    #[test]
+    fn discovers_updates_jsonl_under_sessions() {
+        let fixture = fs_fixture!({
+            "sessions/C%3A%5Cproj/019fa1b1-0000-7000-8000-000000000001/updates.jsonl": "{}\n",
+            "sessions/C%3A%5Cproj/019fa1b1-0000-7000-8000-000000000001/summary.json": "{}",
+            "sessions/C%3A%5Cproj/019fa1b1-0000-7000-8000-000000000001/events.jsonl": "{}\n",
+        });
+        let _guard = EnvVarsGuard::set_many([(
+            GROK_HOME_ENV,
+            Some(OsString::from(fixture.root().as_os_str())),
+        )]);
+        let files = discover_session_files().unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].updates.ends_with("updates.jsonl"));
+        assert!(files[0].summary.is_some());
+        assert!(
+            files[0]
+                .summary
+                .as_ref()
+                .is_some_and(|path| path.ends_with("summary.json"))
+        );
+    }
+
+    #[test]
+    fn grok_home_is_used() {
+        let fixture = fs_fixture!({
+            "sessions/proj/session-a/updates.jsonl": "{}\n",
+        });
+        let _guard = EnvVarsGuard::set_many([(
+            GROK_HOME_ENV,
+            Some(OsString::from(fixture.root().as_os_str())),
+        )]);
+
+        let files = discover_session_files().unwrap();
+        assert_eq!(files.len(), 1);
+        assert!(files[0].updates.ends_with("updates.jsonl"));
+    }
+
+    #[test]
+    fn empty_grok_home_falls_back_to_default_home() {
+        let fixture = fs_fixture!({
+            ".grok/sessions/home/session-a/updates.jsonl": "{}\n",
+        });
+        let home = OsString::from(fixture.root().as_os_str());
+        let _guard = EnvVarsGuard::set_many([
+            (GROK_HOME_ENV, Some(OsString::from("  "))),
+            ("HOME", Some(home.clone())),
+            ("USERPROFILE", Some(home)),
+        ]);
+
+        let files = discover_session_files().unwrap();
+
+        assert_eq!(files.len(), 1);
+        assert!(files[0].updates.to_string_lossy().contains("session-a"));
+    }
+
+    #[test]
+    fn missing_roots_yield_empty_discovery() {
+        let fixture = fs_fixture!({});
+        let missing = fixture.path("does-not-exist");
+        let _guard =
+            EnvVarsGuard::set_many([(GROK_HOME_ENV, Some(OsString::from(missing.as_os_str())))]);
+        let files = discover_session_files().unwrap();
+        assert!(files.is_empty());
+    }
+}

--- a/rust/adapters/grok/src/report.rs
+++ b/rust/adapters/grok/src/report.rs
@@ -1,0 +1,67 @@
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -14,6 +14,7 @@ ccusage-adapter-copilot.workspace = true
 ccusage-adapter-droid.workspace = true
 ccusage-adapter-gemini.workspace = true
 ccusage-adapter-goose.workspace = true
+ccusage-adapter-grok.workspace = true
 ccusage-adapter-hermes.workspace = true
 ccusage-adapter-kilo.workspace = true
 ccusage-adapter-kimi.workspace = true

--- a/rust/crates/ccusage-adapter-all/README.md
+++ b/rust/crates/ccusage-adapter-all/README.md
@@ -10,7 +10,7 @@ into one table or JSON document.
 - `report.rs` — the unified row and total shapes.
 - `types.rs` — the accumulators the merge needs.
 
-This is the only crate that depends on all 15 adapters, which keeps the adapters
+This is the only crate that depends on all 16 adapters, which keeps the adapters
 themselves independent of each other.
 
 ## Public surface
@@ -28,6 +28,7 @@ themselves independent of each other.
 - `ccusage-adapter-droid`
 - `ccusage-adapter-gemini`
 - `ccusage-adapter-goose`
+- `ccusage-adapter-grok`
 - `ccusage-adapter-hermes`
 - `ccusage-adapter-kilo`
 - `ccusage-adapter-kimi`

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -17,6 +17,7 @@ mod adapter {
     pub use ccusage_adapter_droid as droid;
     pub use ccusage_adapter_gemini as gemini;
     pub use ccusage_adapter_goose as goose;
+    pub use ccusage_adapter_grok as grok;
     pub use ccusage_adapter_hermes as hermes;
     pub use ccusage_adapter_kilo as kilo;
     pub use ccusage_adapter_kimi as kimi;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -11,8 +11,8 @@ use crate::{
     BUILT_IN_AGENT_NAMES, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result,
     SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
+        openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -308,6 +308,22 @@ fn load_base_rows(
             agent: BUILT_IN_AGENT_NAMES[14],
             progress_agent: crate::progress::UsageLoadAgent("Qwen"),
             load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+        },
+        AgentLoadSpec {
+            index: 15,
+            agent: BUILT_IN_AGENT_NAMES[15],
+            progress_agent: crate::progress::UsageLoadAgent("Grok"),
+            load: Box::new(|| {
+                let mut rows = load_summary_agent_rows(
+                    "grok",
+                    load_kind,
+                    &loader_shared,
+                    || grok::load_entries(&loader_shared, pricing),
+                    grok::summarize_entries,
+                )?;
+                rows.detected = rows.detected || grok::has_data();
+                Ok(rows)
+            }),
         },
     ];
     let named_pi_stores = resolve_named_pi_store_paths(&shared.pi_stores)?;

--- a/rust/crates/ccusage-adapter-all/src/report.rs
+++ b/rust/crates/ccusage-adapter-all/src/report.rs
@@ -589,6 +589,7 @@ fn agent_label(agent: &str) -> &str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "grok" => "Grok",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -559,6 +559,7 @@ fn isolated_agent_env(
         "GEMINI_DATA_DIR",
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
+        "GROK_HOME",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))
@@ -571,6 +572,37 @@ fn isolated_agent_env(
     vars.push(("XDG_CONFIG_HOME", Some(xdg_config)));
     vars.push((source_key, Some(source_value)));
     EnvVarsGuard::set_many(vars)
+}
+
+fn assert_unified_rows_use_grok_home(kind: AgentReportKind) {
+    let line = r#"{"timestamp":1750000000,"params":{"sessionId":"sess-grok","update":{"sessionUpdate":"turn_completed","usage":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10,"modelUsage":{"grok-4.5-build":{"inputTokens":100,"outputTokens":20,"cachedReadTokens":40,"reasoningTokens":10}}}},"_meta":{"eventId":"evt-grok"}}}"#;
+    let fixture = fs_fixture!({
+        "grok/sessions/proj/sess-grok/updates.jsonl": line,
+    });
+    let _env = isolated_agent_env(&fixture, "GROK_HOME", fixture.path("grok").into_os_string());
+    let shared = fixture_shared("20250615", "20250615");
+
+    let result = loader::load_rows(kind, &shared).unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.detected_agents, vec!["grok"]);
+    assert_eq!(
+        result.rows[0].metadata_agents,
+        (kind != AgentReportKind::Session).then_some(vec!["grok"])
+    );
+    assert_eq!(result.rows[0].input_tokens, 60);
+    assert_eq!(result.rows[0].cache_read_tokens, 40);
+    assert_eq!(result.rows[0].output_tokens, 20);
+}
+
+#[test]
+fn unified_daily_rows_use_grok_home() {
+    assert_unified_rows_use_grok_home(AgentReportKind::Daily);
+}
+
+#[test]
+fn unified_session_rows_use_grok_home() {
+    assert_unified_rows_use_grok_home(AgentReportKind::Session);
 }
 
 fn assert_daily_family_and_session_sections_match_standalone(shared: &SharedArgs) {

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -100,6 +100,10 @@
 			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
+			},
+			{
+				"name": "grok",
+				"description": "Show Grok Build CLI usage commands"
 			}
 		]
 	},
@@ -734,6 +738,43 @@
 			"description": "Show OpenClaw usage grouped by session",
 			"usage": "ccusage openclaw session <OPTIONS>",
 			"options": "openclaw_combined_options"
+		},
+		{
+			"path": ["grok"],
+			"description": "Usage reports for Grok Build CLI.",
+			"usage": "ccusage grok <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Grok Build CLI usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Grok Build CLI usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Grok Build CLI usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["grok", "daily"],
+			"description": "Show Grok Build CLI usage grouped by date",
+			"usage": "ccusage grok daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["grok", "monthly"],
+			"description": "Show Grok Build CLI usage grouped by month",
+			"usage": "ccusage grok monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["grok", "session"],
+			"description": "Show Grok Build CLI usage grouped by session",
+			"usage": "ccusage grok session <OPTIONS>",
+			"options": "agent_options"
 		}
 	]
 }

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -332,6 +332,13 @@ fn parse_command(
             Command::Qwen,
         ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
+        "grok" => parse_basic_agent_command(
+            parser,
+            shared,
+            "grok",
+            STANDARD_AGENT_REPORTS,
+            Command::Grok,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -762,6 +769,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "grok"
     )
 }
 
@@ -921,6 +929,7 @@ fn is_agent_command(command: &str) -> bool {
             | "kimi"
             | "qwen"
             | "openclaw"
+            | "grok"
     )
 }
 
@@ -933,7 +942,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -957,6 +966,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
+        "grok" => "Grok",
         _ => unreachable!("agent is prevalidated"),
     }
 }
@@ -1030,7 +1040,8 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Gemini(args)
             | Command::Kimi(args)
             | Command::Qwen(args)
-            | Command::OpenClaw(args),
+            | Command::OpenClaw(args)
+            | Command::Grok(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };
     shared.last?;

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
+assertion_line: 702
 expression: help_text()
 ---
 USAGE:
@@ -28,6 +29,7 @@ COMMANDS:
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
+  grok                       Show Grok Build CLI usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -51,6 +53,7 @@ For more info, run any command with the `--help` flag:
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help
+  ccusage grok --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
-assertion_line: 752
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: cases
 ---
 [
@@ -363,6 +362,58 @@ expression: cases
           "until": null
         },
         "type": "openclaw"
+      },
+      "shared": {
+        "breakdown": false,
+        "color": false,
+        "compact": false,
+        "config": null,
+        "debug": false,
+        "debugSamples": 5,
+        "jq": null,
+        "json": false,
+        "mode": "Auto",
+        "noColor": false,
+        "noOffline": false,
+        "offline": false,
+        "order": "Asc",
+        "since": null,
+        "singleThread": false,
+        "timezone": null,
+        "until": null
+      }
+    }
+  },
+  {
+    "case": "grok daily",
+    "cli": {
+      "command": {
+        "byAgent": false,
+        "codexSpeed": "Auto",
+        "kind": "Daily",
+        "openClawPath": null,
+        "piPath": null,
+        "sections": null,
+        "shared": {
+          "breakdown": false,
+          "color": false,
+          "compact": false,
+          "config": null,
+          "debug": false,
+          "debugSamples": 5,
+          "jq": null,
+          "json": true,
+          "mode": "Auto",
+          "noColor": false,
+          "noOffline": false,
+          "offline": false,
+          "order": "Asc",
+          "since": null,
+          "singleThread": false,
+          "timezone": null,
+          "until": null
+        },
+        "type": "grok"
       },
       "shared": {
         "breakdown": false,

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -204,6 +204,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
     }
 }
 
@@ -232,6 +233,13 @@ fn parses_root_daily_as_all_agent_report() {
     assert_eq!(args.kind, AgentReportKind::Daily);
     assert!(args.shared.json);
     assert_eq!(args.shared.since.as_deref(), Some("20260102"));
+}
+
+#[test]
+fn commandless_invocation_preserves_default_dispatch() {
+    let cli = parse(&["ccusage"]);
+
+    assert!(cli.command.is_none());
 }
 
 #[test]
@@ -607,7 +615,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
     ];
 
     for agent in agents {
@@ -694,6 +702,17 @@ fn contextual_statusline_help_lists_choice_options() {
 
     assert!(help.contains("choices: off | emoji | text | emoji-text"));
     assert!(help.contains("choices: auto | ccusage | cc | both"));
+}
+
+#[test]
+fn grok_help_does_not_advertise_path_option() {
+    let help = help_text_for_args(&[
+        "ccusage".to_string(),
+        "grok".to_string(),
+        "daily".to_string(),
+    ]);
+
+    assert!(!help.contains("--grok-path"));
 }
 
 #[test]
@@ -807,6 +826,10 @@ fn snapshots_representative_cli_parse_shapes() {
                 "session",
                 "--open-claw-path=/tmp/openclaw",
             ])),
+        }),
+        json!({
+            "case": "grok daily",
+            "cli": cli_snapshot(parse(&["ccusage", "grok", "daily", "--json"])),
         }),
         json!({
             "case": "blocks active recent",
@@ -1184,6 +1207,23 @@ fn parses_openclaw_session_options() {
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);
     assert_eq!(args.open_claw_path.as_deref(), Some("/tmp/openclaw"));
+}
+
+#[test]
+fn parses_grok_daily_options() {
+    let cli = parse(&["ccusage", "grok", "daily", "--json"]);
+    let Some(Command::Grok(args)) = cli.command else {
+        panic!("expected grok command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn rejects_grok_path_option() {
+    let error = parse_error(&["ccusage", "grok", "daily", "--grok-path", "/tmp/grok-home"]);
+
+    assert_eq!(error, "Unknown option '--grok-path'");
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/README.md
+++ b/rust/crates/ccusage-cli/README.md
@@ -4,7 +4,7 @@ The plain argument types the runtime shares: `SharedArgs`, the per-command
 argument structs, and the enums the reports switch on.
 
 This crate deliberately has no dependencies, no build script, and no embedded
-assets. `ccusage-core` and all 15 adapters depend on it, so anything heavier
+assets. `ccusage-core` and all 16 adapters depend on it, so anything heavier
 would sit on every crate's critical path — that is why the parser, the help
 renderer, and the help JSON live in `ccusage-cli-parser` instead.
 

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -25,6 +25,7 @@ pub enum Command {
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
+    Grok(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -953,6 +953,27 @@ mod tests {
     }
 
     #[test]
+    fn grok_namespace_keeps_shared_report_options() {
+        let config = context(
+            json!({
+                "grok": {
+                    "defaults": { "offline": true },
+                    "commands": { "session": { "json": true } }
+                }
+            }),
+            "grok session",
+            Some("grok"),
+            "session",
+        );
+        let mut shared = SharedArgs::default();
+
+        apply_config_to_shared(&mut shared, &config);
+
+        assert!(shared.offline);
+        assert!(shared.json);
+    }
+
+    #[test]
     fn merge_pricing_overrides_field_level_preserves_parent_fields() {
         use crate::config_schema::ConfigPricingOverride;
         use ccusage_cli::PricingOverride;

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -50,6 +50,8 @@ pub struct CcusageConfig {
     pub kimi: Option<KimiConfig>,
     /// Qwen configuration.
     pub qwen: Option<QwenConfig>,
+    /// Grok Build CLI configuration.
+    pub grok: Option<GrokConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -299,6 +301,21 @@ pub struct QwenConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QwenCommandsConfig {
+    pub daily: Option<SharedOptions>,
+    pub monthly: Option<SharedOptions>,
+    pub session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokConfig {
+    pub defaults: Option<SharedOptions>,
+    pub commands: Option<GrokCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GrokCommandsConfig {
     pub daily: Option<SharedOptions>,
     pub monthly: Option<SharedOptions>,
     pub session: Option<SharedOptions>,
@@ -1075,6 +1092,7 @@ mod tests {
             &["openclaw", "defaults"],
             &with_keys(&shared, &["openClawPath"]),
         );
+        assert_schema_properties(&schema, &["grok", "defaults"], &shared);
     }
 
     #[test]
@@ -1094,6 +1112,8 @@ mod tests {
         assert!(schema_property(&schema, &["gemini", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["kimi", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["qwen", "defaults", "openClawPath"]).is_none());
+        assert!(schema_property(&schema, &["grok", "defaults", "grokPath"]).is_none());
+        assert!(schema_property(&schema, &["openclaw", "defaults", "grokPath"]).is_none());
     }
 
     #[test]
@@ -1127,8 +1147,8 @@ mod tests {
             "ccusage-config",
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "droid", "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode",
+                "openclaw", "pi", "qwen",
             ],
         );
         assert!(
@@ -1410,6 +1430,7 @@ mod tests {
             "opencodeWeekly": schema_node(&schema, &["opencode", "commands", "weekly"]),
             "piDefaults": schema_node(&schema, &["pi", "defaults"]),
             "openclawDefaults": schema_node(&schema, &["openclaw", "defaults"]),
+            "grokDefaults": schema_node(&schema, &["grok", "defaults"]),
         }));
     }
 

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,7 +1,6 @@
 ---
-source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
-expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
+source: crates/ccusage-config/src/config_schema.rs
+expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]), \"grokDefaults\":\n    schema_node(&schema, &[\"grok\", \"defaults\"]),\n})"
 ---
 {
   "claudeStatusline": {
@@ -275,6 +274,179 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "additionalProperties": false,
     "description": "Default values for all-agent reports and legacy Claude commands.",
     "markdownDescription": "Default values for all-agent reports and legacy Claude commands.",
+    "properties": {
+      "all": {
+        "default": false,
+        "description": "Accepted for compatibility; all detected supported agents are included by default.",
+        "markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+        "type": "boolean"
+      },
+      "breakdown": {
+        "default": false,
+        "description": "Show per-model cost breakdown.",
+        "markdownDescription": "Show per-model cost breakdown.",
+        "type": "boolean"
+      },
+      "color": {
+        "default": false,
+        "description": "Enable colored output.",
+        "markdownDescription": "Enable colored output.",
+        "type": "boolean"
+      },
+      "compact": {
+        "default": false,
+        "description": "Force compact table layout for narrow terminals.",
+        "markdownDescription": "Force compact table layout for narrow terminals.",
+        "type": "boolean"
+      },
+      "debug": {
+        "default": false,
+        "description": "Show pricing mismatch information for debugging.",
+        "markdownDescription": "Show pricing mismatch information for debugging.",
+        "type": "boolean"
+      },
+      "debugSamples": {
+        "default": 5,
+        "description": "Number of sample discrepancies to show in debug output.",
+        "format": "uint",
+        "markdownDescription": "Number of sample discrepancies to show in debug output.",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "jq": {
+        "description": "jq filter to apply to JSON output.",
+        "markdownDescription": "jq filter to apply to JSON output.",
+        "type": "string"
+      },
+      "json": {
+        "default": false,
+        "description": "Output in JSON format.",
+        "markdownDescription": "Output in JSON format.",
+        "type": "boolean"
+      },
+      "mode": {
+        "default": "auto",
+        "description": "Cost calculation mode.",
+        "enum": [
+          "auto",
+          "calculate",
+          "display"
+        ],
+        "markdownDescription": "Cost calculation mode.",
+        "type": "string"
+      },
+      "noColor": {
+        "default": false,
+        "description": "Disable colored output.",
+        "markdownDescription": "Disable colored output.",
+        "type": "boolean"
+      },
+      "noCost": {
+        "default": false,
+        "description": "Hide cost information in table and JSON output.",
+        "markdownDescription": "Hide cost information in table and JSON output.",
+        "type": "boolean"
+      },
+      "noOffline": {
+        "default": false,
+        "description": "Disable cached pricing data where supported.",
+        "markdownDescription": "Disable cached pricing data where supported.",
+        "type": "boolean"
+      },
+      "offline": {
+        "default": false,
+        "description": "Use cached pricing data where supported.",
+        "markdownDescription": "Use cached pricing data where supported.",
+        "type": "boolean"
+      },
+      "order": {
+        "default": "asc",
+        "description": "Sort order.",
+        "enum": [
+          "desc",
+          "asc"
+        ],
+        "markdownDescription": "Sort order.",
+        "type": "string"
+      },
+      "pricingOverrides": {
+        "additionalProperties": {
+          "additionalProperties": false,
+          "properties": {
+            "cacheCreationInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheCreationInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "fastMultiplier": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "maxInputTokens": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "outputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "outputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "description": "Runtime pricing overrides keyed by raw model name.",
+        "markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+        "type": "object"
+      },
+      "since": {
+        "description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+        "markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+        "type": "string"
+      },
+      "singleThread": {
+        "default": false,
+        "description": "Disable parallel file processing.",
+        "markdownDescription": "Disable parallel file processing.",
+        "type": "boolean"
+      },
+      "timezone": {
+        "description": "Timezone for date grouping (IANA).",
+        "markdownDescription": "Timezone for date grouping (IANA).",
+        "type": "string"
+      },
+      "until": {
+        "description": "Filter until date (inclusive).",
+        "markdownDescription": "Filter until date (inclusive).",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  },
+  "grokDefaults": {
+    "additionalProperties": false,
     "properties": {
       "all": {
         "default": false,
@@ -1134,6 +1306,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "droid",
     "gemini",
     "goose",
+    "grok",
     "hermes",
     "kilo",
     "kimi",

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -25,6 +25,7 @@ ccusage-adapter-copilot.workspace = true
 ccusage-adapter-droid.workspace = true
 ccusage-adapter-gemini.workspace = true
 ccusage-adapter-goose.workspace = true
+ccusage-adapter-grok.workspace = true
 ccusage-adapter-hermes.workspace = true
 ccusage-adapter-kilo.workspace = true
 ccusage-adapter-kimi.workspace = true

--- a/rust/crates/ccusage/README.md
+++ b/rust/crates/ccusage/README.md
@@ -28,6 +28,7 @@ source in its own `ccusage-adapter-*` crate.
 - `ccusage-adapter-droid`
 - `ccusage-adapter-gemini`
 - `ccusage-adapter-goose`
+- `ccusage-adapter-grok`
 - `ccusage-adapter-hermes`
 - `ccusage-adapter-kilo`
 - `ccusage-adapter-kimi`

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -7,6 +7,7 @@ pub(crate) use ccusage_adapter_copilot as copilot;
 pub(crate) use ccusage_adapter_droid as droid;
 pub(crate) use ccusage_adapter_gemini as gemini;
 pub(crate) use ccusage_adapter_goose as goose;
+pub(crate) use ccusage_adapter_grok as grok;
 pub(crate) use ccusage_adapter_hermes as hermes;
 pub(crate) use ccusage_adapter_kilo as kilo;
 pub(crate) use ccusage_adapter_kimi as kimi;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -48,7 +48,8 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Gemini(args)
             | Command::Kimi(args)
             | Command::Qwen(args)
-            | Command::OpenClaw(args),
+            | Command::OpenClaw(args)
+            | Command::Grok(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,
     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -47,6 +47,7 @@ fn main() -> Result<()> {
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
+        Some(Command::Grok(args)) => adapter::grok::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -85,7 +86,7 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 14] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
             ccusage_adapter_amp::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
@@ -93,6 +94,7 @@ mod tests {
             ccusage_adapter_droid::run,
             ccusage_adapter_gemini::run,
             ccusage_adapter_goose::run,
+            ccusage_adapter_grok::run,
             ccusage_adapter_hermes::run,
             ccusage_adapter_kilo::run,
             ccusage_adapter_kimi::run,
@@ -102,7 +104,7 @@ mod tests {
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 14);
+        assert_eq!(runs.len(), 15);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add first-class Grok Build CLI usage reporting to ccusage.

Closes #1513

## What changed

- New Rust adapter `ccusage-adapter-grok` reads completed turns from `$GROK_HOME/sessions/**/updates.jsonl` (`sessionUpdate == "turn_completed"` + `usage` / `modelUsage`)
- Root resolution: official `GROK_HOME`, then `~/.grok` (no ccusage-only path override)
- Token mapping: uncached input = `inputTokens - cachedReadTokens`, full `outputTokens` as output, `reasoningTokens` in extra total only (not double-billed), ignore `costUsdTicks` for invoice USD
- Wire `ccusage grok daily|monthly|session`, config shared options, and all-agent / bare `ccusage` loaders
- Session reports use `SessionAccumulator` so `first_activity`, `last_activity`, and `project_path` are present in tables and JSON (aligned with qwen/opencode/antigravity)
- Docs under `docs/guide/grok/`

## Why

Grok Build writes per-model token usage on completed turns, but ccusage did not load it, so unified totals were incomplete for Grok users.

## Rebase / conflicts

Merged current `main` (including Antigravity #1544 and related docs/wiring) into `feature/grok-build-usage-adapter`. Conflicts were resolved so **both** Grok and Antigravity remain wired in:

- agent inventories (README / guides / env / config namespaces)
- `BUILT_IN_AGENT_NAMES`, unified loader, CLI parser, `last_window`, config schema
- source-support Q&A (Grok and Antigravity documented as supported)

Branch tip: `a3d4a2a`. Merge-base with `main` is current `main` (no remaining conflicts).

## Testing

Raised Grok adapter coverage to roughly the same bar as the Antigravity adapter (#1544): fixture-backed, behavior-named tests; synthesized `updates.jsonl` (no real session trees committed).

### Coverage layers

| Layer | Module | Examples |
| --- | --- | --- |
| Path discovery | `paths.rs` | `updates.jsonl` only, nested multi-project trees, blank `GROK_HOME` fallback, non-directory override |
| Parser / mapping | `parser.rs` | uncached vs cache split, reasoning-only rows, top-level usage fallback, timestamp preference (`agentTimestampMs` vs envelope seconds), summary vs line session id, URL-decoded project path, missing pricing, ignore `costUsdTicks`, in-file dedupe |
| Loader | `loader.rs` | cross-session event dedupe, corrupt sibling isolation, timestamp sort, `has_data` negative path |
| Report | `report.rs` | cache read columns, session activity bounds + `projectPath` in JSON |
| Smoke | `lib.rs` | `#[ignore]` real `$GROK_HOME` load |

Also: CLI parser (`grok` help / rejects `--grok-path`), config schema (no `grokPath`), unified all-agent tests that exercise `GROK_HOME`.

### Local results (after merge with main)

```text
cargo test -p ccusage-adapter-grok --lib
  -> 39 passed; 0 failed; 1 ignored

cargo test -p ccusage-cli-parser --lib
  -> 75 passed

cargo test -p ccusage-config --lib
  -> 26 passed

cargo test -p ccusage-adapter-antigravity --lib
  -> 34 passed

cargo test -p ccusage-adapter-all --lib
  -> 36 passed
```

Related commits on this branch after the original adapter:

- `237d30b` fix(grok): report session activity and project path
- `97777cf` test(grok): expand adapter coverage to antigravity-level
- `a3d4a2a` merge upstream/main (conflict resolution)