### PR TITLE
feat(rovo): add Atlassian Rovo Dev CLI usage adapter

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -78,6 +78,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
+| Rovo Dev CLI       | `ccusage rovo daily`     |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
@@ -132,6 +133,7 @@ bunx ccusage kimi daily
 bunx ccusage qwen daily
 bunx ccusage copilot daily
 bunx ccusage gemini daily
+bunx ccusage rovo daily
 bunx ccusage pi daily --pi-path /path/to/sessions
 bunx ccusage pi daily --pi-path /path/to/sessions,/archive/pi/sessions
 
@@ -164,7 +166,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -11889,6 +11889,684 @@
 						}
 					},
 					"type": "object"
+				},
+				"rovo": {
+					"additionalProperties": false,
+					"description": "Rovo Dev configuration.",
+					"markdownDescription": "Rovo Dev configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"default": false,
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				}
 			},
 			"type": "object"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Rovo Dev CLI', link: '/guide/rovo/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |
@@ -63,6 +63,7 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | Qwen         | `qwen`     | `ccusage qwen daily`      |
 | Copilot CLI  | `copilot`  | `ccusage copilot daily`   |
 | Gemini CLI   | `gemini`   | `ccusage gemini daily`    |
+| Rovo Dev CLI | `rovo`     | `ccusage rovo daily`      |
 
 ## When to Focus a Source
 
@@ -81,6 +82,7 @@ ccusage kilo session
 ccusage qwen daily
 ccusage copilot daily --json
 ccusage gemini session --json
+ccusage rovo daily --json
 ```
 
 ## Next Steps

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -1,6 +1,6 @@
 # Claude Code Data Source
 
-ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read Claude Code usage data as one of its supported local data sources. Claude Code is no longer treated as the only ccusage target; it uses the same unified and focused report model as Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI.
 
 ## Focused Views
 
@@ -75,7 +75,7 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
-For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
+For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
 

--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -4,7 +4,7 @@
 
 > ⚠️ Codex log support is experimental while the Codex CLI log format continues to evolve.
 
-ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+ccusage can read OpenAI Codex CLI session logs as one of its supported local data sources. Codex uses the same unified and focused report model as Claude Code, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI.
 
 ## Focused Views
 

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -180,7 +180,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, and `gemini`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, `gemini`, and `rovo`.
 
 ```json
 {
@@ -260,6 +260,11 @@ Use data source namespaces to set defaults and report overrides. Supported names
 		"defaults": {
 			"offline": true
 		}
+	},
+	"rovo": {
+		"defaults": {
+			"offline": true
+		}
 	}
 }
 ```
@@ -278,6 +283,7 @@ ccusage kimi daily
 ccusage qwen daily
 ccusage copilot monthly
 ccusage gemini daily
+ccusage rovo daily
 ```
 
 Source-specific settings are also applied when running unified reports such as `ccusage daily`. In that case, each source receives its own merged options before data is loaded.

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -109,7 +109,7 @@ For individual developers working on multiple projects:
 
 ### Multiple Sources
 
-Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
+Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI separately with data source namespaces:
 
 ```json
 // ~/.config/claude/ccusage.json

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -23,6 +23,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `QWEN_DATA_DIR`                   | Qwen         | `~/.qwen`                          |
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI  | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI   | `~/.gemini/tmp`                    |
+| `ROVO_DATA_DIR`                   | Rovo Dev CLI | `~/.rovodev`                       |
 
 Example:
 
@@ -41,6 +42,7 @@ export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GEMINI_DATA_DIR="/path/to/gemini/tmp,/archive/gemini/tmp"
+export ROVO_DATA_DIR="/path/to/rovodev,/archive/rovodev"
 ccusage daily
 ```
 
@@ -210,7 +212,7 @@ To see which environment variables are being used:
 
 ```bash
 # Show all environment variables
-env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|CCUSAGE|LOG_LEVEL"
+env | grep -E "CLAUDE|CODEX|OPENCODE|AMP|DROID|CODEBUFF|HERMES|PI_AGENT|GOOSE|OPENCLAW|KILO|KIMI|QWEN|COPILOT|GEMINI|ROVO|CCUSAGE|LOG_LEVEL"
 
 # Debug mode shows environment variable usage
 LOG_LEVEL=4 ccusage daily --debug

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -52,6 +52,7 @@ ccusage pi monthly
 ccusage kilo daily
 ccusage kimi daily
 ccusage qwen daily
+ccusage rovo daily
 ```
 
 ## Your First Report
@@ -176,6 +177,7 @@ If ccusage shows no data, check:
    - OpenClaw: `${OPENCLAW_DIR:-~/.openclaw}` (also scans `~/.clawdbot`, `~/.moltbot`, `~/.moldbot`)
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
+   - Rovo Dev CLI: `${ROVO_DATA_DIR:-~/.rovodev}`
 
 ### Custom Data Directory
 
@@ -196,6 +198,7 @@ export KILO_DATA_DIR="/path/to/kilo"
 export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
+export ROVO_DATA_DIR="/path/to/rovodev"
 ```
 
 Each source-specific path variable can also contain comma-separated directories:
@@ -213,6 +216,7 @@ export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
+export ROVO_DATA_DIR="/path/to/rovodev,/archive/rovodev"
 ```
 
 ## Getting Help

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Rovo Dev CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -89,6 +89,7 @@ ccusage reads from local coding CLI data directories:
 | Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
 | Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
 | Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
+| Rovo Dev CLI | `rovo`     | `${ROVO_DATA_DIR:-~/.rovodev}`                    |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.
@@ -124,6 +125,7 @@ ccusage kimi daily
 ccusage qwen daily
 ccusage copilot daily
 ccusage gemini daily
+ccusage rovo daily
 ```
 
 Use `ccusage <source> <report>` only when you want to narrow a report to one source.

--- a/docs/guide/rovo/index.md
+++ b/docs/guide/rovo/index.md
@@ -1,0 +1,72 @@
+# Rovo Dev CLI Data Source (Experimental)
+
+> Rovo Dev support is experimental. Expect breaking changes while both ccusage and [Rovo Dev CLI](https://www.atlassian.com/software/rovo-dev) continue to evolve.
+
+ccusage can read Atlassian Rovo Dev CLI session files as one of its supported local data sources. Rovo Dev uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, GitHub Copilot CLI, and Gemini CLI.
+
+## Usage
+
+```sh
+# Daily Rovo Dev usage
+ccusage rovo daily
+
+# Monthly Rovo Dev usage
+ccusage rovo monthly
+
+# Rovo Dev sessions
+ccusage rovo session
+
+# Include Rovo Dev in the default all-source report
+ccusage daily
+```
+
+## Data Location
+
+The CLI reads Rovo Dev `session_context.json` files from `ROVO_DATA_DIR` (defaults to `~/.rovodev`). `ROVO_DATA_DIR` can be one directory or a comma-separated list of directories.
+
+```sh
+ROVO_DATA_DIR="$HOME/.rovodev,/backup/rovodev" ccusage rovo daily
+```
+
+Expected files are discovered under:
+
+```text
+~/.rovodev/sessions/<session-id>/session_context.json
+```
+
+When `~/.rovodev/config.yml` moves the sessions directory via `sessions.persistenceDir`, ccusage follows that setting too.
+
+## Supported Reports
+
+| Command                | Description                     | Related Report                          |
+| ---------------------- | ------------------------------- | --------------------------------------- |
+| `ccusage rovo daily`   | Group usage by day              | [Daily Usage](/guide/daily-reports)     |
+| `ccusage rovo monthly` | Group usage by month            | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage rovo session` | Group usage by Rovo Dev session | [Session Usage](/guide/session-reports) |
+
+## Token Mapping
+
+Each `kind: "response"` entry in a session's `message_history` is one usage record:
+
+- **Input tokens** - `usage.details.input_tokens` (the uncached share of the prompt)
+- **Output tokens** - `usage.output_tokens`
+- **Cache read tokens** - `usage.details.cache_read_input_tokens`
+- **Cache creation tokens** - `usage.details.cache_creation_input_tokens`
+
+The top-level `input_tokens` (and `request_tokens` in legacy sessions) already include cache tokens, so ccusage uses the `details` split to avoid double-counting. The cumulative session-level `usage` object is ignored for the same reason. Forked sessions copy the parent conversation's responses into a new session file; ccusage dedupes responses by provider response id — or, for legacy records without ids, by timestamp and token counts — so fork families are counted once.
+
+## Cost Calculation
+
+Rovo Dev bills Atlassian Rovo Dev credits and stores no cost in its local files, so ccusage estimates the equivalent API cost from token counts and LiteLLM pricing for the recorded model (for example `claude-sonnet-4-5-20250929`). The estimate is not what you pay Atlassian. Legacy sessions (CLI 0.6.x) store no model name; those rows display the `unknown` model and report a missing-pricing warning instead of a cost.
+
+## Environment Variables
+
+| Variable        | Description                                                                                |
+| --------------- | ------------------------------------------------------------------------------------------ |
+| `ROVO_DATA_DIR` | Override the root directory, or comma-separated root directories, containing Rovo Dev data |
+
+## Troubleshooting
+
+::: details No Rovo Dev usage data found
+Ensure the data directory exists at `~/.rovodev/sessions/`. Set `ROVO_DATA_DIR` if your Rovo Dev data lives elsewhere or in multiple archive roots, and check `sessions.persistenceDir` in `~/.rovodev/config.yml` if sessions were relocated.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: ccusage
   text: Coding (Agent) CLI Usage Analysis
