### PR TITLE
feat(hermes): discover native profiles by default

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -168,7 +168,7 @@ If ccusage shows no data, check:
    - Amp: `${AMP_DATA_DIR:-~/.local/share/amp}`
    - Droid: `${DROID_SESSIONS_DIR:-~/.factory/sessions}`
    - Codebuff: `${CODEBUFF_DATA_DIR:-~/.config/manicode}`
-   - Hermes Agent: `${HERMES_HOME:-~/.hermes}/state.db`
+   - Hermes Agent: `$HERMES_HOME/state.db`, or `~/.hermes/state.db` and `~/.hermes/profiles/*/state.db` by default
    - pi-agent: `${PI_AGENT_DIR:-~/.pi/agent/sessions}`
    - Goose: standard Goose data roots or `GOOSE_PATH_ROOT`
    - Kilo: `${KILO_DATA_DIR:-~/.local/share/kilo}`

--- a/docs/guide/hermes/index.md
+++ b/docs/guide/hermes/index.md
@@ -2,7 +2,7 @@
 
 > Hermes Agent support is experimental. Expect changes while both ccusage and [Hermes Agent](https://github.com/NousResearch/hermes-agent) continue to evolve.
 
-ccusage can read Hermes Agent session usage from its local SQLite state database. The adapter uses the same focused and unified report shape as the other local coding CLI data sources.
+ccusage can read Hermes Agent session usage from its local SQLite state databases. The adapter uses the same focused and unified report shape as the other local coding CLI data sources.
 
 ## Focused Views
 

--- a/docs/guide/hermes/index.md
+++ b/docs/guide/hermes/index.md
@@ -24,7 +24,7 @@ pnpm dlx ccusage hermes --help
 
 ## Data Source
 
-The CLI reads Hermes Agent session rows from `$HERMES_HOME/state.db`. When `HERMES_HOME` is not set, ccusage checks `~/.hermes/state.db`.
+The CLI reads Hermes Agent session rows from its local SQLite state databases. When `HERMES_HOME` is not set, ccusage checks both the default profile at `~/.hermes/state.db` and every named profile at `~/.hermes/profiles/*/state.db`.
 
 ```bash
 HERMES_HOME="$HOME/.hermes" ccusage hermes daily
@@ -32,7 +32,10 @@ HERMES_HOME="$HOME/.hermes" ccusage hermes daily
 
 ```text
 ~/.hermes/
-└── state.db
+├── state.db
+└── profiles/
+    ├── personal/state.db
+    └── work/state.db
 ```
 
 ## Report Views
@@ -54,15 +57,15 @@ These views support `--json`, `--compact`, `--offline`, `--since`, `--until`, an
 
 ## Environment Variables
 
-| Variable      | Description                                                                       |
-| ------------- | --------------------------------------------------------------------------------- |
-| `HERMES_HOME` | Override the directory containing `state.db`; comma-separated roots are supported |
-| `LOG_LEVEL`   | Adjust verbosity (0 silent ... 5 trace)                                           |
+| Variable      | Description                                                                                                             |
+| ------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `HERMES_HOME` | Override the directories containing `state.db`; comma-separated roots are supported, and only the listed roots are read |
+| `LOG_LEVEL`   | Adjust verbosity (0 silent ... 5 trace)                                                                                 |
 
 ## Troubleshooting
 
 ::: details No Hermes Agent usage data found
-Ensure the database exists at `$HERMES_HOME/state.db` or `~/.hermes/state.db`. If your database lives elsewhere, set `HERMES_HOME` to the directory that contains `state.db`.
+Ensure a database exists at `$HERMES_HOME/state.db`, `~/.hermes/state.db`, or `~/.hermes/profiles/<name>/state.db`. If your database lives elsewhere, set `HERMES_HOME` to the directory that contains `state.db`.
 :::
 
 ::: details Costs showing as $0.00

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,23 +72,23 @@ Each data source page covers the details that only apply to that source, includi
 
 ccusage reads from local coding CLI data directories:
 
-| Agent        | ID         | Default data location                             |
-| ------------ | ---------- | ------------------------------------------------- |
-| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`        |
-| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                         |
-| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`   |
-| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`             |
-| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`      |
-| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`        |
-| Hermes Agent | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`              |
-| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`           |
-| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`    |
-| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                    |
-| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`           |
-| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`) |
-| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
-| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
-| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
+| Agent        | ID         | Default data location                               |
+| ------------ | ---------- | --------------------------------------------------- |
+| Claude Code  | `claude`   | `~/.config/claude/projects/`, `~/.claude/`          |
+| Codex        | `codex`    | `${CODEX_HOME:-~/.codex}`                           |
+| OpenCode     | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`     |
+| Amp          | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`               |
+| Droid        | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`        |
+| Codebuff     | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`          |
+| Hermes Agent | `hermes`   | `$HERMES_HOME/state.db` or default + named profiles |
+| pi-agent     | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`             |
+| Goose        | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`      |
+| OpenClaw     | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                      |
+| Kilo         | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`             |
+| Kimi         | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`)   |
+| Qwen         | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                         |
+| Copilot CLI  | `copilot`  | `~/.copilot/otel/*.jsonl`                           |
+| Gemini CLI   | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`                 |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Each source-specific environment variable can also contain comma-separated directories, which lets unified reports combine current profiles and archives.

--- a/rust/adapters/hermes/README.md
+++ b/rust/adapters/hermes/README.md
@@ -15,7 +15,8 @@ Anything that is not specific to this source belongs in `ccusage-core` or
 
 ## Data source
 
-- `${HERMES_HOME:-~/.hermes}/state.db`
+- `~/.hermes/state.db` and `~/.hermes/profiles/*/state.db` by default
+- `$HERMES_HOME/state.db` when `HERMES_HOME` is set; comma-separated roots are supported
 
 Reads SQLite with the bundled `sqlite` crate, which is why this crate declares it and
 most adapters do not.

--- a/rust/adapters/hermes/src/loader.rs
+++ b/rust/adapters/hermes/src/loader.rs
@@ -192,6 +192,17 @@ mod tests {
                 .sum::<u64>(),
             600
         );
+        for kind in [
+            crate::cli::AgentReportKind::Daily,
+            crate::cli::AgentReportKind::Weekly,
+            crate::cli::AgentReportKind::Monthly,
+            crate::cli::AgentReportKind::Session,
+        ] {
+            let rows = crate::summarize_entries(&entries, kind).unwrap();
+            let report = crate::report_from_rows(&rows, kind);
+            assert_eq!(report["totals"]["inputTokens"].as_u64(), Some(600));
+            assert_eq!(report["totals"]["outputTokens"].as_u64(), Some(30));
+        }
     }
 
     #[test]

--- a/rust/adapters/hermes/src/loader.rs
+++ b/rust/adapters/hermes/src/loader.rs
@@ -109,7 +109,7 @@ mod tests {
     use std::path::Path;
 
     use super::*;
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
 
     fn create_state_db(path: &Path) {
         let db = sqlite::open(path).unwrap();
@@ -133,6 +133,65 @@ mod tests {
             ",
         )
         .unwrap();
+    }
+
+    fn insert_session(path: &Path, session_id: &str, started_at: f64, input_tokens: i64) {
+        let db = sqlite::open(path).unwrap();
+        let mut statement = db
+            .prepare(
+                "
+                    INSERT INTO sessions (
+                        id, source, model, started_at, input_tokens, output_tokens
+                    ) VALUES (?1, 'cli', 'claude-sonnet-4-20250514', ?2, ?3, 10)
+                ",
+            )
+            .unwrap();
+        statement.bind((1, session_id)).unwrap();
+        statement.bind((2, started_at)).unwrap();
+        statement.bind((3, input_tokens)).unwrap();
+        statement.next().unwrap();
+    }
+
+    #[test]
+    fn loads_default_and_named_profile_databases() {
+        let fixture = fs_fixture!({});
+        let default_db = fixture.path(".hermes/state.db");
+        let profile_db = fixture.path(".hermes/profiles/work/state.db");
+        let _ = fixture.create_dir_all(".hermes/profiles/work");
+        create_state_db(&default_db);
+        create_state_db(&profile_db);
+        insert_session(&default_db, "default-only", 1_750_000_000.0, 100);
+        insert_session(&default_db, "shared", 1_750_000_001.0, 200);
+        insert_session(&profile_db, "profile-only", 1_750_000_002.0, 300);
+        insert_session(&profile_db, "shared", 1_750_000_003.0, 400);
+        let _env_guard = EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            ("HERMES_HOME", None),
+        ]);
+        let pricing = PricingMap::load_embedded();
+        let shared = SharedArgs {
+            single_thread: true,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries_inner(&shared, &pricing).unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.session_id.as_ref())
+                .collect::<Vec<_>>(),
+            vec!["default-only", "shared", "profile-only"]
+        );
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.data.message.usage.input_tokens)
+                .sum::<u64>(),
+            600
+        );
     }
 
     #[test]

--- a/rust/adapters/hermes/src/paths.rs
+++ b/rust/adapters/hermes/src/paths.rs
@@ -1,27 +1,124 @@
-use std::{collections::HashSet, env, path::PathBuf};
+use std::{collections::HashSet, env, fs, path::PathBuf};
 
 use crate::Result;
 
 const HERMES_HOME_ENV: &str = "HERMES_HOME";
 
 pub(super) fn hermes_state_db_paths() -> Result<Vec<PathBuf>> {
-    let homes = if let Ok(paths) = env::var(HERMES_HOME_ENV) {
-        paths
-            .split(',')
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-            .map(PathBuf::from)
-            .collect::<Vec<_>>()
+    let (homes, discover_profiles) = if let Ok(paths) = env::var(HERMES_HOME_ENV) {
+        (
+            paths
+                .split(',')
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(PathBuf::from)
+                .collect::<Vec<_>>(),
+            false,
+        )
     } else {
         let home =
             crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
-        vec![home.join(".hermes")]
+        (vec![home.join(".hermes")], true)
     };
+    let mut paths = Vec::new();
+    for home in homes {
+        paths.push(home.join("state.db"));
+        if discover_profiles {
+            let mut profile_paths = fs::read_dir(home.join("profiles"))
+                .map(|entries| {
+                    entries
+                        .filter_map(|entry| entry.ok())
+                        .map(|entry| entry.path().join("state.db"))
+                        .filter(|path| path.is_file())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            profile_paths.sort();
+            paths.extend(profile_paths);
+        }
+    }
     let mut seen = HashSet::new();
-    Ok(homes
+    Ok(paths
         .into_iter()
-        .map(|home| home.join("state.db"))
         .filter(|path| path.is_file())
         .filter(|path| seen.insert(path.clone()))
         .collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
+
+    #[test]
+    fn discovers_default_and_named_profile_databases() {
+        let fixture = fs_fixture!({
+            ".hermes/state.db": "",
+            ".hermes/profiles/work/state.db": "",
+            ".hermes/profiles/personal/state.db": "",
+            ".hermes/profiles/ignored/not-state.db": "",
+        });
+        let _env_guard = EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            (HERMES_HOME_ENV, None),
+        ]);
+
+        let paths = hermes_state_db_paths().unwrap();
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path(".hermes/state.db"),
+                fixture.path(".hermes/profiles/personal/state.db"),
+                fixture.path(".hermes/profiles/work/state.db"),
+            ]
+        );
+    }
+
+    #[test]
+    fn discovers_named_profiles_without_a_default_database() {
+        let fixture = fs_fixture!({
+            ".hermes/profiles/work/state.db": "",
+        });
+        let _env_guard = EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            (HERMES_HOME_ENV, None),
+        ]);
+
+        let paths = hermes_state_db_paths().unwrap();
+
+        assert_eq!(paths, vec![fixture.path(".hermes/profiles/work/state.db")]);
+    }
+
+    #[test]
+    fn explicit_homes_are_authoritative_and_deduplicated() {
+        let fixture = fs_fixture!({
+            "first/state.db": "",
+            "first/profiles/ignored/state.db": "",
+            "second/state.db": "",
+        });
+        let homes = [
+            fixture.path("first"),
+            fixture.path("second"),
+            fixture.path("first"),
+        ]
+        .map(|path| path.display().to_string())
+        .join(",");
+        let _env_guard = EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            (HERMES_HOME_ENV, Some(OsString::from(homes))),
+        ]);
+
+        let paths = hermes_state_db_paths().unwrap();
+
+        assert_eq!(
+            paths,
+            vec![
+                fixture.path("first/state.db"),
+                fixture.path("second/state.db")
+            ]
+        );
+    }
 }

--- a/rust/adapters/hermes/src/paths.rs
+++ b/rust/adapters/hermes/src/paths.rs
@@ -1,4 +1,9 @@
-use std::{collections::HashSet, env, fs, path::PathBuf};
+use std::{
+    collections::HashSet,
+    env, fs,
+    io::ErrorKind,
+    path::{Path, PathBuf},
+};
 
 use crate::Result;
 
@@ -24,17 +29,7 @@ pub(super) fn hermes_state_db_paths() -> Result<Vec<PathBuf>> {
     for home in homes {
         paths.push(home.join("state.db"));
         if discover_profiles {
-            let mut profile_paths = fs::read_dir(home.join("profiles"))
-                .map(|entries| {
-                    entries
-                        .filter_map(|entry| entry.ok())
-                        .map(|entry| entry.path().join("state.db"))
-                        .filter(|path| path.is_file())
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            profile_paths.sort();
-            paths.extend(profile_paths);
+            paths.extend(profile_state_db_paths(&home)?);
         }
     }
     let mut seen = HashSet::new();
@@ -43,6 +38,35 @@ pub(super) fn hermes_state_db_paths() -> Result<Vec<PathBuf>> {
         .filter(|path| path.is_file())
         .filter(|path| seen.insert(path.clone()))
         .collect())
+}
+
+fn profile_state_db_paths(home: &Path) -> Result<Vec<PathBuf>> {
+    let profiles_dir = home.join("profiles");
+    let entries = match fs::read_dir(&profiles_dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(error) => {
+            return Err(crate::cli_error(format!(
+                "failed to read Hermes profiles directory {}: {error}",
+                profiles_dir.display()
+            )));
+        }
+    };
+    let mut paths = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            crate::cli_error(format!(
+                "failed to read an entry in Hermes profiles directory {}: {error}",
+                profiles_dir.display()
+            ))
+        })?;
+        let state_db = entry.path().join("state.db");
+        if state_db.is_file() {
+            paths.push(state_db);
+        }
+    }
+    paths.sort();
+    Ok(paths)
 }
 
 #[cfg(test)]
@@ -60,6 +84,7 @@ mod tests {
             ".hermes/profiles/personal/state.db": "",
             ".hermes/profiles/ignored/not-state.db": "",
         });
+        let _ = fixture.create_dir_all(".hermes/profiles/directory-db/state.db");
         let _env_guard = EnvVarsGuard::set_many([
             ("HOME", Some(fixture.root().as_os_str().to_os_string())),
             (HERMES_HOME_ENV, None),
@@ -75,6 +100,19 @@ mod tests {
                 fixture.path(".hermes/profiles/work/state.db"),
             ]
         );
+    }
+
+    #[test]
+    fn reports_non_missing_profile_directory_errors() {
+        let fixture = fs_fixture!({
+            ".hermes/profiles": "not a directory",
+        });
+        let _env_guard = EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            (HERMES_HOME_ENV, None),
+        ]);
+
+        assert!(hermes_state_db_paths().is_err());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- discover `~/.hermes/profiles/*/state.db` alongside the default Hermes database when `HERMES_HOME` is unset
- keep explicit comma-separated `HERMES_HOME` roots authoritative and preserve deterministic database/session deduplication
- surface profile-directory I/O failures instead of silently omitting usage
- document native profile discovery across the Hermes and data-source guides

## Verification

- `cargo test --manifest-path rust/Cargo.toml -p ccusage-adapter-hermes` (11 passed)
- `cargo clippy --manifest-path rust/Cargo.toml -p ccusage-adapter-hermes --all-targets -- -D warnings`
- `just typecheck`
- `just test`
- pre-push hooks: clippy, oxlint, treefmt, gitleaks, cargo test
- local smoke test confirmed unset `HERMES_HOME` includes named-profile sessions while an explicit default root excludes them

Refs #1578

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788669515&installation_model_id=423687&pr_number=1579&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1579&signature=959598e05415abc61f3ff14e44698a08468f3b3af65c69db415d2f32841bf4cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include Hermes usage from native profiles by default. When `HERMES_HOME` is unset, we now read both the default and named profile databases to produce complete reports.

- New Features
  - Discover `~/.hermes/state.db` and `~/.hermes/profiles/*/state.db` when `HERMES_HOME` is not set.
  - Keep comma-separated `HERMES_HOME` roots authoritative with deterministic DB/session dedupe.
  - Update guides and the Hermes adapter README to document profile discovery and env behavior.

- Bug Fixes
  - Surface I/O errors when reading the profiles directory or entries; only a missing directory is ignored.

<sup>Written for commit 159ead3139df18905e7429db7f99f0b9d6198c50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hermes data discovery now supports multiple local profiles and their separate state databases.
  - Explicit `HERMES_HOME` paths and default profile locations are handled consistently, including comma-separated roots.
  - Data from multiple profiles is combined with duplicate sessions removed and totals included across reports.

- **Documentation**
  - Updated setup, troubleshooting, and data-source guidance to describe profile database locations and discovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->