### PR TITLE
fix(grok): hide empty cache creation column

### DIFF
--- a/docs/guide/grok/index.md
+++ b/docs/guide/grok/index.md
@@ -51,6 +51,11 @@ Only rows with `sessionUpdate == "turn_completed"` and a usable usage breakdown 
 
 These views support `--json`, `--compact`, `--mode`, and `--offline`.
 
+Focused terminal tables omit the `Cache Create` column when the selected Grok
+rows report no cache-creation tokens. The column reappears when selected rows
+contain a non-zero value; JSON output keeps `cacheCreationTokens` in the stable
+report schema either way.
+
 ## What Gets Calculated
 
 - **Token usage** - Grok records OpenAI-style usage where `inputTokens` includes cache. ccusage splits it into uncached input, cache read (`cachedReadTokens`) and cache write (`cacheCreationTokens`), and stores the full `outputTokens` as output.

--- a/docs/guide/grok/index.md
+++ b/docs/guide/grok/index.md
@@ -53,8 +53,8 @@ These views support `--json`, `--compact`, `--mode`, and `--offline`.
 
 Focused terminal tables omit the `Cache Create` column when the selected Grok
 rows report no cache-creation tokens. The column reappears when selected rows
-contain a non-zero value; JSON output keeps `cacheCreationTokens` in the stable
-report schema either way.
+contain a non-zero value; [JSON output](/guide/json-output) keeps
+`cacheCreationTokens` in the stable report schema either way.
 
 ## What Gets Calculated
 

--- a/rust/adapters/grok/src/lib.rs
+++ b/rust/adapters/grok/src/lib.rs
@@ -9,8 +9,8 @@ mod paths;
 mod report;
 
 use crate::{
-    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
-    wants_json,
+    PricingMap, Result, UsageTableOptions, cli::AgentCommandArgs, print_json_or_jq,
+    print_usage_table_with_options, sort_summaries, wants_json,
 };
 
 pub use loader::{has_data, load_entries};
@@ -37,15 +37,23 @@ pub fn run(args: AgentCommandArgs) -> Result<()> {
             shared.no_cost,
         );
     }
-    print_usage_table(
+    let table_options = table_options(&rows);
+    print_usage_table_with_options(
         "Grok Token Usage Report",
         ccusage_core::first_column(args.kind),
         &rows,
         &shared,
         false,
         None,
+        table_options,
     )?;
     Ok(())
+}
+
+fn table_options(rows: &[UsageSummary]) -> UsageTableOptions {
+    UsageTableOptions {
+        show_cache_creation: rows.iter().any(|row| row.cache_creation_tokens > 0),
+    }
 }
 
 #[cfg(test)]
@@ -63,5 +71,44 @@ mod smoke_tests {
         let pricing = PricingMap::load_embedded();
         let entries = load_entries(&shared, &pricing).unwrap();
         let _ = entries.len();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hides_cache_creation_when_selected_rows_are_zero() {
+        assert!(!table_options(&[summary(0), summary(0)]).show_cache_creation);
+    }
+
+    #[test]
+    fn shows_cache_creation_when_any_selected_row_is_nonzero() {
+        assert!(table_options(&[summary(0), summary(25)]).show_cache_creation);
+    }
+
+    fn summary(cache_creation_tokens: u64) -> UsageSummary {
+        UsageSummary {
+            date: Some("2026-08-15".to_string()),
+            month: None,
+            week: None,
+            session_id: None,
+            project_path: None,
+            last_activity: None,
+            first_activity: None,
+            input_tokens: 100,
+            output_tokens: 20,
+            cache_creation_tokens,
+            cache_read_tokens: 40,
+            extra_total_tokens: 0,
+            total_cost: 0.01,
+            credits: None,
+            message_count: None,
+            models_used: vec!["grok-4.5-build".to_string()],
+            model_breakdowns: Vec::new(),
+            project: None,
+            versions: None,
+        }
     }
 }

