### PR TITLE
fix(terminal): compact numeric cells instead of truncating their digits

### DIFF
--- a/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__table__tests__snapshots_narrow_table_with_wrapping_truncation_and_compact_dates.snap
+++ b/rust/crates/ccusage-terminal/src/snapshots/ccusage_terminal__table__tests__snapshots_narrow_table_with_wrapping_truncation_and_compact_dates.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/ccusage-terminal/src/table.rs
-assertion_line: 495
 expression: "table.render_lines().join(\"\\n\")"
 ---
 ┌──────────┬────────────┬──────────┬──────────┬──────────┐
 │ Date     │ Models     │    Input │   Output │     Cost │
 │          │            │          │          │    (USD) │
 ├──────────┼────────────┼──────────┼──────────┼──────────┤
-│ 2026     │ -          │ 123,456… │ 9,876,5… │ $12345.… │
+│ 2026     │ -          │   123.5M │     9.9M │   $12.3K │
 │ 05-18    │ claude-so… │          │          │          │
 │          │ -          │          │          │          │
 │          │ unusually… │          │          │          │

--- a/rust/crates/ccusage-terminal/src/table.rs
+++ b/rust/crates/ccusage-terminal/src/table.rs
@@ -68,7 +68,9 @@ impl SimpleTable {
         let widths = self.column_widths();
         let mut lines = Vec::new();
         lines.push(border('┌', '┬', '┐', &widths));
-        for header_row in expand_multiline_row(&self.headers, self.headers.len(), &widths) {
+        for header_row in
+            expand_multiline_row(&self.headers, self.headers.len(), &widths, &self.aligns)
+        {
             let header_row = header_row
                 .iter()
                 .map(|header| color(self.style, header, Color::Blue))
@@ -80,7 +82,9 @@ impl SimpleTable {
             match row {
                 Some(row) => {
                     let row = self.compact_date_row(row, &widths);
-                    for physical_row in expand_multiline_row(&row, self.headers.len(), &widths) {
+                    for physical_row in
+                        expand_multiline_row(&row, self.headers.len(), &widths, &self.aligns)
+                    {
                         lines.push(table_line(&physical_row, &self.aligns, &widths));
                     }
                 }
@@ -148,7 +152,12 @@ impl SimpleTable {
     }
 }
 
-fn expand_multiline_row(row: &[String], column_count: usize, widths: &[usize]) -> Vec<Vec<String>> {
+fn expand_multiline_row(
+    row: &[String],
+    column_count: usize,
+    widths: &[usize],
+    aligns: &[Align],
+) -> Vec<Vec<String>> {
     let cells = (0..column_count)
         .map(|index| {
             let content_width = widths
@@ -157,7 +166,15 @@ fn expand_multiline_row(row: &[String], column_count: usize, widths: &[usize]) -
                 .unwrap_or_default()
                 .saturating_sub(2);
             row.get(index)
-                .map(|cell| wrap_cell_lines(cell, content_width))
+                .map(|cell| {
+                    if aligns.get(index) == Some(&Align::Right)
+                        && visible_width(cell) > content_width
+                        && let Some(compact) = compact_numeric(cell, content_width)
+                    {
+                        return vec![compact];
+                    }
+                    wrap_cell_lines(cell, content_width)
+                })
                 .filter(|lines| !lines.is_empty())
                 .unwrap_or_else(|| vec![String::new()])
         })
@@ -278,6 +295,54 @@ fn wrap_cell_line(line: &str, width: usize) -> Vec<String> {
     lines
 }
 
+/// Rewrites a numeric cell into a compact `1.2K` / `3.4M` / `5.6B` form that
+/// fits `width` display columns.
+///
+/// Numeric columns must never be ellipsis-truncated: dropping the tail of
+/// `67,992,133` leaves `67,992,…`, which still reads as a number but is wrong
+/// by orders of magnitude. A compact form loses precision instead of meaning.
+/// Returns `None` when the cell is not a plain number and the caller should
+/// fall back to truncation.
+fn compact_numeric(value: &str, width: usize) -> Option<String> {
+    let (prefix, digits) = match value.strip_prefix('$') {
+        Some(rest) => ("$", rest),
+        None => ("", value),
+    };
+    let cleaned = digits.replace(',', "");
+    if cleaned.is_empty() || !cleaned.chars().all(|ch| ch.is_ascii_digit() || ch == '.') {
+        return None;
+    }
+    let number = cleaned.parse::<f64>().ok()?;
+
+    let mut scaled = number;
+    let mut unit = 0usize;
+    while scaled >= 1000.0 && unit < UNIT_SUFFIXES.len() {
+        scaled /= 1000.0;
+        unit += 1;
+    }
+    if unit == 0 {
+        return None;
+    }
+    // Rounding can push the mantissa back over a unit boundary (999,999 would
+    // otherwise render as `1000.0K` rather than `1.0M`).
+    let rounded = (scaled * 10.0).round() / 10.0;
+    if rounded >= 1000.0 && unit < UNIT_SUFFIXES.len() {
+        scaled = rounded / 1000.0;
+        unit += 1;
+    }
+
+    let suffix = UNIT_SUFFIXES[unit - 1];
+    for precision in [1usize, 0] {
+        let candidate = format!("{prefix}{scaled:.precision$}{suffix}");
+        if visible_width(&candidate) <= width {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+const UNIT_SUFFIXES: [char; 3] = ['K', 'M', 'B'];
+
 fn compact_date_cell(value: &str) -> Option<String> {
     let bytes = value.as_bytes();
     if bytes.len() == 10
@@ -347,6 +412,73 @@ mod tests {
             Some("2026\n05-18".to_string())
         );
         assert_eq!(compact_date_cell("20260518"), None);
+    }
+
+    #[test]
+    fn compact_numeric_keeps_magnitude_of_values_that_do_not_fit() {
+        assert_eq!(compact_numeric("123,456,789", 8).as_deref(), Some("123.5M"));
+        assert_eq!(compact_numeric("9,876,543", 8).as_deref(), Some("9.9M"));
+        assert_eq!(compact_numeric("67,992,133", 8).as_deref(), Some("68.0M"));
+        assert_eq!(compact_numeric("$12345.67", 8).as_deref(), Some("$12.3K"));
+        assert_eq!(compact_numeric("4,567,890,123", 8).as_deref(), Some("4.6B"));
+    }
+
+    #[test]
+    fn compact_numeric_drops_precision_before_giving_up() {
+        // 5 columns cannot hold `123.5M`, but `123M` still carries the magnitude.
+        assert_eq!(compact_numeric("123,456,789", 4).as_deref(), Some("123M"));
+        // Nothing fits, so the caller falls back to truncation.
+        assert_eq!(compact_numeric("123,456,789", 3), None);
+    }
+
+    #[test]
+    fn compact_numeric_rounds_across_the_unit_boundary() {
+        assert_eq!(compact_numeric("999,999", 8).as_deref(), Some("1.0M"));
+    }
+
+    #[test]
+    fn compact_numeric_declines_non_numeric_and_already_short_cells() {
+        assert_eq!(compact_numeric("- claude-opus-4-5", 8), None);
+        assert_eq!(compact_numeric("", 8), None);
+        assert_eq!(compact_numeric("2026-05-18", 8), None);
+        // Below 1000 there is no shorter honest form than the value itself.
+        assert_eq!(compact_numeric("602", 2), None);
+    }
+
+    #[test]
+    fn narrow_numeric_columns_keep_their_magnitude_instead_of_an_ellipsis() {
+        let mut table = SimpleTable::new(
+            vec!["Date", "Models", "Input", "Output", "Cost (USD)"],
+            vec![
+                Align::Left,
+                Align::Left,
+                Align::Right,
+                Align::Right,
+                Align::Right,
+            ],
+            TerminalStyle {
+                no_color: true,
+                ..TerminalStyle::default()
+            },
+        )
+        .with_terminal_width(56);
+        table.push(vec![
+            "2026-05-18".to_string(),
+            "- claude-opus-4-5".to_string(),
+            "123,456,789".to_string(),
+            "9,876,543".to_string(),
+            "$12345.67".to_string(),
+        ]);
+
+        let rendered = table.render_lines().join("\n");
+        assert!(
+            rendered.contains("123.5M") && rendered.contains("9.9M"),
+            "numeric cells should compact rather than truncate:\n{rendered}"
+        );
+        assert!(
+            !rendered.contains("123,456…") && !rendered.contains("9,876,5…"),
+            "no numeric cell should end in an ellipsis:\n{rendered}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes the numeric half of #946.

## Problem

When the table does not fit the terminal, `expand_multiline_row` sends every overflowing cell through `wrap_cell_lines` → `truncate_to_width`. For text that is correct. For a number it is not: the digits are dropped from the right, so the cell still reads as a number while being wrong by orders of magnitude, with nothing to signal it.

On a 100-column terminal, a daily report:

```
│ Date     │ Agent      │ Models │    Input │   Output │    Cache │    Cache │    Total │     Cost │
│ 2026     │ All        │        │      602 │  438,716 │ 1,956,3… │ 67,992,… │ 70,388,… │   $64.53 │
│ 07-29    │            │        │          │          │          │          │          │          │
```

`67,992,…` is 68 million rendered as something a reader will scan as sixty-eight thousand.

The narrow-table snapshot in this crate already recorded the behaviour as expected output, which is why it never showed up as a failure:

```
│ 2026     │ -          │ 123,456… │ 9,876,5… │ $12345.… │
```

## What changed

`expand_multiline_row` now knows the column alignments. A right-aligned cell that does not fit is first offered to a new `compact_numeric`, which renders it as `1.2K` / `3.4M` / `5.6B` — losing precision instead of meaning. Everything else is unchanged:

- cells that already fit are never touched;
- non-numeric cells, wrapped headers included, fall through to the existing truncation path;
- a value with no compact form short enough for the column also falls through, so the worst case is exactly today’s behaviour;
- precision degrades before giving up (`123.5M` → `123M` at four columns);
- rounding that crosses a unit boundary folds into the next unit, so `999,999` is `1.0M`, not `1000.0K`.

Snapshot after the change:

```
│ 2026     │ -          │   123.5M │     9.9M │   $12.3K │
│ 05-18    │ claude-so… │          │          │          │
```

## Scope

#946 attributes the truncation to a wide Models column and proposes shortening third-party model names and capping that column. This is the other trigger, the one the second report in that issue describes: it reproduces on a Claude-only report where the Models column holds `- opus-5` and there simply is not enough width for nine columns of ten-digit numbers. Capping the Models column is a separate change and is not in this PR.

## Testing

Run on the pinned 1.97.1 toolchain:

- `cargo fmt -p ccusage-terminal -- --check` clean
- `cargo clippy -p ccusage-terminal --all-targets -- -D warnings` clean
- `cargo test -p ccusage-terminal` — 25 passed, 0 failed, plus the doctest

Five new tests cover magnitude preservation, precision degradation, the unit-boundary rounding case, refusal on non-numeric and sub-1000 cells, and the rendered narrow table. The one snapshot change is the narrow-table case above.

I am not in `APPROVED_CONTRIBUTORS`, so the gate will close this on open. The branch and diff stay intact — reopening is enough if the approach looks right.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1531"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787859170&installation_model_id=423687&pr_number=1531&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1531&signature=6ded7b27036aecbfc8c0819ac7056bd94fd5291c9d3bde46a4dcdb3459b39cdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes numeric truncation in terminal tables by compacting overflowing right-aligned numbers to K/M/B formats. This preserves magnitude and avoids misleading values (e.g., 67,992,133 -> 68.0M), addressing the numeric half of #946.

- **Bug Fixes**
  - Overflowing right-aligned numeric cells render as 1.2K / 3.4M / 5.6B.
  - Cells that fit are unchanged; non-numeric cells still wrap/truncate.
  - Falls back to truncation if no compact form fits; reduces precision first (123.5M -> 123M).
  - Rounds across unit boundaries (999,999 -> 1.0M).
  - Updates one snapshot; adds focused tests for magnitude, precision, rounding, and non-numeric cases.

<sup>Written for commit b506dfee72dddba66d17310a74afe963739b49cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1531?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved narrow table layouts by compacting large numeric values into readable formats such as `K`, `M`, and `B`.
  * Preserved right-aligned numeric data more effectively, reducing unnecessary truncation and ellipses.
  * Added rounding and formatting improvements for values near unit boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->