-  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
+  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI
   image:
     src: /logo.svg
     alt: ccusage logo
@@ -27,7 +27,7 @@ features:
     link: /guide/getting-started
   - icon: 📁
     title: Local Data Sources
-    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
+    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Rovo Dev CLI without uploading your data
     link: /guide/
   - icon: 💰
     title: Cost Analysis

--- a/nix/cargo-artifacts.nix
+++ b/nix/cargo-artifacts.nix
@@ -47,6 +47,7 @@ let
     "opencode"
     "pi"
     "qwen"
+    "rovo"
   ];
   adapterCrates = map (name: "ccusage-adapter-${name}") agentNames ++ [ "ccusage-adapter-all" ];
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -130,6 +130,7 @@ dependencies = [
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
  "ccusage-adapter-qwen",
+ "ccusage-adapter-rovo",
  "ccusage-cli",
  "ccusage-cli-parser",
  "ccusage-config",
@@ -161,6 +162,7 @@ dependencies = [
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
  "ccusage-adapter-qwen",
+ "ccusage-adapter-rovo",
  "ccusage-cli",
  "ccusage-core",
  "ccusage-test-support",
@@ -358,6 +360,18 @@ dependencies = [
 
 [[package]]
 name = "ccusage-adapter-qwen"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-rovo"
 version = "0.0.0"
 dependencies = [
  "ccusage-adapter-common",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -33,6 +33,7 @@ ccusage-adapter-openclaw = { path = "adapters/openclaw" }
 ccusage-adapter-opencode = { path = "adapters/opencode" }
 ccusage-adapter-pi = { path = "adapters/pi" }
 ccusage-adapter-qwen = { path = "adapters/qwen" }
+ccusage-adapter-rovo = { path = "adapters/rovo" }
 ccusage-cli = { path = "crates/ccusage-cli" }
 ccusage-cli-parser = { path = "crates/ccusage-cli-parser" }
 ccusage-config = { path = "crates/ccusage-config" }

--- a/rust/adapters/rovo/Cargo.toml
+++ b/rust/adapters/rovo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccusage-adapter-rovo"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/rovo/README.md
+++ b/rust/adapters/rovo/README.md
@@ -1,0 +1,60 @@
+# ccusage-adapter-rovo
+
+The Atlassian Rovo Dev CLI adapter: it turns per-session `session_context.json`
+files into the usage entries the reports render.
+
+## Owns
+
+- `loader.rs` — reading the source, dedupe, and date filtering.
+- `parser.rs` — raw record parsing, token mapping, and model naming.
+- `paths.rs` — environment variables, default directories, and file discovery.
+- `report.rs` — the JSON and table shapes where they differ from the shared ones.
+
+Anything that is not specific to this source belongs in `ccusage-core` or
+`ccusage-adapter-common` instead.
+
+## Data source
+
+- `${ROVO_DATA_DIR:-~/.rovodev}/**/session_context.json` (sessions live under
+  `sessions/<session-id>/`), plus the directory named by
+  `sessions.persistenceDir` in `~/.rovodev/config.yml` when users relocate the
+  sessions root.
+
+Each session file is one JSON document. Per-turn usage lives in
+`message_history[]` entries with `kind: "response"`; the top-level session
+`usage` object is a cumulative duplicate of those turns and is ignored.
+
+## Token semantics
+
+- The top-level `input_tokens` (modern schema) and `request_tokens` (legacy
+  CLI 0.6.x schema) prompt totals both INCLUDE cache write/read tokens. The
+  `usage.details` object carries the raw provider values, so `details` is the
+  source of truth for the uncached-input/cache-write/cache-read split.
+- Legacy responses persist `model_name: null`; those entries report the
+  `unknown` model and surface the missing-pricing warning instead of a cost.
+- Forked sessions copy the parent's `message_history` prefix verbatim into a
+  new session file. Responses are deduped across files by
+  `provider_response_id` so fork families do not double-count; legacy records
+  without ids fall back to a composite token/timestamp key.
+- No cost is persisted locally (Rovo Dev bills Atlassian credits, not
+  dollars), so costs are LiteLLM estimates of equivalent API pricing and
+  `--mode display` shows 0.
+
+## Public surface
+
+- `loader::load_entries`
+- `report::report_from_rows`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde`
+- `serde_json`
+
+## Build layer
+
+Built in the `adapters` Crane artifact layer; the layer compiles all adapters in one Cargo invocation, so they build concurrently.

--- a/rust/adapters/rovo/src/lib.rs
+++ b/rust/adapters/rovo/src/lib.rs
@@ -1,0 +1,48 @@
+use ccusage_adapter_common::{
+    collect_files_with_extension, filter_loaded_entries_by_date, read_files_parallel,
+};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub use report::{report_from_rows, summarize_entries};
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        ccusage_core::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Rovo Dev Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/rovo/src/loader.rs
+++ b/rust/adapters/rovo/src/loader.rs
@@ -1,0 +1,213 @@
+use std::collections::HashSet;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
+
+use super::{
+    parser::{read_session_file, rovo_entry_key, rovo_entry_to_loaded},
+    paths::discover_session_files,
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Rovo Dev"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let files = discover_session_files()?;
+    // Read session files in parallel, then apply the first-wins dedup
+    // sequentially over the original discovery order so the surviving entry
+    // per key matches the single-threaded read. Forked sessions duplicate the
+    // parent's responses (same provider response ids, or the same
+    // timestamp+token tuples for id-less legacy records), so the dedup is what
+    // keeps fork families from double-counting.
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        read_session_file(file).unwrap_or_else(|error| {
+            debug_log(
+                shared,
+                format!("Failed to read Rovo Dev session file: {error}"),
+            );
+            Vec::new()
+        })
+    });
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for file_entries in loaded {
+        for entry in file_entries {
+            let key = rovo_entry_key(&entry);
+            if seen.insert(key) {
+                entries.push(rovo_entry_to_loaded(
+                    entry,
+                    tz.as_ref(),
+                    shared.mode,
+                    pricing,
+                ));
+            }
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::paths::ROVO_DATA_DIR_ENV;
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    fn response_json(response_id: &str, timestamp: &str, input: u64, output: u64) -> String {
+        serde_json::json!({
+            "kind": "response",
+            "model_name": "claude-sonnet-4-5-20250929",
+            "provider_response_id": response_id,
+            "timestamp": timestamp,
+            "usage": {
+                "input_tokens": input,
+                "output_tokens": output,
+                "details": {
+                    "input_tokens": input,
+                    "output_tokens": output,
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0
+                }
+            }
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn loads_rovo_session_usage_entries() {
+        let fixture = fs_fixture!({
+            "sessions/session-a/session_context.json": format!(
+                r#"{{"id": "session-a", "timestamp": 1771880550, "workspace_path": "/w",
+                     "message_history": [{}]}}"#,
+                response_json("msg_vrtx_1", "2026-02-23T21:03:45.664227Z", 100, 50)
+            ),
+        });
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2026-02-23");
+        assert_eq!(entries[0].session_id.as_ref(), "session-a");
+        assert_eq!(
+            entries[0].model.as_deref(),
+            Some("claude-sonnet-4-5-20250929")
+        );
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 50);
+        assert_eq!(entries[0].project_path.as_ref(), "/w");
+        assert!(
+            entries[0].cost > 0.0,
+            "embedded pricing must price sonnet 4.5"
+        );
+    }
+
+    #[test]
+    fn dedupes_forked_sessions_by_provider_response_id() {
+        let shared_turn = response_json("msg_vrtx_shared", "2026-02-23T21:03:45.664227Z", 100, 50);
+        let fork_turn = response_json("msg_vrtx_fork", "2026-02-24T09:00:00.000000Z", 10, 5);
+        let fixture = fs_fixture!({
+            "sessions/parent/session_context.json": format!(
+                r#"{{"message_history": [{shared_turn}]}}"#
+            ),
+            "sessions/fork/session_context.json": format!(
+                r#"{{"message_history": [{shared_turn}, {fork_turn}]}}"#
+            ),
+        });
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            2,
+            "the copied parent turn must not double-count"
+        );
+        let total_input: u64 = entries
+            .iter()
+            .map(|entry| entry.data.message.usage.input_tokens)
+            .sum();
+        assert_eq!(total_input, 110);
+    }
+
+    #[test]
+    fn dedupes_forked_legacy_sessions_without_response_ids() {
+        // Legacy (CLI 0.6.x) responses have no provider_response_id/vendor_id,
+        // so the copied fork prefix must dedupe on the timestamp+token key.
+        let shared_turn = r#"{
+            "kind": "response",
+            "model_name": null,
+            "vendor_id": null,
+            "timestamp": "2025-06-22T12:04:55.802259+00:00",
+            "usage": {
+                "requests": 0,
+                "request_tokens": 100,
+                "response_tokens": 40,
+                "total_tokens": 140,
+                "details": {
+                    "cache_creation_input_tokens": 0,
+                    "cache_read_input_tokens": 0,
+                    "input_tokens": 100,
+                    "output_tokens": 40
+                }
+            }
+        }"#;
+        let fork_turn = shared_turn.replace("12:04:55.802259", "12:09:01.000001");
+        let fixture = fs_fixture!({
+            "sessions/parent/session_context.json": format!(
+                r#"{{"message_history": [{shared_turn}]}}"#
+            ),
+            "sessions/fork/session_context.json": format!(
+                r#"{{"message_history": [{shared_turn}, {fork_turn}]}}"#
+            ),
+        });
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(
+            entries.len(),
+            2,
+            "the copied legacy parent turn must not double-count"
+        );
+        let total_input: u64 = entries
+            .iter()
+            .map(|entry| entry.data.message.usage.input_tokens)
+            .sum();
+        assert_eq!(total_input, 200);
+    }
+
+    #[test]
+    fn survives_malformed_session_files() {
+        let fixture = fs_fixture!({
+            "sessions/bad/session_context.json": "not json",
+            "sessions/good/session_context.json": format!(
+                r#"{{"message_history": [{}]}}"#,
+                response_json("msg_vrtx_2", "2026-02-23T21:03:45.664227Z", 7, 3)
+            ),
+        });
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.root());
+        let entries = load_entries(&SharedArgs::default(), &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "good");
+    }
+}

--- a/rust/adapters/rovo/src/parser.rs
+++ b/rust/adapters/rovo/src/parser.rs
@@ -1,0 +1,643 @@
+use std::{fs, path::Path, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde::Deserialize;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, cli_error, format_date_tz,
+    missing_pricing_model_for_candidates,
+};
+use ccusage_adapter_common::jsonl;
+
+/// Legacy (CLI 0.6.x) responses persist `model_name: null`; reports show this
+/// placeholder and pricing falls through to the missing-pricing warning.
+const DEFAULT_MODEL: &str = "unknown";
+const PROVIDER_PREFIXES: &[&str] = &["anthropic", "openai"];
+
+/// A Rovo Dev `session_context.json` document (one JSON object per session).
+/// Only the fields ccusage consumes are declared; serde skips everything else.
+#[derive(Debug, Deserialize)]
+struct RovoSessionContext {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    /// Session creation time in Unix epoch seconds. Forked sessions inherit
+    /// the parent's value, so it is only a fallback for per-turn timestamps.
+    #[serde(default, deserialize_with = "jsonl::lenient_i64")]
+    timestamp: Option<i64>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    workspace_path: Option<String>,
+    #[serde(default)]
+    message_history: Vec<serde_json::Value>,
+}
+
+/// A `message_history` entry. Usage is only carried by `kind: "response"`
+/// entries; `kind: "request"` entries never have a `usage` object.
+#[derive(Debug, Default, Deserialize)]
+struct RovoMessage {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    kind: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    model_name: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    timestamp: Option<String>,
+    /// Modern schema (pydantic-ai v1): e.g. `msg_vrtx_...` / `msg_bdrk_...`.
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    provider_response_id: Option<String>,
+    /// Legacy schema (CLI 0.6.x) equivalent of `provider_response_id`.
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    vendor_id: Option<String>,
+    usage: Option<RovoUsage>,
+}
+
+/// Token usage on a response entry. Modern records (pydantic-ai `RunUsage`)
+/// carry `input_tokens`/`output_tokens`/`cache_*_tokens`; legacy records
+/// (pydantic-ai `Usage`) carry `request_tokens`/`response_tokens`. Both
+/// duplicate the raw provider values under `details`.
+#[derive(Debug, Default, Deserialize)]
+struct RovoUsage {
+    /// Modern total prompt tokens; INCLUDES cache write and cache read.
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_write_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_read_tokens: u64,
+    /// Legacy total prompt tokens; INCLUDES cache write and cache read.
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    request_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    response_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    total_tokens: u64,
+    details: Option<RovoUsageDetails>,
+}
+
+/// Raw provider token counts; `input_tokens` here is the uncached share.
+#[derive(Debug, Default, Deserialize)]
+struct RovoUsageDetails {
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    output_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_creation_input_tokens: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    cache_read_input_tokens: u64,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct RovoUsageEntry {
+    timestamp: TimestampMs,
+    timestamp_text: String,
+    session_id: String,
+    workspace_path: Option<String>,
+    model: String,
+    response_id: Option<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_tokens: u64,
+    cache_read_tokens: u64,
+    extra_total_tokens: u64,
+}
+
+pub(super) fn read_session_file(path: &Path) -> Result<Vec<RovoUsageEntry>> {
+    let content = fs::read(path)?;
+    let context: RovoSessionContext = serde_json::from_slice(&content).map_err(|error| {
+        cli_error(format!(
+            "invalid Rovo Dev session file {}: {error}",
+            path.display()
+        ))
+    })?;
+    let session_id = extract_session_id(path, context.id.as_deref());
+    let fallback_timestamp = context
+        .timestamp
+        .and_then(|seconds| seconds.checked_mul(1000))
+        .map(TimestampMs::from_millis)
+        .unwrap_or_else(|| file_modified_timestamp(path));
+    Ok(context
+        .message_history
+        .into_iter()
+        .filter_map(|value| serde_json::from_value::<RovoMessage>(value).ok())
+        .filter_map(|message| {
+            message_to_entry(
+                &message,
+                &session_id,
+                context.workspace_path.as_deref(),
+                fallback_timestamp,
+            )
+        })
+        .collect())
+}
+
+fn message_to_entry(
+    message: &RovoMessage,
+    session_id: &str,
+    workspace_path: Option<&str>,
+    fallback_timestamp: TimestampMs,
+) -> Option<RovoUsageEntry> {
+    if message.kind.as_deref() != Some("response") {
+        return None;
+    }
+    let usage_counts = message.usage.as_ref()?;
+    let (usage, extra_total_tokens) = usage_to_raw(usage_counts);
+    if crate::total_usage_tokens(usage) + extra_total_tokens == 0 {
+        return None;
+    }
+    let timestamp = message
+        .timestamp
+        .as_deref()
+        .and_then(parse_rovo_timestamp)
+        .unwrap_or(fallback_timestamp);
+    Some(RovoUsageEntry {
+        timestamp,
+        timestamp_text: crate::format_rfc3339_millis(timestamp),
+        session_id: session_id.to_string(),
+        workspace_path: workspace_path.map(str::to_string),
+        model: message
+            .model_name
+            .clone()
+            .unwrap_or_else(|| DEFAULT_MODEL.to_string()),
+        response_id: message
+            .provider_response_id
+            .clone()
+            .or_else(|| message.vendor_id.clone()),
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.output_tokens,
+        cache_creation_tokens: usage.cache_creation_input_tokens,
+        cache_read_tokens: usage.cache_read_input_tokens,
+        extra_total_tokens,
+    })
+}
+
+fn usage_to_raw(usage: &RovoUsage) -> (TokenUsageRaw, u64) {
+    // Both schemas duplicate the raw provider values under `details`, and the
+    // top-level prompt total (`input_tokens` modern, `request_tokens` legacy)
+    // already includes cache tokens — `details` is the exact split.
+    let (input_tokens, cache_creation, cache_read) = match usage.details.as_ref() {
+        Some(details) => (
+            details.input_tokens,
+            details.cache_creation_input_tokens,
+            details.cache_read_input_tokens,
+        ),
+        None => (
+            usage
+                .input_tokens
+                .max(usage.request_tokens)
+                .saturating_sub(usage.cache_write_tokens)
+                .saturating_sub(usage.cache_read_tokens),
+            usage.cache_write_tokens,
+            usage.cache_read_tokens,
+        ),
+    };
+    let output_tokens = [
+        usage.output_tokens,
+        usage
+            .details
+            .as_ref()
+            .map(|details| details.output_tokens)
+            .unwrap_or(0),
+        usage.response_tokens,
+    ]
+    .into_iter()
+    .find(|tokens| *tokens > 0)
+    .unwrap_or(0);
+    let raw = TokenUsageRaw {
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: cache_creation,
+        cache_read_input_tokens: cache_read,
+        speed: None,
+        cache_creation: None,
+    };
+    apply_total_token_fallback(raw, 0, usage.total_tokens)
+}
+
+/// Rovo timestamps carry microsecond precision (`2026-02-23T21:03:45.664227Z`
+/// or `...+00:00`), which `parse_ts_timestamp`'s fixed-width fast path does
+/// not accept, so parse through jiff instead.
+fn parse_rovo_timestamp(value: &str) -> Option<TimestampMs> {
+    value
+        .parse::<jiff::Timestamp>()
+        .ok()
+        .map(|timestamp| TimestampMs::from_millis(timestamp.as_millisecond()))
+}
+
+fn extract_session_id(file_path: &Path, context_id: Option<&str>) -> String {
+    // The CLI itself treats the parent directory name as the session id.
+    file_path
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .map(str::to_string)
+        .or_else(|| context_id.map(str::to_string))
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn file_modified_timestamp(path: &Path) -> TimestampMs {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .map(TimestampMs::from_millis)
+        .unwrap_or(TimestampMs::UNIX_EPOCH)
+}
+
+pub(super) fn rovo_entry_key(entry: &RovoUsageEntry) -> String {
+    // Forked sessions copy the parent's message prefix verbatim, so the
+    // provider response id alone identifies a response across session files.
+    if let Some(response_id) = &entry.response_id {
+        return format!("response:{response_id}");
+    }
+    // Legacy (CLI 0.6.x) responses carry no id at all, and a legacy fork's
+    // copied prefix lives under a different session dir than the parent's, so
+    // session_id must stay OUT of this fallback key or fork families
+    // double-count. The millisecond-precision timestamp plus the full token
+    // tuple is discriminating enough on its own.
+    format!(
+        "{}:{}:{}:{}:{}:{}:{}",
+        entry.timestamp_text,
+        entry.model,
+        entry.input_tokens,
+        entry.output_tokens,
+        entry.cache_creation_tokens,
+        entry.cache_read_tokens,
+        entry.extra_total_tokens
+    )
+}
+
+pub(super) fn rovo_entry_to_loaded(
+    entry: RovoUsageEntry,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> LoadedEntry {
+    let usage = TokenUsageRaw {
+        input_tokens: entry.input_tokens,
+        output_tokens: entry.output_tokens,
+        cache_creation_input_tokens: entry.cache_creation_tokens,
+        cache_read_input_tokens: entry.cache_read_tokens,
+        speed: None,
+        cache_creation: None,
+    };
+    let cost = calculate_rovo_cost(&entry, mode, pricing, usage);
+    let missing_pricing_model = missing_rovo_pricing(&entry, mode, pricing, usage);
+    let data = UsageEntry {
+        session_id: Some(entry.session_id.clone()),
+        timestamp: entry.timestamp_text,
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: Some(entry.model.clone()),
+            id: entry.response_id.clone(),
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        date: format_date_tz(entry.timestamp, tz),
+        timestamp: entry.timestamp,
+        project: Arc::from("rovo"),
+        session_id: Arc::from(entry.session_id),
+        project_path: entry
+            .workspace_path
+            .as_deref()
+            .map(Arc::from)
+            .unwrap_or_else(|| Arc::from("Rovo Dev")),
+        cost,
+        extra_total_tokens: entry.extra_total_tokens,
+        credits: None,
+        message_count: None,
+        model: Some(entry.model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        data,
+    }
+}
+
+fn calculate_rovo_cost(
+    entry: &RovoUsageEntry,
+    mode: CostMode,
+    pricing: &PricingMap,
+    usage: TokenUsageRaw,
+) -> f64 {
+    match mode {
+        // Rovo Dev bills Atlassian credits and persists no cost locally, so
+        // display mode has nothing to show.
+        CostMode::Display => 0.0,
+        CostMode::Auto | CostMode::Calculate => {
+            for candidate in model_candidates(entry) {
+                if pricing.find(&candidate).is_some() {
+                    return calculate_cost_for_usage(
+                        Some(&candidate),
+                        usage,
+                        None,
+                        CostMode::Calculate,
+                        Some(pricing),
+                    );
+                }
+            }
+            0.0
+        }
+    }
+}
+
+fn missing_rovo_pricing(
+    entry: &RovoUsageEntry,
+    mode: CostMode,
+    pricing: &PricingMap,
+    usage: TokenUsageRaw,
+) -> Option<String> {
+    if mode == CostMode::Display {
+        return None;
+    }
+    missing_pricing_model_for_candidates(
+        &entry.model,
+        model_candidates(entry),
+        crate::total_usage_tokens(usage).saturating_add(entry.extra_total_tokens),
+        Some(pricing),
+    )
+}
+
+fn model_candidates(entry: &RovoUsageEntry) -> Vec<String> {
+    let mut candidates = vec![entry.model.clone()];
+    candidates.extend(
+        PROVIDER_PREFIXES
+            .iter()
+            .map(|prefix| format!("{prefix}/{}", entry.model)),
+    );
+    candidates
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    fn modern_session_json() -> String {
+        serde_json::json!({
+            "id": "wd2c0476-042b-49f3-b2d4-1a5c6bafe971",
+            "timestamp": 1771880550,
+            "workspace_path": "/home/user/project",
+            "message_history": [
+                {
+                    "kind": "request",
+                    "parts": [{"part_kind": "user-prompt", "content": "hello"}]
+                },
+                {
+                    "kind": "response",
+                    "model_name": "claude-sonnet-4-5-20250929",
+                    "provider_name": "anthropic",
+                    "provider_response_id": "msg_vrtx_014rqTwZTSMNrU4g6HcjDpQp",
+                    "timestamp": "2026-02-23T21:03:45.664227Z",
+                    "usage": {
+                        "input_tokens": 7933,
+                        "cache_write_tokens": 1535,
+                        "cache_read_tokens": 6395,
+                        "output_tokens": 249,
+                        "details": {
+                            "cache_creation_input_tokens": 1535,
+                            "cache_read_input_tokens": 6395,
+                            "input_tokens": 3,
+                            "output_tokens": 249
+                        }
+                    }
+                },
+                {
+                    "kind": "response",
+                    "model_name": "claude-sonnet-4-5-20250929",
+                    "provider_response_id": "msg_bdrk_01AbCdEfGhIjKlMnOpQrStUv",
+                    "timestamp": "2026-02-24T08:15:02.000001Z",
+                    "usage": {
+                        "input_tokens": 12,
+                        "output_tokens": 34,
+                        "details": {
+                            "cache_creation_input_tokens": 0,
+                            "cache_read_input_tokens": 0,
+                            "input_tokens": 12,
+                            "output_tokens": 34
+                        }
+                    }
+                }
+            ],
+            "usage": {"input_tokens": 7945, "output_tokens": 283}
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn maps_modern_response_usage_details_to_token_fields() {
+        let fixture = fs_fixture!({
+            "sessions/session-a/session_context.json": modern_session_json(),
+        });
+        let entries =
+            read_session_file(&fixture.path("sessions/session-a/session_context.json")).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[0].session_id, "session-a");
+        assert_eq!(entries[0].model, "claude-sonnet-4-5-20250929");
+        assert_eq!(
+            entries[0].response_id.as_deref(),
+            Some("msg_vrtx_014rqTwZTSMNrU4g6HcjDpQp")
+        );
+        assert_eq!(entries[0].input_tokens, 3);
+        assert_eq!(entries[0].output_tokens, 249);
+        assert_eq!(entries[0].cache_creation_tokens, 1535);
+        assert_eq!(entries[0].cache_read_tokens, 6395);
+        assert_eq!(entries[0].timestamp_text, "2026-02-23T21:03:45.664Z");
+        assert_eq!(
+            entries[0].workspace_path.as_deref(),
+            Some("/home/user/project")
+        );
+    }
+
+    #[test]
+    fn maps_legacy_usage_and_falls_back_to_unknown_model() {
+        let fixture = fs_fixture!({
+            "sessions/session-b/session_context.json": serde_json::json!({
+                "id": "session-b",
+                "timestamp": 1750592695,
+                "workspace_path": "/home/user/legacy",
+                "message_history": [
+                    {
+                        "kind": "response",
+                        "model_name": null,
+                        "vendor_id": null,
+                        "timestamp": "2025-06-22T12:04:55.802259+00:00",
+                        "usage": {
+                            "requests": 0,
+                            "request_tokens": 20807,
+                            "response_tokens": 240,
+                            "total_tokens": 21047,
+                            "details": {
+                                "cache_creation_input_tokens": 20803,
+                                "cache_read_input_tokens": 0,
+                                "input_tokens": 4,
+                                "output_tokens": 240
+                            }
+                        }
+                    }
+                ]
+            })
+            .to_string(),
+        });
+        let entries =
+            read_session_file(&fixture.path("sessions/session-b/session_context.json")).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model, DEFAULT_MODEL);
+        assert_eq!(entries[0].response_id, None);
+        assert_eq!(entries[0].input_tokens, 4);
+        assert_eq!(entries[0].output_tokens, 240);
+        assert_eq!(entries[0].cache_creation_tokens, 20803);
+        assert_eq!(entries[0].cache_read_tokens, 0);
+        assert_eq!(entries[0].extra_total_tokens, 0);
+        assert_eq!(entries[0].timestamp_text, "2025-06-22T12:04:55.802Z");
+    }
+
+    #[test]
+    fn derives_uncached_input_from_top_level_when_details_are_missing() {
+        let fixture = fs_fixture!({
+            "sessions/session-c/session_context.json": serde_json::json!({
+                "message_history": [
+                    {
+                        "kind": "response",
+                        "model_name": "claude-sonnet-4-5-20250929",
+                        "timestamp": "2026-02-23T21:03:45.664227Z",
+                        "usage": {
+                            "input_tokens": 7933,
+                            "cache_write_tokens": 1535,
+                            "cache_read_tokens": 6395,
+                            "output_tokens": 249
+                        }
+                    }
+                ]
+            })
+            .to_string(),
+        });
+        let entries =
+            read_session_file(&fixture.path("sessions/session-c/session_context.json")).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].input_tokens, 3);
+        assert_eq!(entries[0].cache_creation_tokens, 1535);
+        assert_eq!(entries[0].cache_read_tokens, 6395);
+        assert_eq!(entries[0].output_tokens, 249);
+    }
+
+    #[test]
+    fn skips_requests_zero_token_responses_and_malformed_history_entries() {
+        let fixture = fs_fixture!({
+            "sessions/session-d/session_context.json": serde_json::json!({
+                "message_history": [
+                    {"kind": "request", "parts": []},
+                    {"kind": "response", "usage": {"input_tokens": 0, "output_tokens": 0}},
+                    {"kind": "response"},
+                    "not an object",
+                    {
+                        "kind": "response",
+                        "model_name": "claude-sonnet-4-5-20250929",
+                        "timestamp": "2026-02-23T21:03:45.664227Z",
+                        "usage": {"input_tokens": 5, "output_tokens": 7,
+                                   "details": {"input_tokens": 5, "output_tokens": 7,
+                                               "cache_creation_input_tokens": 0,
+                                               "cache_read_input_tokens": 0}}
+                    }
+                ]
+            })
+            .to_string(),
+        });
+        let entries =
+            read_session_file(&fixture.path("sessions/session-d/session_context.json")).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].input_tokens, 5);
+    }
+
+    #[test]
+    fn falls_back_to_session_epoch_timestamp_when_response_has_none() {
+        let fixture = fs_fixture!({
+            "sessions/session-e/session_context.json": serde_json::json!({
+                "timestamp": 1771880550,
+                "message_history": [
+                    {
+                        "kind": "response",
+                        "model_name": "claude-sonnet-4-5-20250929",
+                        "usage": {"input_tokens": 5, "output_tokens": 7}
+                    }
+                ]
+            })
+            .to_string(),
+        });
+        let entries =
+            read_session_file(&fixture.path("sessions/session-e/session_context.json")).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].timestamp,
+            TimestampMs::from_millis(1771880550000)
+        );
+    }
+
+    #[test]
+    fn prices_rovo_usage_from_pricing_map_and_reports_missing_models() {
+        let mut pricing = PricingMap::default();
+        pricing.load_json(
+            r#"{"claude-sonnet-4-5-20250929": {
+                "input_cost_per_token": 0.000003,
+                "output_cost_per_token": 0.000015,
+                "cache_creation_input_token_cost": 0.00000375,
+                "cache_read_input_token_cost": 0.0000003
+            }}"#,
+        );
+        let usage = TokenUsageRaw {
+            input_tokens: 100,
+            output_tokens: 200,
+            cache_creation_input_tokens: 300,
+            cache_read_input_tokens: 400,
+            speed: None,
+            cache_creation: None,
+        };
+        let priced = RovoUsageEntry {
+            timestamp: TimestampMs::from_millis(1_771_880_550_000),
+            timestamp_text: "2026-02-23T21:02:30.000Z".to_string(),
+            session_id: "session-a".to_string(),
+            workspace_path: None,
+            model: "claude-sonnet-4-5-20250929".to_string(),
+            response_id: Some("msg_vrtx_1".to_string()),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_tokens: usage.cache_creation_input_tokens,
+            cache_read_tokens: usage.cache_read_input_tokens,
+            extra_total_tokens: 0,
+        };
+        let unknown = RovoUsageEntry {
+            model: DEFAULT_MODEL.to_string(),
+            ..priced.clone()
+        };
+
+        let cost = calculate_rovo_cost(&priced, CostMode::Calculate, &pricing, usage);
+        let expected = 100.0 * 0.000003 + 200.0 * 0.000015 + 300.0 * 0.00000375 + 400.0 * 0.0000003;
+        assert!((cost - expected).abs() < 1e-12);
+        assert_eq!(
+            missing_rovo_pricing(&priced, CostMode::Calculate, &pricing, usage),
+            None
+        );
+
+        assert_eq!(
+            calculate_rovo_cost(&unknown, CostMode::Display, &pricing, usage),
+            0.0
+        );
+        assert_eq!(
+            missing_rovo_pricing(&unknown, CostMode::Display, &pricing, usage),
+            None
+        );
+        assert!(missing_rovo_pricing(&unknown, CostMode::Calculate, &pricing, usage).is_some());
+    }
+}

--- a/rust/adapters/rovo/src/paths.rs
+++ b/rust/adapters/rovo/src/paths.rs
@@ -1,0 +1,192 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::{Result, collect_files_with_extension, path_utils::expand_home_path};
+
+pub(super) const ROVO_DATA_DIR_ENV: &str = "ROVO_DATA_DIR";
+const ROVO_SESSION_FILE_NAME: &str = "session_context.json";
+const ROVO_CONFIG_FILE_NAME: &str = "config.yml";
+
+fn roots() -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    let mut seen = HashSet::new();
+    if let Ok(env_paths) = env::var(ROVO_DATA_DIR_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                roots.push(path);
+            }
+        }
+        return Ok(roots);
+    }
+
+    if let Some(home) = crate::home::home_dir() {
+        let path = home.join(".rovodev");
+        if path.is_dir() {
+            roots.push(path);
+        }
+    }
+    Ok(roots)
+}
+
+pub(super) fn discover_session_files() -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    for root in roots()? {
+        let mut candidates = Vec::new();
+        collect_files_with_extension(&root, "json", &mut candidates);
+        // Rovo Dev lets users move the sessions directory outside ~/.rovodev
+        // via `sessions.persistenceDir` in config.yml; scan it too when it is
+        // not already covered by the recursive walk above.
+        if let Some(persistence_dir) = persistence_dir_from_config(&root)
+            && !persistence_dir.starts_with(&root)
+            && persistence_dir.is_dir()
+        {
+            collect_files_with_extension(&persistence_dir, "json", &mut candidates);
+        }
+        files.extend(candidates.into_iter().filter(|file| {
+            file.file_name().and_then(|name| name.to_str()) == Some(ROVO_SESSION_FILE_NAME)
+        }));
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+fn persistence_dir_from_config(root: &Path) -> Option<PathBuf> {
+    let content = fs::read_to_string(root.join(ROVO_CONFIG_FILE_NAME)).ok()?;
+    persistence_dir_from_yaml(&content)
+}
+
+/// Minimal scan for `sessions.persistenceDir` so the adapter does not need a
+/// YAML dependency: find the top-level `sessions:` block, then the first
+/// `persistenceDir:` entry indented under it.
+fn persistence_dir_from_yaml(content: &str) -> Option<PathBuf> {
+    let mut in_sessions = false;
+    for line in content.lines() {
+        let trimmed = line.trim_start();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+        let indent = line.len() - trimmed.len();
+        if indent == 0 {
+            // Tolerate trailing whitespace or a comment after the key so
+            // hand-edited configs (`sessions:  # session settings`) still open
+            // the block.
+            in_sessions = trimmed
+                .strip_prefix("sessions:")
+                .is_some_and(|rest| rest.trim().is_empty() || rest.trim_start().starts_with('#'));
+            continue;
+        }
+        if !in_sessions {
+            continue;
+        }
+        if let Some(raw) = trimmed.strip_prefix("persistenceDir:") {
+            let value = raw
+                .split(" #")
+                .next()
+                .unwrap_or(raw)
+                .trim()
+                .trim_matches('"')
+                .trim_matches('\'');
+            if value.is_empty() {
+                return None;
+            }
+            return Some(expand_home_path(value));
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    #[test]
+    fn discovers_session_context_files_under_env_root() {
+        let fixture = fs_fixture!({
+            "sessions/session-a/session_context.json": "{}",
+            "sessions/session-a/metadata.json": "{}",
+            "sessions/nested/session-b/session_context.json": "{}",
+            "mcp.json": "{}",
+        });
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.root());
+        let files = discover_session_files().unwrap();
+
+        assert_eq!(
+            files,
+            vec![
+                fixture.path("sessions/nested/session-b/session_context.json"),
+                fixture.path("sessions/session-a/session_context.json"),
+            ]
+        );
+    }
+
+    #[test]
+    fn follows_sessions_persistence_dir_from_config_yml() {
+        let fixture = fs_fixture!({
+            "rovodev/config.yml": "",
+            "workspace/.rovodev/sessions/session-c/session_context.json": "{}",
+        });
+        let persistence_dir = fixture.path("workspace/.rovodev/sessions");
+        let _ = fixture.write_file(
+            "rovodev/config.yml",
+            format!(
+                "version: 1\nsessions:\n  persistenceDir: {}\n  retentionDays: 30\n",
+                persistence_dir.display()
+            ),
+        );
+        let _cleanup = EnvVarGuard::set(ROVO_DATA_DIR_ENV, fixture.path("rovodev"));
+        let files = discover_session_files().unwrap();
+
+        assert_eq!(
+            files,
+            vec![fixture.path("workspace/.rovodev/sessions/session-c/session_context.json")]
+        );
+    }
+
+    #[test]
+    fn parses_persistence_dir_only_under_the_sessions_block() {
+        let yaml = "logging:\n  persistenceDir: /wrong\nsessions:\n  # a comment\n  persistenceDir: \"/data/rovo sessions\" # trailing\n";
+
+        assert_eq!(
+            persistence_dir_from_yaml(yaml),
+            Some(PathBuf::from("/data/rovo sessions"))
+        );
+        assert_eq!(persistence_dir_from_yaml("sessions:\n  other: 1\n"), None);
+    }
+
+    #[test]
+    fn opens_the_sessions_block_despite_trailing_comment_or_whitespace() {
+        assert_eq!(
+            persistence_dir_from_yaml("sessions: # session settings\n  persistenceDir: /data/a\n"),
+            Some(PathBuf::from("/data/a"))
+        );
+        assert_eq!(
+            persistence_dir_from_yaml("sessions:   \n  persistenceDir: /data/b\n"),
+            Some(PathBuf::from("/data/b"))
+        );
+        assert_eq!(
+            persistence_dir_from_yaml("sessionsOld:\n  persistenceDir: /data/c\n"),
+            None
+        );
+    }
+
+    #[test]
+    fn expands_home_in_persistence_dir() {
+        let fixture = fs_fixture!({});
+        let _home = EnvVarGuard::set("HOME", fixture.root());
+
+        assert_eq!(
+            persistence_dir_from_yaml("sessions:\n  persistenceDir: ~/rovo-sessions\n"),
+            Some(fixture.path("rovo-sessions"))
+        );
+    }
+}

--- a/rust/adapters/rovo/src/report.rs
+++ b/rust/adapters/rovo/src/report.rs
@@ -1,0 +1,67 @@
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -21,6 +21,7 @@ ccusage-adapter-openclaw.workspace = true
 ccusage-adapter-opencode.workspace = true
 ccusage-adapter-pi.workspace = true
 ccusage-adapter-qwen.workspace = true
+ccusage-adapter-rovo.workspace = true
 ccusage-cli.workspace = true
 ccusage-core.workspace = true
 serde.workspace = true

--- a/rust/crates/ccusage-adapter-all/README.md
+++ b/rust/crates/ccusage-adapter-all/README.md
@@ -35,6 +35,7 @@ themselves independent of each other.
 - `ccusage-adapter-opencode`
 - `ccusage-adapter-pi`
 - `ccusage-adapter-qwen`
+- `ccusage-adapter-rovo`
 - `ccusage-cli`
 - `ccusage-core`
 - `serde`

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -24,6 +24,7 @@ mod adapter {
     pub use ccusage_adapter_opencode as opencode;
     pub use ccusage_adapter_pi as pi;
     pub use ccusage_adapter_qwen as qwen;
+    pub use ccusage_adapter_rovo as rovo;
 }
 
 use crate::{

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -12,7 +12,7 @@ use crate::{
     SessionAccumulator, UsageSummary,
     adapter::{
         amp, claude, codebuff, codex, copilot, droid, gemini, goose, hermes, kilo, kimi, openclaw,
-        opencode, pi, qwen,
+        opencode, pi, qwen, rovo,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -308,6 +308,21 @@ fn load_base_rows(
             agent: BUILT_IN_AGENT_NAMES[14],
             progress_agent: crate::progress::UsageLoadAgent("Qwen"),
             load: Box::new(|| load_qwen_rows(load_kind, &loader_shared)),
+        },
+        AgentLoadSpec {
+            index: 15,
+            agent: BUILT_IN_AGENT_NAMES[15],
+            progress_agent: crate::progress::UsageLoadAgent("Rovo Dev"),
+            load: Box::new(|| {
+                load_priced_summary_agent_rows(
+                    "rovo",
+                    load_kind,
+                    &loader_shared,
+                    pricing,
+                    rovo::load_entries,
+                    rovo::summarize_entries,
+                )
+            }),
         },
     ];
     let named_pi_stores = resolve_named_pi_store_paths(&shared.pi_stores)?;

--- a/rust/crates/ccusage-adapter-all/src/report.rs
+++ b/rust/crates/ccusage-adapter-all/src/report.rs
@@ -589,6 +589,7 @@ fn agent_label(agent: &str) -> &str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "rovo" => "Rovo Dev",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -559,6 +559,7 @@ fn isolated_agent_env(
         "GEMINI_DATA_DIR",
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
+        "ROVO_DATA_DIR",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -98,6 +98,10 @@
 				"description": "Show Qwen usage commands"
 			},
 			{
+				"name": "rovo",
+				"description": "Show Rovo Dev usage commands"
+			},
+			{
 				"name": "openclaw",
 				"description": "Show OpenClaw usage commands"
 			}
@@ -696,6 +700,43 @@
 			"path": ["qwen", "session"],
 			"description": "Show Qwen usage grouped by session",
 			"usage": "ccusage qwen session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["rovo"],
+			"description": "Usage reports for rovo.",
+			"usage": "ccusage rovo <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Rovo Dev usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Rovo Dev usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Rovo Dev usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["rovo", "daily"],
+			"description": "Show Rovo Dev usage grouped by date",
+			"usage": "ccusage rovo daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["rovo", "monthly"],
+			"description": "Show Rovo Dev usage grouped by month",
+			"usage": "ccusage rovo monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["rovo", "session"],
+			"description": "Show Rovo Dev usage grouped by session",
+			"usage": "ccusage rovo session <OPTIONS>",
 			"options": "agent_options"
 		},
 		{

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -331,6 +331,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Qwen,
         ),
+        "rovo" => parse_basic_agent_command(
+            parser,
+            shared,
+            "rovo",
+            STANDARD_AGENT_REPORTS,
+            Command::Rovo,
+        ),
         "openclaw" => parse_openclaw_command(parser, shared, config),
         _ => Err(format!("Unknown command '{command}'")),
     }
@@ -762,6 +769,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "rovo"
     )
 }
 
