### PR TITLE
fix(cli): reapply date-bound validation

### DIFF
--- a/docs/guide/cli-options.md
+++ b/docs/guide/cli-options.md
@@ -21,6 +21,8 @@ ccusage monthly --since 20260101
 ccusage session --until 20260531
 ```
 
+Both bounds accept `YYYY-MM-DD` or `YYYYMMDD` and are inclusive. Any other spelling, or a value that is not a real calendar date such as `2026-02-30`, is rejected with a non-zero exit code instead of silently changing which rows the report keeps. The same check applies to `since` and `until` in a [configuration file](/guide/config-files).
+
 ### Recent Periods
 
 Instead of working out dates, ask for the most recent periods of whatever the report groups by:

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -4,8 +4,9 @@ use crate::arg_parser::ArgParser;
 use crate::help::{print_help_and_exit, print_version_and_exit};
 use ccusage_cli::{
     AgentCommandArgs, AgentReportKind, BlocksArgs, CliConfig, CodexSpeed, Command, CostMode,
-    CostSource, DailyArgs, OPENCODE_AGENT_REPORTS, STANDARD_AGENT_REPORTS, SessionArgs, SharedArgs,
-    SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
+    CostSource, DATE_BOUND_FORMATS, DailyArgs, OPENCODE_AGENT_REPORTS, STANDARD_AGENT_REPORTS,
+    SessionArgs, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
+    normalize_date_bound,
 };
 
 use crate::Cli;
@@ -713,10 +714,10 @@ fn parse_shared_arg_for_command(
 fn parse_shared_arg(parser: &mut ArgParser, shared: &mut SharedArgs) -> Result<(), String> {
     match parser.next_flag()?.as_str() {
         "-s" | "--since" => {
-            shared.since = Some(normalize_date_bound(&parser.value_for("--since")?))
+            shared.since = Some(parse_date_bound("--since", &parser.value_for("--since")?)?)
         }
         "-u" | "--until" => {
-            shared.until = Some(normalize_date_bound(&parser.value_for("--until")?))
+            shared.until = Some(parse_date_bound("--until", &parser.value_for("--until")?)?)
         }
         "--last" => shared.last = Some(parse_last_periods(&parser.value_for("--last")?)?),
         "-j" | "--json" => shared.json = true,
@@ -1003,6 +1004,12 @@ fn is_shared_flag(arg: &str) -> bool {
             | "--single-thread"
             | "--no-cost"
     )
+}
+
+fn parse_date_bound(flag: &str, value: &str) -> Result<String, String> {
+    normalize_date_bound(value).ok_or_else(|| {
+        format!("Invalid value for {flag} '{value}'. Expected {DATE_BOUND_FORMATS}.")
+    })
 }
 
 fn parse_last_periods(value: &str) -> Result<u32, String> {

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -243,6 +243,38 @@ fn commandless_invocation_preserves_default_dispatch() {
 }
 
 #[test]
+fn rejects_date_bounds_that_are_not_real_calendar_dates() {
+    for value in [
+        "2026-02-30",
+        "2026-13-01",
+        "abc",
+        "2026/07/10",
+        "2026-07-10T00:00:00Z",
+    ] {
+        assert_eq!(
+            parse_error(&["ccusage", "daily", "--since", value]),
+            format!("Invalid value for --since '{value}'. Expected YYYY-MM-DD or YYYYMMDD.")
+        );
+        assert_eq!(
+            parse_error(&["ccusage", "daily", "--until", value]),
+            format!("Invalid value for --until '{value}'. Expected YYYY-MM-DD or YYYYMMDD.")
+        );
+    }
+}
+
+#[test]
+fn accepts_both_documented_date_bound_formats() {
+    for (value, normalized) in [("2026-07-10", "20260710"), ("20260710", "20260710")] {
+        let cli = parse(&["ccusage", "daily", "--since", value, "--until", value]);
+        let Some(Command::All(args)) = cli.command else {
+            panic!("expected all-agent command");
+        };
+        assert_eq!(args.shared.since.as_deref(), Some(normalized));
+        assert_eq!(args.shared.until.as_deref(), Some(normalized));
+    }
+}
+
+#[test]
 fn parses_last_periods_on_period_reports() {
     let cli = parse(&["ccusage", "daily", "--last", "1"]);
     let Some(Command::All(args)) = cli.command else {

--- a/rust/crates/ccusage-cli/README.md
+++ b/rust/crates/ccusage-cli/README.md
@@ -18,6 +18,7 @@ renderer, and the help JSON live in `ccusage-cli-parser` instead.
 - `types::Command`
 - `types::CostMode`
 - `types::CostSource`
+- `types::DATE_BOUND_FORMATS`
 - `types::DailyArgs`
 - `types::NamedPiStore`
 - `types::NoConfig`

--- a/rust/crates/ccusage-cli/src/lib.rs
+++ b/rust/crates/ccusage-cli/src/lib.rs
@@ -2,7 +2,7 @@ mod types;
 
 pub use types::{
     AgentCommandArgs, AgentReportKind, BlocksArgs, CliConfig, CodexSpeed, Command, CostMode,
-    CostSource, DailyArgs, NamedPiStore, NoConfig, OPENCODE_AGENT_REPORTS, PricingOverride,
-    STANDARD_AGENT_REPORTS, SessionArgs, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate,
-    WeekDay, WeeklyArgs, normalize_date_bound,
+    CostSource, DATE_BOUND_FORMATS, DailyArgs, NamedPiStore, NoConfig, OPENCODE_AGENT_REPORTS,
+    PricingOverride, STANDARD_AGENT_REPORTS, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
+    VisualBurnRate, WeekDay, WeeklyArgs, normalize_date_bound,
 };

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -66,8 +66,57 @@ impl SharedArgs {
     }
 }
 
-pub fn normalize_date_bound(value: &str) -> String {
-    value.replace('-', "")
+/// The two documented spellings of a `--since` / `--until` bound.
+pub const DATE_BOUND_FORMATS: &str = "YYYY-MM-DD or YYYYMMDD";
+
+/// Normalizes a date bound into the `YYYYMMDD` form the report keys use.
+///
+/// Reports compare bounds against row keys as plain strings, so a value that is
+/// not one of the two documented formats, or that is not a real calendar date,
+/// would silently turn the filter into a no-op or drop every row. Returns
+/// `None` for those values so callers can reject them.
+pub fn normalize_date_bound(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let digits: [u8; 8] = match bytes.len() {
+        8 => bytes.try_into().ok()?,
+        10 if bytes[4] == b'-' && bytes[7] == b'-' => {
+            let mut digits = [0u8; 8];
+            digits[..4].copy_from_slice(&bytes[..4]);
+            digits[4..6].copy_from_slice(&bytes[5..7]);
+            digits[6..].copy_from_slice(&bytes[8..]);
+            digits
+        }
+        _ => return None,
+    };
+    if !digits.iter().all(u8::is_ascii_digit) {
+        return None;
+    }
+    let number = |slice: &[u8]| {
+        slice
+            .iter()
+            .fold(0u32, |value, digit| value * 10 + u32::from(digit - b'0'))
+    };
+    let year = number(&digits[..4]) as i32;
+    let month = number(&digits[4..6]);
+    let day = number(&digits[6..]);
+    if day == 0 || day > days_in_month(year, month) {
+        return None;
+    }
+    std::str::from_utf8(&digits).ok().map(str::to_string)
+}
+
+fn days_in_month(year: i32, month: u32) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 if is_leap_year(year) => 29,
+        2 => 28,
+        _ => 0,
+    }
+}
+
+fn is_leap_year(year: i32) -> bool {
+    year % 4 == 0 && (year % 100 != 0 || year % 400 == 0)
 }
 
 #[derive(Clone)]
@@ -265,3 +314,60 @@ pub trait CliConfig {
 pub struct NoConfig;
 
 impl CliConfig for NoConfig {}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_date_bound;
+
+    #[test]
+    fn accepts_both_documented_formats() {
+        assert_eq!(
+            normalize_date_bound("2026-07-10").as_deref(),
+            Some("20260710")
+        );
+        assert_eq!(
+            normalize_date_bound("20260710").as_deref(),
+            Some("20260710")
+        );
+    }
+
+    #[test]
+    fn accepts_leap_day_only_in_leap_years() {
+        assert_eq!(
+            normalize_date_bound("2024-02-29").as_deref(),
+            Some("20240229")
+        );
+        assert_eq!(
+            normalize_date_bound("2000-02-29").as_deref(),
+            Some("20000229")
+        );
+        assert_eq!(normalize_date_bound("2026-02-29"), None);
+        assert_eq!(normalize_date_bound("1900-02-29"), None);
+    }
+
+    #[test]
+    fn rejects_impossible_calendar_dates() {
+        assert_eq!(normalize_date_bound("2026-02-30"), None);
+        assert_eq!(normalize_date_bound("2026-13-01"), None);
+        assert_eq!(normalize_date_bound("2026-00-10"), None);
+        assert_eq!(normalize_date_bound("2026-07-00"), None);
+        assert_eq!(normalize_date_bound("2026-04-31"), None);
+    }
+
+    #[test]
+    fn rejects_undocumented_spellings() {
+        assert_eq!(normalize_date_bound("abc"), None);
+        assert_eq!(normalize_date_bound(""), None);
+        assert_eq!(normalize_date_bound("2026/07/10"), None);
+        assert_eq!(normalize_date_bound("2026-7-10"), None);
+        assert_eq!(normalize_date_bound("2026-07-10T00:00:00Z"), None);
+        assert_eq!(normalize_date_bound("2026-07-1"), None);
+        assert_eq!(normalize_date_bound("2026_07_10"), None);
+    }
+
+    #[test]
+    fn rejects_non_ascii_values_without_panicking() {
+        assert_eq!(normalize_date_bound("２０２６０７１０"), None);
+        assert_eq!(normalize_date_bound("2026-07-1０"), None);
+    }
+}

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -7,8 +7,8 @@ use std::{
 use serde_json::{Map, Value};
 
 use ccusage_cli::{
-    BlocksArgs, CodexSpeed, CostMode, CostSource, DailyArgs, NamedPiStore, PricingOverride,
-    SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
+    BlocksArgs, CodexSpeed, CostMode, CostSource, DATE_BOUND_FORMATS, DailyArgs, NamedPiStore,
+    PricingOverride, SharedArgs, SortOrder, StatuslineArgs, VisualBurnRate, WeekDay, WeeklyArgs,
     normalize_date_bound,
 };
 
@@ -29,25 +29,64 @@ pub struct ConfigContext {
     value: Option<Value>,
     command: ConfigCommand,
     pi_stores: Vec<NamedPiStore>,
-    error: Option<String>,
+    pi_store_error: Option<String>,
+    date_bound_error: Option<String>,
 }
 
 impl ConfigContext {
     pub fn from_args(args: &[String]) -> Self {
         let command = detect_config_command(args);
         let value = load_config_value(scan_config_path(args).as_deref());
-        let (pi_stores, error) = value
+        let (pi_stores, pi_store_error) = value
             .as_ref()
             .map(parse_named_pi_stores)
             .transpose()
             .map(|stores| (stores.unwrap_or_default(), None))
             .unwrap_or_else(|error| (Vec::new(), Some(error)));
-        Self {
+        let mut context = Self {
             value,
             command,
             pi_stores,
-            error,
-        }
+            pi_store_error,
+            date_bound_error: None,
+        };
+        context.date_bound_error = context.detect_date_bound_error();
+        context
+    }
+
+    /// Named pi stores only reach commands that read them, so their parse error
+    /// stays gated on those commands.
+    fn active_pi_store_error(&self) -> Option<&str> {
+        self.command_uses_named_pi_stores()
+            .then_some(self.pi_store_error.as_deref())
+            .flatten()
+    }
+
+    /// Config bounds bypass the CLI parser, so they need the same rejection the
+    /// parser gives `--since` / `--until`. `apply_shared_options` cannot fail,
+    /// so the check runs here and surfaces through `config_error` for every
+    /// command that applies shared options, not just the pi-store readers.
+    fn detect_date_bound_error(&self) -> Option<String> {
+        self.option_maps().into_iter().find_map(|options| {
+            [
+                ("since", options.get("since")),
+                ("until", options.get("until")),
+            ]
+            .into_iter()
+            .find_map(|(key, value)| {
+                let value = value?;
+                let Some(value) = value.as_str() else {
+                    return Some(config_error(format!(
+                        "{key} must be a string. Expected {DATE_BOUND_FORMATS}"
+                    )));
+                };
+                normalize_date_bound(value).is_none().then(|| {
+                    config_error(format!(
+                        "{key} '{value}' is not a valid date. Expected {DATE_BOUND_FORMATS}"
+                    ))
+                })
+            })
+        })
     }
 
     fn option_maps(&self) -> Vec<&Map<String, Value>> {
@@ -321,6 +360,7 @@ fn option_takes_value(arg: &str) -> bool {
         "-s" | "--since"
             | "-u"
             | "--until"
+            | "--last"
             | "-m"
             | "--mode"
             | "--debug-samples"
@@ -348,6 +388,7 @@ fn option_takes_value(arg: &str) -> bool {
             | "--refresh-interval"
             | "--context-low-threshold"
             | "--context-medium-threshold"
+            | "--sections"
     )
 }
 
@@ -366,7 +407,7 @@ fn apply_config_to_shared(shared: &mut SharedArgs, config: &ConfigContext) {
     for options in config.option_maps() {
         apply_shared_options(shared, SharedOptions::from_map(options));
     }
-    if config.error.is_none() {
+    if config.pi_store_error.is_none() {
         shared.pi_stores = config.pi_stores.clone();
     }
 }
@@ -486,9 +527,8 @@ fn apply_config_to_agent_args(
 
 impl ccusage_cli::CliConfig for ConfigContext {
     fn config_error(&self) -> Option<&str> {
-        self.command_uses_named_pi_stores()
-            .then_some(self.error.as_deref())
-            .flatten()
+        self.active_pi_store_error()
+            .or(self.date_bound_error.as_deref())
     }
 
     fn apply_shared(&self, shared: &mut SharedArgs) {
@@ -522,11 +562,13 @@ impl ccusage_cli::CliConfig for ConfigContext {
 }
 
 fn apply_shared_options(shared: &mut SharedArgs, options: SharedOptions) {
-    if let Some(since) = options.since {
-        shared.since = Some(normalize_date_bound(&since));
+    // Invalid bounds are rejected in `ConfigContext::detect_date_bound_error`, so an
+    // unnormalizable value here is left for that error to report.
+    if let Some(since) = options.since.as_deref().and_then(normalize_date_bound) {
+        shared.since = Some(since);
     }
-    if let Some(until) = options.until {
-        shared.until = Some(normalize_date_bound(&until));
+    if let Some(until) = options.until.as_deref().and_then(normalize_date_bound) {
+        shared.until = Some(until);
     }
     if let Some(json) = options.json {
         shared.json = json;
@@ -1166,6 +1208,111 @@ mod tests {
         assert!(validate_named_pi_store_name("codex").is_err());
     }
 
+    #[test]
+    fn rejects_config_date_bounds_that_are_not_real_calendar_dates() {
+        let config = config_context_from_json(r#"{ "defaults": { "since": "2026-02-30" } }"#);
+
+        assert_eq!(
+            config.config_error(),
+            Some(
+                "Invalid ccusage config: since '2026-02-30' is not a valid date. Expected YYYY-MM-DD or YYYYMMDD"
+            )
+        );
+
+        let config = config_context_from_json(r#"{ "commands": { "daily": { "until": "abc" } } }"#);
+
+        assert_eq!(
+            config.config_error(),
+            Some(
+                "Invalid ccusage config: until 'abc' is not a valid date. Expected YYYY-MM-DD or YYYYMMDD"
+            )
+        );
+    }
+
+    #[test]
+    fn rejects_config_date_bounds_that_are_not_strings() {
+        let config = config_context_from_json(r#"{ "defaults": { "since": 20260710 } }"#);
+
+        assert_eq!(
+            config.config_error(),
+            Some("Invalid ccusage config: since must be a string. Expected YYYY-MM-DD or YYYYMMDD")
+        );
+    }
+
+    #[test]
+    fn detects_commands_after_root_options_with_values() {
+        for command in [
+            vec!["--last", "1", "weekly"],
+            vec!["--sections", "daily", "weekly"],
+        ] {
+            let config = config_context_for_command(
+                r#"{ "commands": { "weekly": { "since": "not-a-date" } } }"#,
+                &command,
+            );
+
+            assert_eq!(
+                config.config_error(),
+                Some(
+                    "Invalid ccusage config: since 'not-a-date' is not a valid date. Expected YYYY-MM-DD or YYYYMMDD"
+                ),
+                "expected {command:?} to inspect the weekly command config"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_config_date_bounds_for_commands_without_named_pi_stores() {
+        for command in [
+            vec!["blocks"],
+            vec!["statusline"],
+            vec!["all", "daily"],
+            vec!["codex", "daily"],
+        ] {
+            let config = config_context_for_command(
+                r#"{ "defaults": { "since": "2026-02-30" } }"#,
+                &command,
+            );
+
+            assert_eq!(
+                config.config_error(),
+                Some(
+                    "Invalid ccusage config: since '2026-02-30' is not a valid date. Expected YYYY-MM-DD or YYYYMMDD"
+                ),
+                "expected {command:?} to reject the invalid config date bound"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_named_pi_store_errors_gated_to_commands_that_read_them() {
+        let raw = r#"{ "pi": { "stores": [{ "name": "omp" }] } }"#;
+
+        assert_eq!(
+            config_context_for_command(raw, &["daily"]).config_error(),
+            Some(
+                "Invalid ccusage config: pi.stores[0] must contain string fields 'name' and 'path'"
+            )
+        );
+        assert_eq!(
+            config_context_for_command(raw, &["blocks"]).config_error(),
+            None
+        );
+    }
+
+    #[test]
+    fn normalizes_valid_config_date_bounds() {
+        let config = config_context_from_json(
+            r#"{ "defaults": { "since": "2026-01-01", "until": "20260131" } }"#,
+        );
+        let mut shared = SharedArgs::default();
+
+        assert_eq!(config.config_error(), None);
+        apply_config_to_shared(&mut shared, &config);
+
+        assert_eq!(shared.since.as_deref(), Some("20260101"));
+        assert_eq!(shared.until.as_deref(), Some("20260131"));
+    }
+
     fn context(value: Value, raw: &str, agent: Option<&str>, report: &str) -> ConfigContext {
         ConfigContext {
             value: Some(value),
@@ -1175,18 +1322,25 @@ mod tests {
                 report: report.to_string(),
             },
             pi_stores: Vec::new(),
-            error: None,
+            pi_store_error: None,
+            date_bound_error: None,
         }
     }
 
     fn config_context_from_json(raw: &str) -> ConfigContext {
+        config_context_for_command(raw, &["daily"])
+    }
+
+    fn config_context_for_command(raw: &str, command: &[&str]) -> ConfigContext {
         let fixture = fs_fixture!({
             "ccusage.json": raw,
         });
-        ConfigContext::from_args(&[
-            "daily".to_string(),
-            "--config".to_string(),
-            fixture.path("ccusage.json").to_string_lossy().into_owned(),
-        ])
+        let mut args = command
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<String>>();
+        args.push("--config".to_string());
+        args.push(fixture.path("ccusage.json").to_string_lossy().into_owned());
+        ConfigContext::from_args(&args)
     }
 }

--- a/rust/crates/ccusage-core/src/summary.rs
+++ b/rust/crates/ccusage-core/src/summary.rs
@@ -540,7 +540,7 @@ mod tests {
                 }),
             ];
             let shared = SharedArgs {
-                since: Some(normalize_date_bound(since)),
+                since: normalize_date_bound(since),
                 order: SortOrder::Asc,
                 ..SharedArgs::default()
             };


### PR DESCRIPTION
Reapply the date-bound validation removed by the preceding revert.

This restores the documented CLI and configuration validation while recording dok123 as a co-author of the reapplication.

Testing: pre-push clippy, treefmt, gitleaks, and cargo test passed.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reapplies strict validation of `--since`/`--until` date bounds in the CLI and config. Previously we accepted loosely formatted values by stripping dashes, which could silently change which rows a report kept; now only `YYYY-MM-DD` or `YYYYMMDD` are accepted, dates must be real calendar dates, and invalid values exit with an error. The same check applies to `since`/`until` in config.

- Exposes `DATE_BOUND_FORMATS` from `ccusage-cli` and updates `normalize_date_bound` to return `Option<String>` after validating and normalizing to `YYYYMMDD`.
- CLI parser (`ccusage-cli-parser`) errors with “Expected YYYY-MM-DD or YYYYMMDD” and rejects undocumented spellings.
- Config loader (`ccusage-config`) validates `since`/`until` early, surfaces a single config error, and keeps pi-store errors gated to readers; valid bounds are normalized before applying shared options.
- Docs clarify accepted formats and inclusivity; tests cover invalid dates and both accepted formats.

Bold sections aren't required here, but migration notes follow.

- Migration
  - CLI: ensure scripts and users pass `YYYY-MM-DD` or `YYYYMMDD`; invalid values now fail with a non-zero exit.
  - Config: set `since`/`until` as strings using those formats; non-strings or invalid dates fail config validation.
  - External users of `ccusage-cli`: update call sites to handle `normalize_date_bound` returning `Option<String>`.

<sup>Written for commit 6d00c281a4748e6f33e5e4a9cc9d9ae5673feebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added date filtering with `YYYY-MM-DD` and `YYYYMMDD` formats.
  * Date filters now support inclusive ranges and configuration-file values.
* **Bug Fixes**
  * Invalid formats, impossible dates, and non-calendar dates are rejected with clear errors and a non-zero exit code.
  * Improved handling of date-filter and command-line option validation.
* **Documentation**
  * Documented supported date formats, validation rules, and public date-format information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->