### PR TITLE
fix(statusline): load pricing overrides from config for cost calculation

### DIFF
--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -113,6 +113,7 @@ pub struct StatuslineArgs {
     pub config: Option<PathBuf>,
     pub debug: bool,
     pub model_label_aliases: HashMap<String, String>,
+    pub pricing_overrides: BTreeMap<String, PricingOverride>,
 }
 
 #[derive(Clone)]
@@ -177,6 +178,7 @@ impl Default for StatuslineArgs {
             config: None,
             debug: false,
             model_label_aliases: HashMap::new(),
+            pricing_overrides: BTreeMap::new(),
         }
     }
 }

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -457,6 +457,9 @@ fn apply_config_to_statusline_args(args: &mut StatuslineArgs, config: &ConfigCon
         if let Some(aliases) = options.model_label_aliases {
             args.model_label_aliases = aliases;
         }
+        if let Some(pricing_overrides) = options.pricing_overrides {
+            merge_pricing_overrides(&mut args.pricing_overrides, pricing_overrides);
+        }
     }
 }
 

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -454,6 +454,8 @@ pub struct StatuslineSpecificOptions {
     pub debug: Option<bool>,
     /// Map model identifiers to short display labels.
     pub model_label_aliases: Option<HashMap<String, String>>,
+    /// Runtime pricing overrides keyed by raw model name.
+    pub pricing_overrides: Option<BTreeMap<String, ConfigPricingOverride>>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -621,6 +623,7 @@ impl StatuslineSpecificOptions {
             timezone: string_option(map, "timezone"),
             debug: bool_option(map, "debug"),
             model_label_aliases: hashmap_option(map, "modelLabelAliases"),
+            pricing_overrides: pricing_override_map_option(map, "pricingOverrides"),
         }
     }
 }
@@ -1054,6 +1057,7 @@ mod tests {
                 "noCache",
                 "noOffline",
                 "offline",
+                "pricingOverrides",
                 "refreshInterval",
                 "timezone",
                 "visualBurnRate",

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/ccusage/src/config_schema.rs
-assertion_line: 1293
+source: crates/ccusage-config/src/config_schema.rs
 expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]),\n})"
 ---
 {
@@ -72,6 +71,58 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
         "description": "Use cached pricing data where supported.",
         "markdownDescription": "Use cached pricing data where supported.",
         "type": "boolean"
+      },
+      "pricingOverrides": {
+        "additionalProperties": {
+          "additionalProperties": false,
+          "properties": {
+            "cacheCreationInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheCreationInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "fastMultiplier": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "maxInputTokens": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "outputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "outputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "description": "Runtime pricing overrides keyed by raw model name.",
+        "markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+        "type": "object"
       },
       "refreshInterval": {
         "default": 1,

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -333,6 +333,7 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
         serde_json::from_str(stdin.trim()).context("Invalid input format")?;
     let shared = SharedArgs {
         offline: args.offline && !args.no_offline,
+        pricing_overrides: args.pricing_overrides.clone(),
         ..SharedArgs::default()
     };
     let cache_enabled = args.cache && !args.no_cache;


### PR DESCRIPTION
## Summary

Fixes #1591: the `statusline` command ignored `pricingOverrides` from `ccusage.json`, so third-party models (e.g. DeepSeek/GLM via an Anthropic-compatible relay) always showed `$0.00` costs in the status line, while `daily` reports were correct.

## Root cause

`run_statusline` rebuilt `SharedArgs` with `..SharedArgs::default()`, discarding the `pricing_overrides` the CLI layer had loaded from config. Every other command receives its `SharedArgs` from `Cli::parse_from_with_config` (which applies config via `apply_shared`); only `statusline` reconstructs it from defaults.

## Changes

- `StatuslineArgs` gains a `pricing_overrides: BTreeMap<String, PricingOverride>` field (mirrors `modelLabelAliases` handling)
- `StatuslineSpecificOptions` gains a `pricingOverrides` config field, parsed in `from_map`
- `apply_config_to_statusline_args` merges them into `StatuslineArgs`
- `run_statusline` copies them into the `SharedArgs` used by `load_entries`

## Verification

- Before: `💰 $0.00 session / $0.00 today / $0.00 block` with configured `pricingOverrides` for `deepseek-v4-flash`
- After: `💰 $0.18 session / $0.18 today / $0.12 block (3h 41m left) | 🔥 $0.09/hr`
- `--config <path>` explicit override works
- Official test payload (claude-sonnet-4, LiteLLM table) unchanged
- Full workspace test suite passes (48 suites); schema key-list test and insta snapshot updated for the new `pricingOverrides` key

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ccusage/codesmith/ccusage/pr/1592"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788942363&installation_model_id=423687&pr_number=1592&repository=ccusage%2Fccusage&return_to=https%3A%2F%2Fgithub.com%2Fccusage%2Fccusage%2Fpull%2F1592&signature=0106a27015d59ace5505c2f14e23ddf8f03aefaabcaabb9d25125d207453ab7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cost calculation in the `statusline` command by loading `pricingOverrides` from config so third-party models show correct costs. Previously `statusline` rebuilt `SharedArgs` and dropped overrides, resulting in $0.00. Fixes #1591.

- **Bug Fixes**
  - Add `pricing_overrides` to `StatuslineArgs` and parse `pricingOverrides` in `StatuslineSpecificOptions`, merging via `apply_config_to_statusline_args`.
  - Pass overrides into `SharedArgs` in `run_statusline` for `load_entries`.
  - Update config schema and snapshots; explicit `--config` override works.

<sup>Written for commit 3b7e465dadf8e9e59089d937d1e9787ef9856a21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring pricing overrides in the statusline.
  * Pricing overrides can now be specified per model and merged with existing settings.
  * Statusline processing now applies configured pricing overrides when displaying usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->