### PR TITLE
fix(claude): scope session date bounds to usage entries

### DIFF
--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -592,10 +592,12 @@ fn filtered_pi_format_agent_rows(
 
 fn load_claude_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRows> {
     if kind == AgentReportKind::Session {
-        let entries = claude::load_entries(shared, None)?;
+        let mut entries = claude::load_entries(shared, None)?;
         let detected = !entries.is_empty();
-        let mut summaries = summarize_entry_sessions(&entries)?;
-        filter_session_summaries(&mut summaries, shared);
+        // Match the pi path: scope the date window to entries before
+        // summarizing, so session totals cover only the requested window.
+        filter_loaded_entries_by_date(&mut entries, shared);
+        let summaries = summarize_entry_sessions(&entries)?;
         return Ok(AgentRows {
             rows: summary_rows("claude", summaries, false),
             detected,
@@ -1426,5 +1428,39 @@ mod tests {
                 ("pi", ["[pi] gpt-5".to_string()].as_slice()),
             ]
         );
+    }
+
+    #[test]
+    fn unified_claude_session_rows_scope_totals_to_the_date_window() {
+        let fixture = fs_fixture!({
+            "projects/project1/session1/chat.jsonl": [
+                r#"{"timestamp":"2026-01-01T12:00:00.000Z","message":{"id":"msg_1","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":10}},"requestId":"req_1","costUSD":0.01}"#,
+                r#"{"timestamp":"2026-01-02T12:00:00.000Z","message":{"id":"msg_2","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":20}},"requestId":"req_2","costUSD":0.02}"#,
+                r#"{"timestamp":"2026-01-03T12:00:00.000Z","message":{"id":"msg_3","model":"claude-opus-4-6","usage":{"input_tokens":3,"output_tokens":30}},"requestId":"req_3","costUSD":0.03}"#,
+            ]
+            .join("\n"),
+        });
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        let shared = |since: Option<&str>, until: Option<&str>| SharedArgs {
+            mode: crate::cli::CostMode::Display,
+            since: since.map(str::to_string),
+            until: until.map(str::to_string),
+            ..SharedArgs::default()
+        };
+
+        let lifetime = load_claude_rows(AgentReportKind::Session, &shared(None, None)).unwrap();
+        assert_eq!(lifetime.rows.len(), 1);
+        assert_eq!(lifetime.rows[0].output_tokens, 60);
+
+        // Both bounds are inclusive, and the window scopes the totals rather
+        // than only selecting which sessions are listed.
+        let windowed = load_claude_rows(
+            AgentReportKind::Session,
+            &shared(Some("20260102"), Some("20260103")),
+        )
+        .unwrap();
+        assert_eq!(windowed.rows.len(), 1);
+        assert_eq!(windowed.rows[0].output_tokens, 50);
     }
 }

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -6,14 +6,15 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use ccusage_adapter_common::filter_loaded_entries_by_date;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::pricing::PricingMap;
 use crate::{
     BucketKind, Color, Context, DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS,
-    MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, block_json,
-    calculate_burn_rate,
+    MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, UsageSummary,
+    block_json, calculate_burn_rate,
     cli::{
         BlocksArgs, CostSource, DailyArgs, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
         VisualBurnRate, WeekDay, WeeklyArgs,
@@ -141,15 +142,16 @@ pub(crate) fn run_weekly(args: WeeklyArgs) -> Result<()> {
     Ok(())
 }
 
-pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
-    let shared = args.shared.clone();
-    if let Some(id) = args.id {
-        return run_session_id(&id, &shared);
-    }
+/// Build one row per Claude session, scoped to the `--since` / `--until`
+/// window.
+///
+/// The window is applied to usage entries before grouping. Filtering the
+/// grouped rows afterwards can only drop whole sessions, which would leave
+/// every surviving row reporting its lifetime totals.
+fn claude_session_rows(shared: &SharedArgs) -> Result<Vec<UsageSummary>> {
+    let mut entries = load_entries(shared, None)?;
+    filter_loaded_entries_by_date(&mut entries, shared);
 
-    let mut session_shared = shared.clone();
-    session_shared.order = SortOrder::Desc;
-    let entries = load_entries(&session_shared, None)?;
     let mut grouped = Vec::<SessionAccumulator>::new();
     let mut group_indexes = FxHashMap::<(Arc<str>, Arc<str>), usize>::default();
     for entry in &entries {
@@ -169,26 +171,21 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
     for group in grouped {
         rows.push(group.into_summary()?);
     }
-    if session_shared.since.is_some() || session_shared.until.is_some() {
-        rows.retain(|row| {
-            let date = row
-                .last_activity
-                .as_deref()
-                .unwrap_or_default()
-                .replace('-', "");
-            session_shared
-                .since
-                .as_ref()
-                .is_none_or(|since| &date >= since)
-                && session_shared
-                    .until
-                    .as_ref()
-                    .is_none_or(|until| &date <= until)
-        });
-    }
     rows.retain(|row| {
         row.input_tokens + row.output_tokens + row.cache_creation_tokens + row.cache_read_tokens > 0
     });
+    Ok(rows)
+}
+
+pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
+    let shared = args.shared.clone();
+    if let Some(id) = args.id {
+        return run_session_id(&id, &shared);
+    }
+
+    let mut session_shared = shared.clone();
+    session_shared.order = SortOrder::Desc;
+    let mut rows = claude_session_rows(&session_shared)?;
     rows.sort_by(|a, b| match session_shared.order {
         SortOrder::Asc => a.total_cost.total_cmp(&b.total_cost),
         SortOrder::Desc => b.total_cost.total_cmp(&a.total_cost),
@@ -215,7 +212,8 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
 }
 
 fn run_session_id(id: &str, shared: &SharedArgs) -> Result<()> {
-    let entries = load_entries(shared, None)?;
+    let mut entries = load_entries(shared, None)?;
+    filter_loaded_entries_by_date(&mut entries, shared);
     let mut session_entries = entries
         .into_iter()
         .filter(|entry| {
@@ -842,9 +840,10 @@ struct HookContext {
 
 #[cfg(test)]
 mod tests {
-    use ccusage_test_support::fs_fixture;
+    use ccusage_test_support::{EnvVarGuard, Fixture, fs_fixture};
 
     use super::*;
+    use crate::cli::CostMode;
 
     #[test]
     fn calculates_context_tokens_from_latest_assistant_transcript_line() {
@@ -1062,5 +1061,98 @@ mod tests {
             Some("xhigh")
         );
         assert!(without_effort.effort.is_none());
+    }
+
+    /// One Claude session with usage on three consecutive UTC days,
+    /// 10 / 20 / 30 output tokens and $0.01 / $0.02 / $0.03.
+    fn three_day_session_fixture() -> Fixture {
+        fs_fixture!({
+            "projects/project1/session1/chat.jsonl": [
+                r#"{"timestamp":"2026-01-01T12:00:00.000Z","message":{"id":"msg_1","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":10}},"requestId":"req_1","costUSD":0.01}"#,
+                r#"{"timestamp":"2026-01-02T12:00:00.000Z","message":{"id":"msg_2","model":"claude-opus-4-6","usage":{"input_tokens":2,"output_tokens":20}},"requestId":"req_2","costUSD":0.02}"#,
+                r#"{"timestamp":"2026-01-03T12:00:00.000Z","message":{"id":"msg_3","model":"claude-opus-4-6","usage":{"input_tokens":3,"output_tokens":30}},"requestId":"req_3","costUSD":0.03}"#,
+            ]
+            .join("\n"),
+        })
+    }
+
+    fn session_shared(since: Option<&str>, until: Option<&str>) -> SharedArgs {
+        SharedArgs {
+            mode: CostMode::Display,
+            since: since.map(str::to_string),
+            until: until.map(str::to_string),
+            ..SharedArgs::default()
+        }
+    }
+
+    #[test]
+    fn session_rows_report_lifetime_totals_without_date_bounds() {
+        let fixture = three_day_session_fixture();
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        let rows = claude_session_rows(&session_shared(None, None)).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].output_tokens, 60);
+        assert!((rows[0].total_cost - 0.06).abs() < 1e-9);
+    }
+
+    #[test]
+    fn session_rows_scope_totals_to_the_date_window() {
+        let fixture = three_day_session_fixture();
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        let rows = claude_session_rows(&session_shared(Some("20260102"), None)).unwrap();
+
+        // The session started on 2026-01-01, so the row survives either way.
+        // Only a window applied to entries changes the totals.
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].output_tokens, 50);
+        assert!((rows[0].total_cost - 0.05).abs() < 1e-9);
+    }
+
+    #[test]
+    fn session_rows_treat_both_date_bounds_as_inclusive() {
+        let fixture = three_day_session_fixture();
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        let single_day =
+            claude_session_rows(&session_shared(Some("20260102"), Some("20260102"))).unwrap();
+        assert_eq!(single_day.len(), 1);
+        assert_eq!(single_day[0].output_tokens, 20);
+
+        // The last activity falls on the `--until` day, which must be kept.
+        let through_last_day =
+            claude_session_rows(&session_shared(Some("20260101"), Some("20260103"))).unwrap();
+        assert_eq!(through_last_day.len(), 1);
+        assert_eq!(through_last_day[0].output_tokens, 60);
+    }
+
+    #[test]
+    fn session_rows_drop_a_session_with_no_entries_in_the_window() {
+        let fixture = three_day_session_fixture();
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        let rows = claude_session_rows(&session_shared(Some("20260201"), None)).unwrap();
+
+        assert!(rows.is_empty());
+    }
+
+    #[test]
+    fn session_rows_resolve_entry_dates_in_the_requested_timezone() {
+        let fixture = fs_fixture!({
+            "projects/project1/session1/chat.jsonl":
+                r#"{"timestamp":"2026-01-02T02:00:00.000Z","message":{"id":"msg_1","model":"claude-opus-4-6","usage":{"input_tokens":1,"output_tokens":10}},"requestId":"req_1","costUSD":0.01}"#,
+        });
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+
+        // 2026-01-02T02:00Z is still 2026-01-01 in Montreal (UTC-5).
+        let mut montreal = session_shared(Some("20260102"), None);
+        montreal.timezone = Some("America/Montreal".to_string());
+        assert!(claude_session_rows(&montreal).unwrap().is_empty());
+
+        let mut utc = session_shared(Some("20260102"), None);
+        utc.timezone = Some("UTC".to_string());
+        assert_eq!(claude_session_rows(&utc).unwrap().len(), 1);
     }
 }


### PR DESCRIPTION
fix(claude): scope session date bounds to usage entries

Fixes #1609.

`ccusage claude session` and the Claude rows of `ccusage session` applied
`--since` / `--until` to grouped rows instead of to usage entries. Because a
row is a whole session, that could only include or exclude a session; every
surviving row still reported its lifetime totals.

Three symptoms shared this one cause:

1. Totals ignored the window entirely.
2. `--until` dropped a session whose last activity fell on the boundary day.
   `last_activity` is a full RFC3339 timestamp, so `"20260814T09:38:56.467Z"`
   never compares `<=` `"20260814"`.
3. `--timezone` had no effect, because `last_activity` is UTC-only while the
   daily path formats dates with `shared.timezone`.

## Change

Both Claude session paths now call the existing
`ccusage_adapter_common::filter_loaded_entries_by_date` on loaded entries
before grouping, which is what every other adapter already does and what the
pi path in `load_pi_format_agent_rows` does today. `entry.date` is produced by
`format_date_tz` with the requested timezone and is a plain `YYYY-MM-DD`, so
all three symptoms are fixed together.

- `rust/crates/ccusage/src/commands/mod.rs`: session grouping extracted into
  `claude_session_rows`, which filters entries before grouping. The row-level
  `last_activity` comparison is removed. `--id` lookup filters too, so
  `session --id X --since Y` no longer reports lifetime totals.
- `rust/crates/ccusage-adapter-all/src/loader.rs`: `load_claude_rows` filters
  entries before `summarize_entry_sessions`, mirroring the pi path. `detected`
  is still computed before filtering, so a session outside the window does not
  make the agent look absent.

Unbounded reports are unchanged. Codex behavior is untouched.

## Tests

- `claude_session_rows` with no bounds still reports lifetime totals.
- `--since` changes the totals for a session that survives either way — this
  is the case the old code could not express.
- Both bounds inclusive, including the `--until` boundary day.
- A session with no entries in the window drops out.
- A non-UTC `--timezone` decides which day an entry belongs to.
- The unified path gets the same window/inclusivity assertions through
  `load_claude_rows`.

## Not in this PR

`load_qwen_rows` still calls `filter_session_summaries` after summarizing and
has the same defect. It is left alone to keep this change focused; I did not
verify qwen's date semantics. `filter_session_summaries` is kept for that
caller and can be removed once qwen is migrated.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Claude session date bounds to usage entries so windowed reports show window totals and respect timezone. Previously, `--since`/`--until` filtered grouped session rows, which kept surviving sessions at lifetime totals, excluded sessions ending on the `--until` day, and ignored `--timezone`; now the window is applied to entries before grouping, fixing all three.

- Filters entries with `ccusage_adapter_common::filter_loaded_entries_by_date` before grouping in both paths: `ccusage` CLI (`claude_session_rows` in `ccusage`) and unified adapter (`load_claude_rows` in `ccusage-adapter-all`). `last_activity` row-level comparison is removed.
- Both bounds are inclusive and resolved using the requested timezone; totals reflect only windowed entries. `session --id` now respects date bounds.
- Unbounded reports and Codex behavior are unchanged. `detected` remains computed pre-filter, so agents aren’t marked absent by windowing.
- Note: `load_qwen_rows` still filters after summarizing and retains the old behavior; no migration in this PR.

<sup>Written for commit 0be332d1904402bfab40b504202a82e0c1c1755f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Session usage totals now accurately reflect the selected `--since` and `--until` date range.
  - Session details are filtered consistently, including entries at the inclusive date boundaries.
  - Date filtering now handles timezone-aware dates and empty date windows correctly.
  - Lifetime totals remain accurate while windowed totals include only matching activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->