### PR TITLE
fix(codex): map auto-review usage to GPT-5.6 Luna

### DIFF
--- a/docs/guide/codex/index.md
+++ b/docs/guide/codex/index.md
@@ -60,7 +60,7 @@ These views support `--json`, `--compact`, `--offline`, and `--speed auto|standa
 | `CODEX_HOME` | Override the root directory, or comma-separated directories, containing Codex homes or saved `codex exec --json` JSONL files |
 | `LOG_LEVEL`  | Adjust log verbosity (0 silent … 5 trace)                                                                                    |
 
-When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the Codex parser maps the label to the newest known Codex/OpenAI model available on the log date using a pinned models.dev snapshot before pricing uses the resolved model name. No manual override is needed.
+When Codex emits a model alias, the CLI automatically resolves it through the LiteLLM pricing data when possible. For `codex-auto-review`, the Codex parser maps the label to the newest known Codex/OpenAI model available on the log date using a pinned models.dev snapshot before pricing uses the resolved model name. Records on or after July 9, 2026 resolve to `gpt-5.6-luna`; older records retain their historical model mapping. No manual override is needed.
 
 ## Speed Pricing
 

--- a/nix/tools/models-dev-gen/gen.ts
+++ b/nix/tools/models-dev-gen/gen.ts
@@ -188,6 +188,7 @@ function isCodexAutoReviewFallbackCandidate(modelId: string, model: ModelMetadat
 	return (
 		modelName === 'gpt-5' ||
 		modelName === 'gpt-5-codex' ||
+		modelName === 'gpt-5.6-luna' ||
 		/^gpt-5\.\d+$/.test(modelName) ||
 		/^gpt-5\.\d+-codex$/.test(modelName)
 	);

--- a/rust/adapters/codex/src/codex-auto-review-fallbacks.json
+++ b/rust/adapters/codex/src/codex-auto-review-fallbacks.json
@@ -1,5 +1,9 @@
 [
 	{
+		"releasedOn": "2026-07-09",
+		"model": "gpt-5.6-luna"
+	},
+	{
 		"releasedOn": "2026-04-23",
 		"model": "gpt-5.5"
 	},

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -840,16 +840,40 @@ mod tests {
                     },
                 })
                 .to_string(),
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-07-08T23:59:59.999Z",
+                    "model": "codex-auto-review",
+                    "usage": {
+                        "input_tokens": 40,
+                        "output_tokens": 20,
+                        "total_tokens": 60,
+                    },
+                })
+                .to_string(),
+                json!({
+                    "type": "turn.completed",
+                    "timestamp": "2026-07-09T00:00:00.000Z",
+                    "model": "codex-auto-review",
+                    "usage": {
+                        "input_tokens": 50,
+                        "output_tokens": 25,
+                        "total_tokens": 75,
+                    },
+                })
+                .to_string(),
             ]
             .join("\n"),
         });
 
         let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
 
-        assert_eq!(events.len(), 3);
+        assert_eq!(events.len(), 5);
         assert_eq!(events[0].model.as_deref(), Some("gpt-5.3-codex"));
         assert_eq!(events[1].model.as_deref(), Some("gpt-5.4"));
         assert_eq!(events[2].model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(events[3].model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(events[4].model.as_deref(), Some("gpt-5.6-luna"));
         assert!(events.iter().all(|event| event.is_fallback_model));
     }
 
@@ -968,15 +992,31 @@ mod tests {
                     },
                 })
                 .to_string(),
+                json!({
+                    "timestamp": "2026-07-09T00:01:00.000Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "token_count",
+                        "info": {
+                            "last_token_usage": {
+                                "input_tokens": 30,
+                                "output_tokens": 15,
+                                "total_tokens": 45,
+                            },
+                        },
+                    },
+                })
+                .to_string(),
             ]
             .join("\n"),
         });
 
         let events = load_codex_events_from_directory(fixture.root(), true).unwrap();
 
-        assert_eq!(events.len(), 2);
+        assert_eq!(events.len(), 3);
         assert_eq!(events[0].model.as_deref(), Some("gpt-5.2-codex"));
         assert_eq!(events[1].model.as_deref(), Some("gpt-5.5"));
+        assert_eq!(events[2].model.as_deref(), Some("gpt-5.6-luna"));
         assert!(events.iter().all(|event| event.is_fallback_model));
     }
 

--- a/rust/adapters/codex/src/parser.rs
+++ b/rust/adapters/codex/src/parser.rs
@@ -1122,11 +1122,11 @@ mod tests {
     fn loads_codex_auto_review_fallbacks_from_models_dev_snapshot() {
         let fallbacks = codex_auto_review_fallback_models();
 
-        assert_eq!(fallbacks.len(), 7);
-        assert_eq!(fallbacks[0].released_on, "2026-04-23");
-        assert_eq!(fallbacks[0].model, "gpt-5.5");
-        assert_eq!(fallbacks[6].released_on, "2025-08-07");
-        assert_eq!(fallbacks[6].model, "gpt-5");
+        assert_eq!(fallbacks.len(), 8);
+        assert_eq!(fallbacks[0].released_on, "2026-07-09");
+        assert_eq!(fallbacks[0].model, "gpt-5.6-luna");
+        assert_eq!(fallbacks[7].released_on, "2025-08-07");
+        assert_eq!(fallbacks[7].model, "gpt-5");
         assert!(
             fallbacks
                 .windows(2)

--- a/rust/crates/ccusage-core/src/pricing.rs
+++ b/rust/crates/ccusage-core/src/pricing.rs
@@ -1056,7 +1056,7 @@ impl PricingMap {
         for (model, input, output, cache_create, cache_read) in [
             ("gpt-5.6-sol", 5e-6, 30e-6, 6.25e-6, 0.5e-6),
             ("gpt-5.6-terra", 2.5e-6, 15e-6, 3.125e-6, 0.25e-6),
-            ("gpt-5.6-luna", 1e-6, 6e-6, 1.25e-6, 0.1e-6),
+            ("gpt-5.6-luna", 0.2e-6, 1.2e-6, 0.25e-6, 0.02e-6),
         ] {
             self.entries.insert(
                 model.to_string(),
@@ -1348,7 +1348,7 @@ fn builtin_long_context_rates(base_model: &str) -> Option<LongContextRates> {
     match base_model {
         "gpt-5.6-sol" => Some(openai(10e-6, 45e-6, Some(12.5e-6), Some(1e-6))),
         "gpt-5.6-terra" => Some(openai(5e-6, 22.5e-6, Some(6.25e-6), Some(0.5e-6))),
-        "gpt-5.6-luna" => Some(openai(2e-6, 9e-6, Some(2.5e-6), Some(0.2e-6))),
+        "gpt-5.6-luna" => Some(openai(0.4e-6, 1.8e-6, Some(0.5e-6), Some(0.04e-6))),
         // gpt-5.5 and gpt-5.4 have no separate cache-write price, so cache
         // writes are billed as regular input in both tiers.
         "gpt-5.5" => Some(openai(10e-6, 45e-6, Some(10e-6), Some(1e-6))),
@@ -2105,10 +2105,14 @@ mod tests {
         assert_eq!(terra.output_above_200k, Some(22.5e-6));
 
         let luna = pricing.find("gpt-5.6-luna").unwrap();
-        assert_eq!(luna.input, 1e-6);
-        assert_eq!(luna.output, 6e-6);
-        assert_eq!(luna.input_above_200k, Some(2e-6));
-        assert_eq!(luna.output_above_200k, Some(9e-6));
+        assert_eq!(luna.input, 0.2e-6);
+        assert_eq!(luna.output, 1.2e-6);
+        assert_eq!(luna.cache_create, 0.25e-6);
+        assert_eq!(luna.cache_read, 0.02e-6);
+        assert_eq!(luna.input_above_200k, Some(0.4e-6));
+        assert_eq!(luna.output_above_200k, Some(1.8e-6));
+        assert_eq!(luna.cache_create_above_200k, Some(0.5e-6));
+        assert_eq!(luna.cache_read_above_200k, Some(0.04e-6));
     }
 
     #[test]


### PR DESCRIPTION
Maps `codex-auto-review` records on and after July 9, 2026 to `gpt-5.6-luna` while preserving the historical GPT-5.5 boundary. The models.dev generator now retains Luna in regenerated fallback snapshots, and the Codex guide documents the mapping.

Testing:
- `cargo test --manifest-path rust/Cargo.toml --workspace --features ccusage-core/fetch-litellm-pricing` (522 passed, 2 ignored)
- `cargo clippy --manifest-path rust/Cargo.toml --workspace --all-targets --features ccusage-core/fetch-litellm-pricing -- -D warnings`
- `cargo fmt --manifest-path rust/Cargo.toml --all -- --check`
- `pnpm --filter @ccusage/docs build`
- CLI JSON smoke for a July 10 `codex-auto-review` record

Related: #1589

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788909020&installation_model_id=423687&pr_number=1590&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1590&signature=fbcbf883eef5a9dc32821f90e7137156f913fd81e912d56cedc7809a5a8c5e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Maps `codex-auto-review` usage dated July 9, 2026 and later to `gpt-5.6-luna`, preserving historical mappings for earlier records. Corrects `gpt-5.6-luna` pricing so post-boundary records bill accurately.

**Review notes**
- Added a 2026-07-09 Luna boundary to the Codex fallback list and timestamp-based resolver; tests cover pre/post-boundary events (including streamed token counts). Docs now state the new mapping.
- Admitted `gpt-5.6-luna` as a fallback candidate in the models.dev generator so regenerated snapshots remain stable.
- Fixed built-in rates for `gpt-5.6-luna` (input 0.2e-6, output 1.2e-6; long-context input 0.4e-6, output 1.8e-6; cache create 0.25e-6, cache read 0.02e-6) and updated assertions.

<sup>Written for commit 5dc6f650e4bbe9e0fb2603c08d288a8a0bc0f4b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for resolving `codex-auto-review` to `gpt-5.6-luna` for records dated July 9, 2026 and later.

* **Documentation**
  * Clarified that older records retain their historical model mappings.

* **Bug Fixes**
  * Improved date-based fallback handling across the July 8–9, 2026 transition.
  * Updated `gpt-5.6-luna` pricing, including long-context rates, to reflect lower costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->