@@ -920,6 +928,7 @@ fn is_agent_command(command: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "rovo"
             | "openclaw"
     )
 }
@@ -933,7 +942,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" => {
+        | "gemini" | "kimi" | "qwen" | "rovo" | "openclaw" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -956,6 +965,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
         "qwen" => "Qwen",
+        "rovo" => "Rovo Dev",
         "openclaw" => "OpenClaw",
         _ => unreachable!("agent is prevalidated"),
     }
@@ -1030,6 +1040,7 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Gemini(args)
             | Command::Kimi(args)
             | Command::Qwen(args)
+            | Command::Rovo(args)
             | Command::OpenClaw(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,6 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
+assertion_line: 702
 expression: help_text()
 ---
 USAGE:
@@ -27,6 +28,7 @@ COMMANDS:
   gemini                     Show Gemini CLI usage commands
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
+  rovo                       Show Rovo Dev usage commands
   openclaw                   Show OpenClaw usage commands
 
 For more info, run any command with the `--help` flag:
@@ -50,6 +52,7 @@ For more info, run any command with the `--help` flag:
   ccusage gemini --help
   ccusage kimi --help
   ccusage qwen --help
+  ccusage rovo --help
   ccusage openclaw --help
 
 OPTIONS:

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -203,6 +203,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Gemini(args)) => agent_command_snapshot("gemini", args),
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
+        Some(Command::Rovo(args)) => agent_command_snapshot("rovo", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
     }
 }
