### PR TITLE
perf(codex): prune historical files for date ranges

### DIFF
--- a/rust/adapters/codex/src/aggregate.rs
+++ b/rust/adapters/codex/src/aggregate.rs
@@ -11,8 +11,9 @@ use jiff::tz::TimeZone as JiffTimeZone;
 use rustc_hash::FxHasher;
 
 use crate::{
-    CodexGroup, CodexServiceTier, CodexTokenUsageEvent, CodexUsageBucket, Result,
+    CodexGroup, CodexServiceTier, CodexTokenUsageEvent, CodexUsageBucket, MILLIS_PER_DAY, Result,
     cli::{AgentReportKind, SharedArgs, WeekDay},
+    date_range_bounds_ms,
     fast::FxHashMap,
     format_date_tz, merge_codex_service_tiers, parse_ts_timestamp, parse_tz, wants_json,
     week_start,
@@ -73,7 +74,10 @@ fn load_groups_from_sources(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let file_groups = paths::collect_deduped_codex_usage_files(sources);
+    let mut file_groups = paths::collect_deduped_codex_usage_files(sources);
+    for group in &mut file_groups {
+        retain_report_files(&mut group.files, shared);
+    }
     let replay_plan = CodexReplayPlan::new(
         file_groups
             .iter()
@@ -106,7 +110,8 @@ pub(super) fn load_groups_from_directory(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let files = paths::collect_codex_usage_files(sessions_dir);
+    let mut files = paths::collect_codex_usage_files(sessions_dir);
+    retain_report_files(&mut files, shared);
     let replay_plan =
         CodexReplayPlan::new([(sessions_dir, files.as_slice())], shared.single_thread);
     let run = CodexAggregateRun {
@@ -123,6 +128,31 @@ pub(super) fn load_groups_from_directory(
     let mut groups = aggregate_files_parallel(&run, &seen)?;
     apply_recorded_usage_from_shards(&mut groups, &seen, shared, kind);
     Ok(groups)
+}
+
+fn retain_report_files(files: &mut Vec<PathBuf>, shared: &SharedArgs) {
+    let timezone = parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+    let (Some(start), _) = date_range_bounds_ms(shared.since.as_deref(), None, timezone.as_ref())
+    else {
+        return;
+    };
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok());
+    if now.is_none_or(|now| start > now) {
+        return;
+    }
+    // ponytail: mtime is a one-day-widened proxy; inspect file tails if preserved mtimes matter.
+    let cutoff = start.saturating_sub(MILLIS_PER_DAY);
+    files.retain(|file| {
+        file.metadata()
+            .and_then(|metadata| metadata.modified())
+            .ok()
+            .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+            .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+            .is_none_or(|modified| modified >= cutoff)
+    });
 }
 
 fn aggregate_files_with_dedupe(
@@ -709,6 +739,41 @@ mod tests {
                 None,
             );
         }
+    }
+
+    #[test]
+    fn skips_codex_files_older_than_since_window() {
+        let fixture = fs_fixture!({
+            "old.jsonl": "",
+            "recent.jsonl": "",
+        });
+        let old = fixture.path("old.jsonl");
+        let recent = fixture.path("recent.jsonl");
+        for (file, timestamp) in [
+            (&old, "2026-05-20T00:00:00Z"),
+            (&recent, "2026-05-28T12:00:00Z"),
+        ] {
+            let modified = std::time::UNIX_EPOCH
+                + std::time::Duration::from_millis(
+                    parse_ts_timestamp(timestamp).unwrap().as_millis() as u64,
+                );
+            std::fs::File::options()
+                .write(true)
+                .open(file)
+                .unwrap()
+                .set_times(std::fs::FileTimes::new().set_modified(modified))
+                .unwrap();
+        }
+        let mut files = vec![old, recent.clone()];
+        let shared = SharedArgs {
+            since: Some("20260529".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        retain_report_files(&mut files, &shared);
+
+        assert_eq!(files, vec![recent]);
     }
 
     #[test]

--- a/rust/adapters/codex/src/lib.rs
+++ b/rust/adapters/codex/src/lib.rs
@@ -26,6 +26,14 @@ pub use types::{
 };
 pub(crate) use types::{CodexRawUsage, merge_codex_service_tiers};
 
+pub fn has_data() -> bool {
+    paths::codex_usage_sources().is_ok_and(|sources| {
+        sources
+            .iter()
+            .any(|source| !paths::collect_codex_usage_files(&source.dir).is_empty())
+    })
+}
+
 use report::{print_table_from_groups, report_from_groups};
 
 use crate::cli::{AgentReportKind, CodexSpeed};

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -627,23 +627,8 @@ fn load_codex_rows(
     shared: &SharedArgs,
     pricing: &PricingMap,
 ) -> Result<AgentRows> {
-    if shared.since.is_none() && shared.until.is_none() {
-        let groups = codex::load_groups(shared, kind)?;
-        let detected = !groups.is_empty();
-        let speed = codex::resolve_codex_speed(CodexSpeed::Auto);
-        return Ok(AgentRows {
-            rows: groups
-                .iter()
-                .map(|(period, group)| codex_group_row(period, group, pricing, speed))
-                .collect(),
-            detected,
-        });
-    }
-
-    let mut events = codex::load_codex_events(shared)?;
-    let detected = !events.is_empty();
-    codex::filter_events_by_date(&mut events, shared)?;
-    let groups = codex::aggregate_events(&events, kind, shared.timezone.as_deref())?;
+    let groups = codex::load_groups(shared, kind)?;
+    let detected = !groups.is_empty() || codex::has_data();
     let speed = codex::resolve_codex_speed(CodexSpeed::Auto);
     Ok(AgentRows {
         rows: groups

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -525,6 +525,31 @@ fn multi_section_codex_fixture_matches_standalone_sections_for_daily_and_session
     assert_daily_family_and_session_sections_match_standalone(&shared);
 }
 
+#[test]
+fn detects_codex_when_date_filter_excludes_all_rows() {
+    let fixture = fs_fixture!({
+        "codex/sessions/session.jsonl": codex_usage_line(
+            "2026-01-02T08:01:00.000Z",
+            "gpt-5.2",
+            1_000,
+        ),
+    });
+    let _env = isolated_agent_env(
+        &fixture,
+        "CODEX_HOME",
+        fixture.path("codex").into_os_string(),
+    );
+
+    let result = loader::load_rows(
+        AgentReportKind::Daily,
+        &fixture_shared("20990102", "20990102"),
+    )
+    .unwrap();
+
+    assert!(result.rows.is_empty());
+    assert_eq!(result.detected_agents, vec!["codex"]);
+}
+
 fn fixture_shared(since: &str, until: &str) -> SharedArgs {
     SharedArgs {
         since: Some(since.to_string()),


### PR DESCRIPTION
Summary:
- prefilter Codex session files by a conservative `--since` mtime boundary before replay planning and JSONL parsing
- keep exact event-level date filtering authoritative
- preserve Codex detection when the selected window contains no Codex rows

Testing:
- `cargo test -p ccusage-adapter-codex` (77 passed)
- `cargo test -p ccusage-adapter-all` (37 passed)
- `cargo fmt --all --check`
- release build: `cargo build --release -p ccusage`
- local `codex daily --last 1 --offline --no-cost --json`: 166-191 ms warm

Closes #1598


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefilters Codex session files by a conservative mtime cutoff when a since date is provided, reducing replay planning and JSONL parsing. Keeps event-level date filtering authoritative and ensures Codex is still detected when the selected window has no rows (addresses Linear #1598).

- Retains only files with mtime >= (since − 1 day), respecting timezone; skips prefilter if since is missing or after now.
- Unifies `ccusage-adapter-all` to always load grouped Codex data; detection is now `!groups.is_empty() || codex::has_data()`.
- Adds `codex::has_data()` to detect presence of any Codex files and tests covering file pruning and detection when the date filter excludes all rows.

<sup>Written for commit 8a4ce8e07d5a345e8dee147b59621a6d9514729a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Codex usage loading by excluding files outside the requested date range.
  - Codex remains detected even when no usage records match the selected dates.
  - Added safeguards for invalid, future, or unavailable date information.

- **Tests**
  - Added coverage for filtering outdated usage files.
  - Added regression coverage for Codex detection when filtered results are empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->