--- a/rust/adapters/grok/src/report.rs
+++ b/rust/adapters/grok/src/report.rs
@@ -146,6 +146,7 @@ mod tests {
 
         assert_eq!(report["daily"][0]["inputTokens"], 60);
         assert_eq!(report["daily"][0]["outputTokens"], 20);
+        assert_eq!(report["daily"][0]["cacheCreationTokens"], 0);
         assert_eq!(report["daily"][0]["cacheReadTokens"], 40);
         // totalTokens is uncached input + output + cache read; reasoning is
         // already inside output and is never added again.

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -31,10 +31,10 @@ pub use date_utils::*;
 pub use last_window::{PeriodUnit, last_periods_since};
 pub use logger::{debug_log, log_level};
 pub use output::{
-    format_currency, format_models_multiline, format_number, group_project_output, json_float,
-    print_json_or_jq, print_missing_pricing_warnings, print_missing_pricing_warnings_for_models,
-    print_usage_table, session_summary_json, should_use_compact_layout, summary_json, totals_json,
-    wants_json,
+    UsageTableOptions, format_currency, format_models_multiline, format_number,
+    group_project_output, json_float, print_json_or_jq, print_missing_pricing_warnings,
+    print_missing_pricing_warnings_for_models, print_usage_table, print_usage_table_with_options,
+    session_summary_json, should_use_compact_layout, summary_json, totals_json, wants_json,
 };
 pub use pricing::{Pricing, PricingMap};
 pub(crate) use project_names::parse_project_aliases;

--- a/rust/crates/ccusage-core/src/output.rs
+++ b/rust/crates/ccusage-core/src/output.rs
@@ -589,7 +589,8 @@ mod tests {
 
     #[test]
     fn focused_table_includes_cache_creation_by_default() {
-        let (headers, aligns) = usage_table_columns("Date", false, true);
+        let options = UsageTableOptions::default();
+        let (headers, aligns) = usage_table_columns("Date", false, options.show_cache_creation);
 
         assert!(headers.contains(&"Cache Create"));
         assert_eq!(headers.len(), aligns.len());

--- a/rust/crates/ccusage-core/src/output.rs
+++ b/rust/crates/ccusage-core/src/output.rs
@@ -142,6 +142,21 @@ pub fn print_json_or_jq(mut value: Value, jq: Option<&str>, no_cost: bool) -> Re
     Ok(())
 }
 
+/// Controls optional metrics in a focused usage table.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct UsageTableOptions {
+    /// Whether a full-width table includes the cache-creation column.
+    pub show_cache_creation: bool,
+}
+
+impl Default for UsageTableOptions {
+    fn default() -> Self {
+        Self {
+            show_cache_creation: true,
+        }
+    }
+}
+
 pub fn print_usage_table(
     title: &str,
     first_column: &str,
@@ -149,6 +164,27 @@ pub fn print_usage_table(
     shared: &SharedArgs,
     group_projects: bool,
     project_aliases: Option<&str>,
+) -> Result<()> {
+    print_usage_table_with_options(
+        title,
+        first_column,
+        rows,
+        shared,
+        group_projects,
+        project_aliases,
+        UsageTableOptions::default(),
+    )
+}
+
+/// Print a focused usage table with source-specific display options.
+pub fn print_usage_table_with_options(
+    title: &str,
+    first_column: &str,
+    rows: &[UsageSummary],
+    shared: &SharedArgs,
+    group_projects: bool,
+    project_aliases: Option<&str>,
+    options: UsageTableOptions,
 ) -> Result<()> {
     if rows.is_empty() {
         eprintln!("{}", empty_usage_table_message());
@@ -164,40 +200,8 @@ pub fn print_usage_table(
     );
     let include_last_activity = rows.iter().any(|row| row.last_activity.is_some());
     print_box_title(title, shared);
-    let mut headers = if compact {
-        vec![first_column, "Models", "Input", "Output", "Cost (USD)"]
-    } else {
-        vec![
-            first_column,
-            "Models",
-            "Input",
-            "Output",
-            "Cache Create",
-            "Cache Read",
-            "Total Tokens",
-            "Cost (USD)",
-        ]
-    };
-    let mut aligns = if compact {
-        vec![
-            Align::Left,
-            Align::Left,
-            Align::Right,
-            Align::Right,
-            Align::Right,
-        ]
-    } else {
-        vec![
-            Align::Left,
-            Align::Left,
-            Align::Right,
-            Align::Right,
-            Align::Right,
-            Align::Right,
-            Align::Right,
-            Align::Right,
-        ]
-    };
+    let (mut headers, mut aligns) =
+        usage_table_columns(first_column, compact, options.show_cache_creation);
     if shared.no_cost {
         headers.pop();
         aligns.pop();
@@ -235,26 +239,24 @@ pub fn print_usage_table(
             .unwrap_or("");
         let models = format_models_multiline(&row.models_used);
         let total_tokens = row.total_tokens();
-        let mut values = if compact {
-            vec![
-                label.to_string(),
-                models,
-                format_number(row.input_tokens),
-                format_number(row.output_tokens),
-                format_currency(row.total_cost),
-            ]
+        let mut values = vec![
+            label.to_string(),
+            models,
+            format_number(row.input_tokens),
+            format_number(row.output_tokens),
+        ];
+        if !compact && options.show_cache_creation {
+            values.push(format_number(row.cache_creation_tokens));
+        }
+        if compact {
+            values.push(format_currency(row.total_cost));
         } else {
-            vec![
-                label.to_string(),
-                models,
-                format_number(row.input_tokens),
-                format_number(row.output_tokens),
-                format_number(row.cache_creation_tokens),
+            values.extend([
                 format_number(row.cache_read_tokens),
                 format_number(total_tokens),
                 format_currency(row.total_cost),
-            ]
-        };
+            ]);
+        }
         if shared.no_cost {
             values.pop();
         }
@@ -265,7 +267,14 @@ pub fn print_usage_table(
         }
         table.push(values);
         if shared.breakdown {
-            push_breakdown_rows(&mut table, row, compact, include_last_activity, shared);
+            push_breakdown_rows(
+                &mut table,
+                row,
+                compact,
+                options.show_cache_creation,
+                include_last_activity,
+                shared,
+            );
         }
     }
 
@@ -295,26 +304,22 @@ pub fn print_usage_table(
         .and_then(Value::as_u64)
         .unwrap_or(input + output + cache_create + cache_read);
     table.separator();
-    let mut total_row = if compact {
-        vec![
-            color(shared, "Total", Color::Yellow),
-            String::new(),
-            color(shared, format_number(input), Color::Yellow),
-            color(shared, format_number(output), Color::Yellow),
-            color(shared, format_currency(total_cost), Color::Yellow),
-        ]
+    let mut total_row = vec![
+        color(shared, "Total", Color::Yellow),
+        String::new(),
+        color(shared, format_number(input), Color::Yellow),
+        color(shared, format_number(output), Color::Yellow),
+    ];
+    if !compact && options.show_cache_creation {
+        total_row.push(color(shared, format_number(cache_create), Color::Yellow));
+    }
+    if compact {
+        total_row.push(color(shared, format_currency(total_cost), Color::Yellow));
     } else {
-        vec![
-            color(shared, "Total", Color::Yellow),
-            String::new(),
-            color(shared, format_number(input), Color::Yellow),
-            color(shared, format_number(output), Color::Yellow),
-            color(shared, format_number(cache_create), Color::Yellow),
-            color(shared, format_number(cache_read), Color::Yellow),
-            color(shared, format_number(total_tokens), Color::Yellow),
-            color(shared, format_currency(total_cost), Color::Yellow),
-        ]
-    };
+        total_row.push(color(shared, format_number(cache_read), Color::Yellow));
+        total_row.push(color(shared, format_number(total_tokens), Color::Yellow));
+        total_row.push(color(shared, format_currency(total_cost), Color::Yellow));
+    }
     if shared.no_cost {
         total_row.pop();
     }
@@ -329,6 +334,27 @@ pub fn print_usage_table(
         eprintln!("Expand terminal width to see cache metrics and total tokens");
     }
     Ok(())
+}
+
+fn usage_table_columns(
+    first_column: &str,
+    compact: bool,
+    show_cache_creation: bool,
+) -> (Vec<&str>, Vec<Align>) {
+    let mut headers = vec![first_column, "Models", "Input", "Output"];
+    let mut aligns = vec![Align::Left, Align::Left, Align::Right, Align::Right];
+    if !compact && show_cache_creation {
+        headers.push("Cache Create");
+        aligns.push(Align::Right);
+    }
+    if compact {
+        headers.push("Cost (USD)");
+        aligns.push(Align::Right);
+    } else {
+        headers.extend(["Cache Read", "Total Tokens", "Cost (USD)"]);
+        aligns.extend([Align::Right, Align::Right, Align::Right]);
+    }
+    (headers, aligns)
 }
 
 fn empty_usage_table_message() -> &'static str {
@@ -406,6 +432,7 @@ fn push_breakdown_rows(
     table: &mut SimpleTable,
     row: &UsageSummary,
     compact: bool,
+    show_cache_creation: bool,
     include_last_activity: bool,
     shared: &SharedArgs,
 ) {
@@ -414,33 +441,27 @@ fn push_breakdown_rows(
             + breakdown.output_tokens
             + breakdown.cache_creation_tokens
             + breakdown.cache_read_tokens;
-        let mut values = if compact {
-            vec![
-                color(
-                    shared,
-                    format!("  └─ {}", short_model_name(&breakdown.model_name)),
-                    Color::Grey,
-                ),
-                String::new(),
-                color(shared, format_number(breakdown.input_tokens), Color::Grey),
-                color(shared, format_number(breakdown.output_tokens), Color::Grey),
-                color(shared, format_currency(breakdown.cost), Color::Grey),
-            ]
+        let mut values = vec![
+            color(
+                shared,
+                format!("  └─ {}", short_model_name(&breakdown.model_name)),
+                Color::Grey,
+            ),
+            String::new(),
+            color(shared, format_number(breakdown.input_tokens), Color::Grey),
+            color(shared, format_number(breakdown.output_tokens), Color::Grey),
+        ];
+        if !compact && show_cache_creation {
+            values.push(color(
+                shared,
+                format_number(breakdown.cache_creation_tokens),
+                Color::Grey,
+            ));
+        }
+        if compact {
+            values.push(color(shared, format_currency(breakdown.cost), Color::Grey));
         } else {
-            vec![
-                color(
-                    shared,
-                    format!("  └─ {}", short_model_name(&breakdown.model_name)),
-                    Color::Grey,
-                ),
-                String::new(),
-                color(shared, format_number(breakdown.input_tokens), Color::Grey),
-                color(shared, format_number(breakdown.output_tokens), Color::Grey),
-                color(
-                    shared,
-                    format_number(breakdown.cache_creation_tokens),
-                    Color::Grey,
-                ),
+            values.extend([
                 color(
                     shared,
                     format_number(breakdown.cache_read_tokens),
@@ -448,8 +469,8 @@ fn push_breakdown_rows(
                 ),
                 color(shared, format_number(total), Color::Grey),
                 color(shared, format_currency(breakdown.cost), Color::Grey),
-            ]
-        };
+            ]);
+        }
         if shared.no_cost {
             values.pop();
         }
@@ -545,6 +566,33 @@ mod tests {
     #[test]
     fn empty_usage_table_message_is_provider_agnostic() {
         assert_eq!(empty_usage_table_message(), "No usage data found.");
+    }
+
+    #[test]
+    fn focused_table_can_omit_cache_creation_without_dropping_cache_reads() {
+        let (headers, aligns) = usage_table_columns("Date", false, false);
+
+        assert_eq!(
+            headers,
+            vec![
+                "Date",
+                "Models",
+                "Input",
+                "Output",
+                "Cache Read",
+                "Total Tokens",
+                "Cost (USD)",
+            ]
+        );
+        assert_eq!(headers.len(), aligns.len());
+    }
+
+    #[test]
+    fn focused_table_includes_cache_creation_by_default() {
+        let (headers, aligns) = usage_table_columns("Date", false, true);
+
+        assert!(headers.contains(&"Cache Create"));
+        assert_eq!(headers.len(), aligns.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Hide the `Cache Create` column in focused Grok terminal reports when every selected row reports zero.
- Keep the column available when a selected Grok row contains a non-zero value.
- Preserve cache reads, total tokens, JSON/JQ fields, and unified/all report columns.
- Document the focused Grok display behavior and add regression coverage.

## Testing

- `just typecheck`
- `just test`
- `just hawk`
- `just --justfile docs/justfile build`
- Real `ccusage grok daily --offline` and `--breakdown` output with local Grok logs
- Push hooks: clippy, treefmt, gitleaks, cargo test

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hides the Cache Create column in focused Grok terminal reports when all selected rows have zero cache-creation tokens. The column reappears when any selected row is non-zero; cache-read, total tokens, and JSON output remain unchanged.

- **Review notes**
  - Shared renderer adds `UsageTableOptions` and `print_usage_table_with_options`; `print_usage_table` forwards defaults that still show Cache Create. The Grok adapter sets `show_cache_creation` only when any selected row is non-zero.
  - Tests guard the public default and the Grok-specific behavior; docs clarify the display rule and link to JSON output. JSON always includes `cacheCreationTokens`; compact mode is unchanged.
  - No migration required. If scripts parse terminal columns, use `--json` for a stable schema.

<sup>Written for commit e7dcf79dc74a8b414c810455314b67d9827418e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1605?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Usage tables can now hide the **Cache Create** column when all displayed rows have zero cache-creation usage.
  * The column remains visible whenever cache-creation usage is present.
  * Cache-read and total-token metrics remain available regardless of the setting.
  * JSON output consistently includes `cacheCreationTokens`, including zero values.

* **Bug Fixes**
  * Improved consistency of cache-creation metrics across Grok daily reports, summaries, totals, and model breakdowns.

* **Documentation**
  * Updated the Grok usage guide to explain conditional Cache Create column visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->