@@ -607,7 +608,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw",
+        "copilot", "gemini", "kimi", "qwen", "rovo", "openclaw",
     ];
 
     for agent in agents {
@@ -1163,6 +1164,16 @@ fn parses_kimi_session_options() {
     let cli = parse(&["ccusage", "kimi", "session", "--json"]);
     let Some(Command::Kimi(args)) = cli.command else {
         panic!("expected kimi command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn parses_rovo_session_options() {
+    let cli = parse(&["ccusage", "rovo", "session", "--json"]);
+    let Some(Command::Rovo(args)) = cli.command else {
+        panic!("expected rovo command");
     };
     assert_eq!(args.kind, AgentReportKind::Session);
     assert!(args.shared.json);

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -24,6 +24,7 @@ pub enum Command {
     Gemini(AgentCommandArgs),
     Kimi(AgentCommandArgs),
     Qwen(AgentCommandArgs),
+    Rovo(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
 }
 

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -50,6 +50,8 @@ pub struct CcusageConfig {
     pub kimi: Option<KimiConfig>,
     /// Qwen configuration.
     pub qwen: Option<QwenConfig>,
+    /// Rovo Dev configuration.
+    pub rovo: Option<RovoConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -299,6 +301,21 @@ pub struct QwenConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct QwenCommandsConfig {
+    pub daily: Option<SharedOptions>,
+    pub monthly: Option<SharedOptions>,
+    pub session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RovoConfig {
+    pub defaults: Option<SharedOptions>,
+    pub commands: Option<RovoCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RovoCommandsConfig {
     pub daily: Option<SharedOptions>,
     pub monthly: Option<SharedOptions>,
     pub session: Option<SharedOptions>,
@@ -1128,7 +1145,7 @@ mod tests {
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
                 "gemini", "goose", "hermes", "kilo", "kimi", "opencode", "openclaw", "pi", "qwen",
-                "droid",
+                "droid", "rovo",
             ],
         );
         assert!(
@@ -1271,6 +1288,13 @@ mod tests {
                 }
             },
             "qwen": {
+                "commands": {
+                    "session": {
+                        "json": true
+                    }
+                }
+            },
+            "rovo": {
                 "commands": {
                     "session": {
                         "json": true

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,6 @@
 ---
-source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
+source: crates/ccusage-config/src/config_schema.rs
+assertion_line: 1426
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -1140,7 +1140,8 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "openclaw",
     "opencode",
     "pi",
-    "qwen"
+    "qwen",
+    "rovo"
   ],
   "rootRef": "#/definitions/ccusage-config"
 }

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "rovo",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -32,6 +32,7 @@ ccusage-adapter-openclaw.workspace = true
 ccusage-adapter-opencode.workspace = true
 ccusage-adapter-pi.workspace = true
 ccusage-adapter-qwen.workspace = true
+ccusage-adapter-rovo.workspace = true
 ccusage-cli-parser.workspace = true
 ccusage-cli.workspace = true
 ccusage-config.workspace = true

--- a/rust/crates/ccusage/README.md
+++ b/rust/crates/ccusage/README.md
@@ -35,6 +35,7 @@ source in its own `ccusage-adapter-*` crate.
 - `ccusage-adapter-opencode`
 - `ccusage-adapter-pi`
 - `ccusage-adapter-qwen`
+- `ccusage-adapter-rovo`
 - `ccusage-cli`
 - `ccusage-cli-parser`
 - `ccusage-config`

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -14,3 +14,4 @@ pub(crate) use ccusage_adapter_openclaw as openclaw;
 pub(crate) use ccusage_adapter_opencode as opencode;
 pub(crate) use ccusage_adapter_pi as pi;
 pub(crate) use ccusage_adapter_qwen as qwen;
+pub(crate) use ccusage_adapter_rovo as rovo;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -48,6 +48,7 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Gemini(args)
             | Command::Kimi(args)
             | Command::Qwen(args)
+            | Command::Rovo(args)
             | Command::OpenClaw(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -46,6 +46,7 @@ fn main() -> Result<()> {
         Some(Command::Copilot(args)) => adapter::copilot::run(args),
         Some(Command::Gemini(args)) => adapter::gemini::run(args),
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
+        Some(Command::Rovo(args)) => adapter::rovo::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         None => {
             let args = AgentCommandArgs {
@@ -85,7 +86,7 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 14] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
             ccusage_adapter_amp::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
@@ -100,9 +101,10 @@ mod tests {
             ccusage_adapter_opencode::run,
             ccusage_adapter_pi::run,
             ccusage_adapter_qwen::run,
+            ccusage_adapter_rovo::run,
         ];
 
-        assert_eq!(runs.len(), 14);
+        assert_eq!(runs.len(), 15);
     }
 
     #[test]
@@ -861,6 +863,116 @@ mod tests {
                 "cacheReadTokens": 10,
                 "cost": 0.05
             }])
+        );
+    }
+
+    #[test]
+    fn loads_rovo_session_usage_entries() {
+        let fixture = fs_fixture!({
+            "sessions/session-a/session_context.json": json!({
+                "id": "session-a",
+                "timestamp": 1771880550,
+                "workspace_path": "/home/user/project",
+                "message_history": [
+                    {"kind": "request", "parts": []},
+                    {
+                        "kind": "response",
+                        "model_name": "claude-sonnet-4-5-20250929",
+                        "provider_response_id": "msg_vrtx_014rqTwZTSMNrU4g6HcjDpQp",
+                        "timestamp": "2026-02-23T21:03:45.664227Z",
+                        "usage": {
+                            "input_tokens": 7933,
+                            "cache_write_tokens": 1535,
+                            "cache_read_tokens": 6395,
+                            "output_tokens": 249,
+                            "details": {
+                                "cache_creation_input_tokens": 1535,
+                                "cache_read_input_tokens": 6395,
+                                "input_tokens": 3,
+                                "output_tokens": 249
+                            }
+                        }
+                    }
+                ]
+            })
+            .to_string(),
+        });
+        let _cleanup = EnvVarGuard::set("ROVO_DATA_DIR", fixture.root());
+
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = adapter::rovo::load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2026-02-23");
+        assert_eq!(entries[0].session_id.as_ref(), "session-a");
+        assert_eq!(
+            entries[0].model.as_deref(),
+            Some("claude-sonnet-4-5-20250929")
+        );
+        assert_eq!(entries[0].data.message.usage.input_tokens, 3);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 249);
+        assert_eq!(
+            entries[0].data.message.usage.cache_creation_input_tokens,
+            1535
+        );
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 6395);
+        assert_eq!(entries[0].project_path.as_ref(), "/home/user/project");
+    }
+
+    #[test]
+    fn builds_rovo_daily_json_report() {
+        let entry = LoadedEntry {
+            data: UsageEntry {
+                session_id: Some("session-a".to_string()),
+                timestamp: "2026-02-23T21:03:45.664Z".to_string(),
+                version: None,
+                message: UsageMessage {
+                    usage: TokenUsageRaw {
+                        input_tokens: 100,
+                        output_tokens: 50,
+                        cache_creation_input_tokens: 20,
+                        cache_read_input_tokens: 10,
+                        speed: None,
+                        cache_creation: None,
+                    },
+                    model: Some("claude-sonnet-4-5-20250929".to_string()),
+                    id: Some("msg_vrtx_1".to_string()),
+                },
+                cost_usd: None,
+                request_id: None,
+                is_api_error_message: None,
+                is_sidechain: None,
+            },
+            timestamp: parse_ts_timestamp("2026-02-23T21:03:45.664Z").unwrap(),
+            date: "2026-02-23".to_string(),
+            project: Arc::from("rovo"),
+            session_id: Arc::from("session-a"),
+            project_path: Arc::from("/home/user/project"),
+            cost: 0.02,
+            extra_total_tokens: 0,
+            credits: None,
+            message_count: None,
+            model: Some("claude-sonnet-4-5-20250929".to_string()),
+            usage_limit_reset_time: None,
+            missing_pricing_model: None,
+        };
+
+        let rows = adapter::rovo::summarize_entries(&[entry], AgentReportKind::Daily).unwrap();
+        let report = adapter::rovo::report_from_rows(&rows, AgentReportKind::Daily);
+
+        assert_eq!(report["daily"][0]["date"], "2026-02-23");
+        assert_eq!(report["daily"][0]["inputTokens"], 100);
+        assert_eq!(report["daily"][0]["outputTokens"], 50);
+        assert_eq!(report["daily"][0]["cacheCreationTokens"], 20);
+        assert_eq!(report["daily"][0]["cacheReadTokens"], 10);
+        assert_eq!(report["daily"][0]["totalTokens"], 180);
+        assert_eq!(report["daily"][0]["totalCost"], json!(0.02));
+        assert_eq!(
+            report["daily"][0]["modelsUsed"],
+            json!(["claude-sonnet-4-5-20250929"])
         );
     }
 


### PR DESCRIPTION
## Summary

- add a Rovo Dev adapter that reads local `session_context.json` session files from `~/.rovodev`
- expose `ccusage rovo daily/monthly/session` and include Rovo Dev in the all-source report
- support `ROVO_DATA_DIR` (a single directory or comma-separated list) and follow `sessions.persistenceDir` from `config.yml` when sessions are relocated
- map both the modern (pydantic-ai) and legacy (CLI 0.6.x) usage schemas, using the `usage.details` split so cache tokens are not double-counted
- dedupe forked sessions by provider response id, or by timestamp and token counts for legacy records without ids, so fork families are counted once
- estimate cost from token counts and LiteLLM pricing for the recorded model; Rovo Dev bills Atlassian credits and stores no cost locally, so `--mode display` shows 0 and legacy sessions without a model name report a missing-pricing warning
- update the config schema, docs (new Rovo Dev guide plus getting-started, config, env vars, all-reports, README, and site indexes), and tests

Closes  #1530

## Validation

- just test
- just typecheck
- just fmt
- just check

> [!NOTE]
> Rovo Dev support is marked experimental, matching the other newer adapters. The cost column is a LiteLLM estimate of equivalent API pricing, not the Atlassian Rovo Dev credits actually billed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1527"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787848156&installation_model_id=423687&pr_number=1527&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1527&signature=5f583fbacb75c937c75863b76f92d818be0d20d7075ec7559dd5e52061c7f4ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atlassian Rovo Dev CLI support with a new adapter and commands. Rovo sessions are now included in daily/monthly/session reports and in unified all-source views.

- **New Features**
  - New commands: `ccusage rovo daily`, `ccusage rovo monthly`, `ccusage rovo session`.
  - New crate `ccusage-adapter-rovo`; wired into `ccusage-adapter-all` and the main binary.
  - Reads `session_context.json` from `~/.rovodev` or `ROVO_DATA_DIR`; also follows `sessions.persistenceDir` in `config.yml`.
  - Supports both modern (pydantic-ai) and legacy (CLI 0.6.x) usage schemas.
  - Dedupe forked sessions by provider response id or timestamp+token for legacy entries.
  - Estimates cost via LiteLLM pricing for the recorded model; warns if model is missing. Rovo credits are not shown.

- **Migration**
  - Use `ccusage rovo daily` (or run `ccusage daily` to include it in all-source reports).
  - Optionally set `ROVO_DATA_DIR` to one or more directories (comma-separated).
  - Configure per-source defaults with the new `rovo` namespace in config files.

<sup>Written for commit 565c43fee2abded9ea1baa4848c38c9f59ad3303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental Rovo Dev CLI support.
  * Added daily, monthly, and session usage reports through commands such as `ccusage rovo daily`.
  * Included Rovo usage in unified reports, with token tracking, estimated costs, filtering, sorting, and JSON output.
  * Added support for custom Rovo data directories through `ROVO_DATA_DIR`.

* **Documentation**
  * Added setup, configuration, troubleshooting, and usage guidance for Rovo Dev CLI.
  * Updated supported-source lists and navigation throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->