### PR TITLE
docs: add coffee-paladin to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -15,6 +15,7 @@ These projects are maintained independently and are not affiliated with the ccus
 
 - [ccusage Raycast Extension](https://www.raycast.com/nyatinte/ccusage) - Raycast integration for quick usage checks
 - [ccusage.nvim](https://github.com/S1M0N38/ccusage.nvim) - Track Claude Code usage in Neovim
+- [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin) - macOS menu bar thermal guard for AI agent workloads, showing today's ccusage totals next to chip temperature
 
 ## CLI Utilities
 


### PR DESCRIPTION
coffee-paladin is a thermal guard for Macs running AI coding agents: it pauses heavy work with SIGSTOP when the chip gets hot and resumes it once the machine cools, so a long agent session does not cook the laptop.

It calls `ccusage daily --json --by-agent` and `ccusage blocks --active --json` and shows the result in the menu bar next to chip temperature, fans and the running agent sessions - so "what is this costing me" and "what is this doing to the machine" are answered in the same place. Tokens lead the row and the dollar figure is prefixed with `~`, since most users are on a subscription where it is an API-price equivalent rather than money spent. Nothing is vendored: the binary is called and its answer cached, and with no ccusage installed those rows simply do not exist.

Thanks for the tool - having one CLI that already speaks Claude Code, Codex, Gemini and the rest saved me writing a parser per agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds coffee-paladin to the Community Projects page, linking to its repo and describing it as a macOS menu bar thermal guard that shows today’s `ccusage` totals alongside chip temperature. Improves discoverability of third-party tools integrating with `ccusage`; docs-only change.

**Review notes**
- Verify the GitHub link resolves and the project meets community-project criteria.
- Confirm the entry’s wording and length match adjacent items and that the list renders correctly.

<sup>Written for commit aacf4ac26874f193616a0e39cd05274bcc96ece3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Coffee Paladin to the Extensions & Integrations list.
  * Documented its macOS menu bar thermal monitoring and usage total display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->