### PR TITLE
feat(zcode): add ZCode usage adapter

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -79,6 +79,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
 | Grok Build CLI     | `ccusage grok daily`     |
+| ZCode              | `ccusage zcode daily`    |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 
@@ -134,6 +135,7 @@ bunx ccusage qwen daily
 bunx ccusage copilot daily
 bunx ccusage gemini daily
 bunx ccusage grok daily
+bunx ccusage zcode daily
 bunx ccusage pi daily --pi-path /path/to/sessions
 bunx ccusage pi daily --pi-path /path/to/sessions,/archive/pi/sessions
 
@@ -166,7 +168,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -12567,6 +12567,684 @@
 						}
 					},
 					"type": "object"
+				},
+				"zcode": {
+					"additionalProperties": false,
+					"description": "ZCode configuration.",
+					"markdownDescription": "ZCode configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": ["auto", "calculate", "display"],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": ["desc", "asc"],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": ["auto", "calculate", "display"],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"default": false,
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": ["desc", "asc"],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
 				}
 			},
 			"type": "object"

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -84,7 +84,7 @@ export default defineConfig({
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
 						{ text: 'Grok Build CLI', link: '/guide/grok/' },
-					{ text: 'ZCode', link: '/guide/zcode/' },
+						{ text: 'ZCode', link: '/guide/zcode/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
 						{ text: 'Grok Build CLI', link: '/guide/grok/' },
+					{ text: 'ZCode', link: '/guide/zcode/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |
@@ -64,6 +64,7 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | Copilot CLI    | `copilot`  | `ccusage copilot daily`   |
 | Gemini CLI     | `gemini`   | `ccusage gemini daily`    |
 | Grok Build CLI | `grok`     | `ccusage grok daily`      |
+| ZCode          | `zcode`    | `ccusage zcode daily`     |
 
 ## When to Focus a Source
 
@@ -83,6 +84,7 @@ ccusage qwen daily
 ccusage copilot daily --json
 ccusage gemini session --json
 ccusage grok daily --json
+ccusage zcode daily --json
 ```
 
 ## Next Steps

--- a/docs/guide/claude/index.md
+++ b/docs/guide/claude/index.md
@@ -75,7 +75,7 @@ export CLAUDE_CONFIG_DIR="~/.config/claude,/backup/claude-archive"
 ccusage claude monthly
 ```
 
-For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
+For Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode data locations, use the source-specific environment variables listed in [Environment Variables](/guide/environment-variables).
 
 ### Directory Detection
 

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -180,7 +180,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, `gemini`, and `grok`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, `gemini`, `grok`, and `zcode`.
 
 ```json
 {

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -109,7 +109,7 @@ For individual developers working on multiple projects:
 
 ### Multiple Sources
 
-Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI separately with data source namespaces:
+Configure Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode separately with data source namespaces:
 
 ```json
 // ~/.config/claude/ccusage.json

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -24,6 +24,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI    | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI     | `~/.gemini/tmp`                    |
 | `GROK_HOME`                       | Grok Build CLI | `~/.grok`                          |
+| `ZCODE_HOME`                      | ZCode          | `~/.zcode`                         |
 
 Example:
 
@@ -43,6 +44,7 @@ export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GEMINI_DATA_DIR="/path/to/gemini/tmp,/archive/gemini/tmp"
 export GROK_HOME="/path/to/grok-home"
+export ZCODE_HOME="/path/to/zcode-home,/archive/zcode"
 ccusage daily
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -177,6 +177,7 @@ If ccusage shows no data, check:
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
    - Grok Build CLI: `${GROK_HOME:-~/.grok}`
+   - ZCode: `${ZCODE_HOME:-~/.zcode}`
 
 ### Custom Data Directory
 
@@ -198,6 +199,7 @@ export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GROK_HOME="/path/to/grok-home"
+export ZCODE_HOME="/path/to/zcode-home"
 ```
 
 Each source-specific path variable can also contain comma-separated directories, except `GROK_HOME`, which takes a single root:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,9 +2,9 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode.
 
-The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
+The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, ZCode, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
 ## The Problem
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -90,6 +90,7 @@ ccusage reads from local coding CLI data directories:
 | Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
 | Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
 | Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                           |
+| ZCode          | `zcode`    | `${ZCODE_HOME:-~/.zcode}`                         |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.
@@ -126,6 +127,7 @@ ccusage qwen daily
 ccusage copilot daily
 ccusage gemini daily
 ccusage grok daily
+ccusage zcode daily
 ```
 
 Use `ccusage <source> <report>` only when you want to narrow a report to one source.

--- a/docs/guide/zcode/index.md
+++ b/docs/guide/zcode/index.md
@@ -19,7 +19,7 @@ Most users can start with unified reports such as `ccusage daily`. Add the `zcod
 
 ## Data Source
 
-The CLI reads completed model requests from the `model_usage` table in ZCode's SQLite database, joining `session` for the project directory and app version.
+The CLI reads completed model requests from the `model_usage` table in ZCode's SQLite database, joining `session` for the project directory.
 
 Root resolution (highest first):
 
@@ -47,14 +47,14 @@ Only rows with `status = 'completed'` are counted. Error and cancelled attempts 
 | `ccusage zcode monthly` | Aggregate usage by month     | [Monthly Usage](/guide/monthly-reports) |
 | `ccusage zcode session` | Group usage by ZCode session | [Session Usage](/guide/session-reports) |
 
-These views support `--json`, `--compact`, `--mode`, and `--offline`.
+These views support [`--json`](/guide/json-output), `--compact`, `--mode`, and `--offline`.
 
 ## What Gets Calculated
 
-- **Token usage** - ZCode records OpenAI-style usage where `input_tokens` includes the cache-read slice. ccusage carves `cache_read_input_tokens` out of input so cache reads are reported and priced at their own rate.
+- **Token usage** - ZCode records OpenAI-style usage where `input_tokens` includes cache-read and cache-creation tokens. ccusage carves both cache slices out of input so the reported buckets remain additive and use their own pricing rates.
 - **Reasoning tokens** - ZCode's schema has a `reasoning_tokens` column, but every observed row records zero; reasoning is assumed to sit inside output and is never added on top. If a future ZCode version moves it outside, the recorded total grows past the counted buckets and ccusage routes the difference into its extra-tokens bucket instead of dropping it.
-- **Costs** - ZCode records no per-request cost, so every cost mode derives from the pricing tables. Model ids are lowercased for lookup (`GLM-5.3` matches the `glm-5.3` pricing entry).
-- **Session metadata** - Session reports carry the project directory, first/last activity, and app version from the `session` table.
+- **Costs** - ZCode records no per-request cost. The default `auto` mode and `calculate` estimate costs from the pricing tables; `display` shows `$0.00` because there is no recorded cost to display. Pricing lookup honors an exact raw-model override first, then tries provider-qualified Z.ai and normalized aliases.
+- **Session metadata** - Session reports carry the project directory and first/last activity.
 
 ## Environment Variables
 
@@ -89,5 +89,5 @@ Ensure `~/.zcode/cli/db/db.sqlite` exists and has completed rows in `model_usage
 :::
 
 ::: details Costs showing as $0.00
-ZCode subscription usage has no recorded per-request cost, so costs are always table estimates. If a model is missing from pricing, the cost stays at zero and a missing-pricing warning may appear.
+ZCode records no per-request cost, so `--mode display` shows `$0.00`. Use the default `auto` mode or `--mode calculate` to estimate costs from the pricing tables. If a model is missing from pricing, the estimate stays at zero and a missing-pricing warning may appear.
 :::

--- a/docs/guide/zcode/index.md
+++ b/docs/guide/zcode/index.md
@@ -1,0 +1,93 @@
+# ZCode Data Source
+
+ccusage can read the local ZCode desktop app's usage database as a supported data source. ZCode uses the same unified and focused report model as other agents.
+
+## Focused Views
+
+```bash
+# Daily ZCode usage
+ccusage zcode daily
+
+# Monthly ZCode usage
+ccusage zcode monthly
+
+# ZCode sessions
+ccusage zcode session
+```
+
+Most users can start with unified reports such as `ccusage daily`. Add the `zcode` namespace only when you want to focus the same report shape on ZCode usage.
+
+## Data Source
+
+The CLI reads completed model requests from the `model_usage` table in ZCode's SQLite database, joining `session` for the project directory and app version.
+
+Root resolution (highest first):
+
+1. A non-empty `ZCODE_HOME` (one root or a comma-separated list)
+2. `~/.zcode`
+
+```bash
+ZCODE_HOME="$HOME/.zcode" ccusage zcode daily
+```
+
+```text
+$ZCODE_HOME/   # or ~/.zcode
+└── cli/
+    └── db/
+        └── db.sqlite  # model_usage + session tables
+```
+
+Only rows with `status = 'completed'` are counted. Error and cancelled attempts record zero tokens, so skipping them changes nothing. The database is opened read-only, which is safe while ZCode is running.
+
+## Report Views
+
+| Focused view            | Description                  | See also                                |
+| ----------------------- | ---------------------------- | --------------------------------------- |
+| `ccusage zcode daily`   | Aggregate usage by date      | [Daily Usage](/guide/daily-reports)     |
+| `ccusage zcode monthly` | Aggregate usage by month     | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage zcode session` | Group usage by ZCode session | [Session Usage](/guide/session-reports) |
+
+These views support `--json`, `--compact`, `--mode`, and `--offline`.
+
+## What Gets Calculated
+
+- **Token usage** - ZCode records OpenAI-style usage where `input_tokens` includes the cache-read slice. ccusage carves `cache_read_input_tokens` out of input so cache reads are reported and priced at their own rate.
+- **Reasoning tokens** - ZCode's schema has a `reasoning_tokens` column, but every observed row records zero; reasoning is assumed to sit inside output and is never added on top. If a future ZCode version moves it outside, the recorded total grows past the counted buckets and ccusage routes the difference into its extra-tokens bucket instead of dropping it.
+- **Costs** - ZCode records no per-request cost, so every cost mode derives from the pricing tables. Model ids are lowercased for lookup (`GLM-5.3` matches the `glm-5.3` pricing entry).
+- **Session metadata** - Session reports carry the project directory, first/last activity, and app version from the `session` table.
+
+## Environment Variables
+
+| Variable     | Description                                      |
+| ------------ | ------------------------------------------------ |
+| `ZCODE_HOME` | ZCode data home (single root or comma-separated) |
+| `LOG_LEVEL`  | Adjust verbosity (0 silent ... 5 trace)          |
+
+## Configuration
+
+```json
+{
+	"zcode": {
+		"defaults": {
+			"offline": true
+		},
+		"commands": {
+			"session": {
+				"json": true
+			}
+		}
+	}
+}
+```
+
+The `zcode` namespace supports the same shared report options as other focused sources. Use `zcode.defaults` for all ZCode reports and a matching `zcode.commands.daily`, `zcode.commands.monthly`, or `zcode.commands.session` object for report-specific overrides. The data root is discovered from `ZCODE_HOME` or `~/.zcode`, not from ccusage configuration.
+
+## Troubleshooting
+
+::: details No ZCode usage data found
+Ensure `~/.zcode/cli/db/db.sqlite` exists and has completed rows in `model_usage`. Set `ZCODE_HOME` if your data lives elsewhere. A database ZCode has reformatted to an unexpected schema degrades to no entries; run with `--debug` to see the failure.
+:::
+
+::: details Costs showing as $0.00
+ZCode subscription usage has no recorded per-request cost, so costs are always table estimates. If a model is missing from pricing, the cost stays at zero and a missing-pricing warning may appear.
+:::

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: ccusage
   text: Coding (Agent) CLI Usage Analysis
-  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI
+  tagline: A fast local CLI for tracking tokens and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode
   image:
     src: /logo.svg
     alt: ccusage logo
@@ -27,7 +27,7 @@ features:
     link: /guide/getting-started
   - icon: 📁
     title: Local Data Sources
-    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, and Gemini CLI without uploading your data
+    details: Reads local usage logs from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and ZCode without uploading your data
     link: /guide/
   - icon: 💰
     title: Cost Analysis

--- a/nix/cargo-artifacts.nix
+++ b/nix/cargo-artifacts.nix
@@ -48,6 +48,7 @@ let
     "opencode"
     "pi"
     "qwen"
+    "zcode"
   ];
   adapterCrates = map (name: "ccusage-adapter-${name}") agentNames ++ [ "ccusage-adapter-all" ];
 

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
  "ccusage-adapter-qwen",
+ "ccusage-adapter-zcode",
  "ccusage-cli",
  "ccusage-cli-parser",
  "ccusage-config",
@@ -169,6 +170,7 @@ dependencies = [
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
  "ccusage-adapter-qwen",
+ "ccusage-adapter-zcode",
  "ccusage-cli",
  "ccusage-core",
  "ccusage-test-support",
@@ -386,6 +388,18 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-zcode"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde_json",
+ "sqlite",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -34,6 +34,7 @@ ccusage-adapter-openclaw = { path = "adapters/openclaw" }
 ccusage-adapter-opencode = { path = "adapters/opencode" }
 ccusage-adapter-pi = { path = "adapters/pi" }
 ccusage-adapter-qwen = { path = "adapters/qwen" }
+ccusage-adapter-zcode = { path = "adapters/zcode" }
 ccusage-cli = { path = "crates/ccusage-cli" }
 ccusage-cli-parser = { path = "crates/ccusage-cli-parser" }
 ccusage-config = { path = "crates/ccusage-config" }

--- a/rust/adapters/zcode/Cargo.toml
+++ b/rust/adapters/zcode/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccusage-adapter-zcode"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde_json.workspace = true
+sqlite.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/zcode/README.md
+++ b/rust/adapters/zcode/README.md
@@ -19,15 +19,15 @@ Anything that is not specific to this source belongs in `ccusage-core` or
 
 The `model_usage` table records one row per model request. The adapter selects
 rows with `status = 'completed'` — error and cancelled attempts record zero
-tokens — and joins `session` for the project directory and app version.
+tokens — and joins `session` for the project directory.
 
 ## Token semantics
 
-- `input_tokens` **includes** the cache-read slice: the schema's own
+- `input_tokens` **includes** the cache-read and cache-creation slices: the schema's own
   `computed_total_tokens` is `input_tokens + output_tokens` exactly, and
-  `cache_read_input_tokens <= input_tokens` holds for every observed row. The
-  parser carves the cache-read slice out of input so the reported buckets stay
-  additive and cache reads price at their cheaper rate.
+  the cache buckets fit within `input_tokens` for every observed row. The parser
+  carves both slices out of input so the reported buckets stay additive and
+  cache tokens price at their cheaper rates.
 - `reasoning_tokens` and `cache_creation_input_tokens` exist in the schema but
   are zero in every observed row. Reasoning is assumed to sit inside output
   (matching how the GLM provider reports it); if a future version moves
@@ -37,9 +37,11 @@ tokens — and joins `session` for the project directory and app version.
 
 ## Cost semantics
 
-ZCode records no per-request cost, so every cost mode derives from the pricing
-tables. Model ids are lowercased before lookup (`GLM-5.3` -> `glm-5.3`) because
-pricing keys match case-sensitively.
+ZCode records no per-request cost. The default `auto` mode and `calculate`
+estimate costs from the pricing tables; `display` reports zero because there is
+no recorded cost to display. Pricing lookup tries the raw model id first, then a
+provider-qualified Z.ai id and normalized aliases, so exact custom-provider
+overrides and Z.ai pricing both work.
 
 ## Schema stability
 

--- a/rust/adapters/zcode/README.md
+++ b/rust/adapters/zcode/README.md
@@ -1,0 +1,68 @@
+# ccusage-adapter-zcode
+
+The ZCode adapter: it turns the ZCode desktop app's SQLite usage ledger into
+the usage entries the reports render.
+
+## Owns
+
+- `loader.rs` — reading the source, dedupe, and date filtering.
+- `parser.rs` — row mapping, token semantics, and model naming.
+- `paths.rs` — environment variables, default directories, and file discovery.
+- `report.rs` — the JSON and table shapes where they differ from the shared ones.
+
+Anything that is not specific to this source belongs in `ccusage-core` or
+`ccusage-adapter-common` instead.
+
+## Data source
+
+- `${ZCODE_HOME:-~/.zcode}/cli/db/db.sqlite`
+
+The `model_usage` table records one row per model request. The adapter selects
+rows with `status = 'completed'` — error and cancelled attempts record zero
+tokens — and joins `session` for the project directory and app version.
+
+## Token semantics
+
+- `input_tokens` **includes** the cache-read slice: the schema's own
+  `computed_total_tokens` is `input_tokens + output_tokens` exactly, and
+  `cache_read_input_tokens <= input_tokens` holds for every observed row. The
+  parser carves the cache-read slice out of input so the reported buckets stay
+  additive and cache reads price at their cheaper rate.
+- `reasoning_tokens` and `cache_creation_input_tokens` exist in the schema but
+  are zero in every observed row. Reasoning is assumed to sit inside output
+  (matching how the GLM provider reports it); if a future version moves
+  reasoning outside output, `computed_total_tokens` grows past the counted
+  buckets and the shared total-token fallback routes the difference into the
+  extra-tokens bucket instead of dropping it.
+
+## Cost semantics
+
+ZCode records no per-request cost, so every cost mode derives from the pricing
+tables. Model ids are lowercased before lookup (`GLM-5.3` -> `glm-5.3`) because
+pricing keys match case-sensitively.
+
+## Schema stability
+
+The database layout is undocumented and the app updates frequently. A database
+that cannot be opened or queried degrades to no entries with a `--debug` log
+line, the same contract the Kilo adapter uses; the fixture tests pin the
+current shape.
+
+## Public surface
+
+- `loader::load_entries`
+- `report::report_from_rows`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde_json`
+- `sqlite`
+
+## Build layer
+
+Built in the `adapters` Crane artifact layer; the layer compiles all adapters in one Cargo invocation, so they build concurrently.

--- a/rust/adapters/zcode/src/lib.rs
+++ b/rust/adapters/zcode/src/lib.rs
@@ -1,0 +1,47 @@
+use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        ccusage_core::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "ZCode Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/zcode/src/lib.rs
+++ b/rust/adapters/zcode/src/lib.rs
@@ -1,4 +1,4 @@
-use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_adapter_common::filter_loaded_entries_by_date;
 use ccusage_core::*;
 
 mod loader;

--- a/rust/adapters/zcode/src/loader.rs
+++ b/rust/adapters/zcode/src/loader.rs
@@ -1,10 +1,9 @@
 use std::{collections::HashSet, path::Path, path::PathBuf};
 
+use ccusage_adapter_common::read_files_parallel;
 use jiff::tz::TimeZone as JiffTimeZone;
 
-use crate::{
-    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
-};
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz};
 
 use super::{
     parser::{ZcodeUsageRow, row_to_entry},
@@ -61,9 +60,9 @@ fn load_entries_from_database(
     };
     let Ok(mut statement) = connection.prepare(
         "SELECT m.id, m.session_id, m.started_at, m.model_id, \
-         m.input_tokens, m.output_tokens, m.reasoning_tokens, \
-         m.cache_creation_input_tokens, m.cache_read_input_tokens, \
-         m.computed_total_tokens, s.directory, s.version \
+         m.input_tokens, m.output_tokens, m.cache_creation_input_tokens, \
+         m.cache_read_input_tokens, \
+         m.computed_total_tokens, s.directory \
          FROM model_usage m LEFT JOIN session s ON s.id = m.session_id \
          WHERE m.status = 'completed'",
     ) else {
@@ -104,12 +103,10 @@ fn read_usage_row(statement: &sqlite::Statement<'_>) -> Option<ZcodeUsageRow> {
         model_id: statement.read::<String, _>(3).ok()?,
         input_tokens: read_token_column(statement, 4),
         output_tokens: read_token_column(statement, 5),
-        // Index 6 is reasoning_tokens, which the parser does not consume.
-        cache_creation_input_tokens: read_token_column(statement, 7),
-        cache_read_input_tokens: read_token_column(statement, 8),
-        computed_total_tokens: read_token_column(statement, 9),
-        directory: statement.read::<Option<String>, _>(10).ok().flatten(),
-        version: statement.read::<Option<String>, _>(11).ok().flatten(),
+        cache_creation_input_tokens: read_token_column(statement, 6),
+        cache_read_input_tokens: read_token_column(statement, 7),
+        computed_total_tokens: read_token_column(statement, 8),
+        directory: statement.read::<Option<String>, _>(9).ok().flatten(),
     })
 }
 
@@ -138,13 +135,14 @@ mod tests {
             )",
         )
         .unwrap();
-        db.execute("CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, version TEXT)")
+        db.execute("CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT)")
             .unwrap();
     }
 
     struct UsageCounts {
         input_tokens: i64,
         output_tokens: i64,
+        cache_creation: i64,
         cache_read: i64,
         computed_total: i64,
     }
@@ -163,7 +161,7 @@ mod tests {
                 "INSERT INTO model_usage (id, session_id, started_at, model_id, status,
                  input_tokens, output_tokens, reasoning_tokens,
                  cache_creation_input_tokens, cache_read_input_tokens, computed_total_tokens)
-                 VALUES (?1, ?2, ?3, 'GLM-5.3', ?4, ?5, ?6, 0, 0, ?7, ?8)",
+                 VALUES (?1, ?2, ?3, 'GLM-5.3', ?4, ?5, ?6, 0, ?7, ?8, ?9)",
             )
             .unwrap();
         statement.bind((1, id)).unwrap();
@@ -172,19 +170,19 @@ mod tests {
         statement.bind((4, status)).unwrap();
         statement.bind((5, counts.input_tokens)).unwrap();
         statement.bind((6, counts.output_tokens)).unwrap();
-        statement.bind((7, counts.cache_read)).unwrap();
-        statement.bind((8, counts.computed_total)).unwrap();
+        statement.bind((7, counts.cache_creation)).unwrap();
+        statement.bind((8, counts.cache_read)).unwrap();
+        statement.bind((9, counts.computed_total)).unwrap();
         statement.next().unwrap();
     }
 
-    fn insert_session(path: &Path, id: &str, directory: &str, version: &str) {
+    fn insert_session(path: &Path, id: &str, directory: &str) {
         let db = sqlite::open(path).unwrap();
         let mut statement = db
-            .prepare("INSERT INTO session (id, directory, version) VALUES (?1, ?2, ?3)")
+            .prepare("INSERT INTO session (id, directory) VALUES (?1, ?2)")
             .unwrap();
         statement.bind((1, id)).unwrap();
         statement.bind((2, directory)).unwrap();
-        statement.bind((3, version)).unwrap();
         statement.next().unwrap();
     }
 
@@ -209,7 +207,7 @@ mod tests {
     #[test]
     fn carves_cache_reads_out_of_input_tokens_and_prices_the_model() {
         let (fixture, db_file) = fixture_with_db();
-        insert_session(&db_file, "session-a", "/Users/aaron/code/proj", "0.16.3");
+        insert_session(&db_file, "session-a", "/Users/aaron/code/proj");
         // input_tokens includes the cache-read slice; computed = input + output.
         insert_usage(
             &db_file,
@@ -220,6 +218,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 16_507,
                 output_tokens: 59,
+                cache_creation: 0,
                 cache_read: 11_712,
                 computed_total: 16_566,
             },
@@ -234,14 +233,42 @@ mod tests {
         assert_eq!(usage.cache_read_input_tokens, 11_712);
         assert_eq!(usage.cache_creation_input_tokens, 0);
         assert_eq!(entries[0].date, "2026-08-16");
-        assert_eq!(entries[0].model.as_deref(), Some("glm-5.3"));
+        assert_eq!(entries[0].model.as_deref(), Some("GLM-5.3"));
         assert_eq!(entries[0].session_id.as_ref(), "session-a");
         assert_eq!(entries[0].project_path.as_ref(), "/Users/aaron/code/proj");
-        assert_eq!(entries[0].data.version.as_deref(), Some("0.16.3"));
+        assert_eq!(entries[0].data.version, None);
         // glm-5.3 is in the embedded pricing snapshot, so the cost derives
         // from it instead of reporting a missing-pricing model.
         assert!(entries[0].cost > 0.0);
         assert!(entries[0].missing_pricing_model.is_none());
+    }
+
+    #[test]
+    fn carves_cache_creation_out_of_input_tokens() {
+        let (fixture, db_file) = fixture_with_db();
+        insert_usage(
+            &db_file,
+            "usage-1",
+            "session-a",
+            1_786_909_042_666,
+            "completed",
+            UsageCounts {
+                input_tokens: 1_000,
+                output_tokens: 300,
+                cache_creation: 100,
+                cache_read: 200,
+                computed_total: 1_300,
+            },
+        );
+
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert_eq!(entries.len(), 1);
+        let usage = entries[0].data.message.usage;
+        assert_eq!(usage.input_tokens, 700);
+        assert_eq!(usage.cache_creation_input_tokens, 100);
+        assert_eq!(usage.cache_read_input_tokens, 200);
+        assert_eq!(crate::total_usage_tokens(usage), 1_300);
     }
 
     #[test]
@@ -256,6 +283,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 100,
                 output_tokens: 10,
+                cache_creation: 0,
                 cache_read: 0,
                 computed_total: 110,
             },
@@ -269,6 +297,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 0,
                 output_tokens: 0,
+                cache_creation: 0,
                 cache_read: 0,
                 computed_total: 0,
             },
@@ -282,6 +311,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 0,
                 output_tokens: 0,
+                cache_creation: 0,
                 cache_read: 0,
                 computed_total: 0,
             },
@@ -291,6 +321,33 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].data.message.id.as_deref(), Some("usage-1"));
+    }
+
+    #[test]
+    fn clamps_cache_reads_to_input_tokens() {
+        let (fixture, db_file) = fixture_with_db();
+        insert_usage(
+            &db_file,
+            "usage-1",
+            "session-a",
+            1_786_909_042_666,
+            "completed",
+            UsageCounts {
+                input_tokens: 10,
+                output_tokens: 5,
+                cache_creation: 0,
+                cache_read: 40,
+                computed_total: 15,
+            },
+        );
+
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert_eq!(entries.len(), 1);
+        let usage = entries[0].data.message.usage;
+        assert_eq!(usage.input_tokens, 0);
+        assert_eq!(usage.cache_read_input_tokens, 10);
+        assert_eq!(crate::total_usage_tokens(usage), 15);
     }
 
     #[test]
@@ -326,6 +383,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 100,
                 output_tokens: 10,
+                cache_creation: 0,
                 cache_read: 0,
                 computed_total: 110,
             },
@@ -343,6 +401,7 @@ mod tests {
             UsageCounts {
                 input_tokens: 50,
                 output_tokens: 5,
+                cache_creation: 0,
                 cache_read: 0,
                 computed_total: 55,
             },

--- a/rust/adapters/zcode/src/loader.rs
+++ b/rust/adapters/zcode/src/loader.rs
@@ -1,0 +1,376 @@
+use std::{collections::HashSet, path::Path, path::PathBuf};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::SharedArgs, debug_log, parse_tz, read_files_parallel,
+};
+
+use super::{
+    parser::{ZcodeUsageRow, row_to_entry},
+    paths::{db_path, paths},
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("ZCode"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let db_paths: Vec<PathBuf> = paths()?.iter().filter_map(|path| db_path(path)).collect();
+    // Load each database in parallel (a fresh read-only connection per DB), then
+    // run the sequential id dedup over the original path order so the surviving
+    // record per id matches the single-threaded read.
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_entries_from_database(db_path, tz.as_ref(), shared, pricing)
+    });
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for db_entries in loaded {
+        for entry in db_entries {
+            if let Some(id) = entry.data.message.id.as_deref()
+                && !seen.insert(id.to_string())
+            {
+                continue;
+            }
+            entries.push(entry);
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_entries_from_database(
+    db_path: &Path,
+    tz: Option<&JiffTimeZone>,
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+) -> Vec<LoadedEntry> {
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        debug_log(
+            shared,
+            format!("Failed to open ZCode database: {}", db_path.display()),
+        );
+        return Vec::new();
+    };
+    let Ok(mut statement) = connection.prepare(
+        "SELECT m.id, m.session_id, m.started_at, m.model_id, \
+         m.input_tokens, m.output_tokens, m.reasoning_tokens, \
+         m.cache_creation_input_tokens, m.cache_read_input_tokens, \
+         m.computed_total_tokens, s.directory, s.version \
+         FROM model_usage m LEFT JOIN session s ON s.id = m.session_id \
+         WHERE m.status = 'completed'",
+    ) else {
+        debug_log(
+            shared,
+            format!("Failed to read ZCode database: {}", db_path.display()),
+        );
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                let row = read_usage_row(&statement);
+                if let Some(entry) = row.and_then(|row| row_to_entry(row, tz, shared.mode, pricing))
+                {
+                    entries.push(entry);
+                }
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => {
+                debug_log(
+                    shared,
+                    format!("Failed to query ZCode database: {}", db_path.display()),
+                );
+                break;
+            }
+        }
+    }
+    entries
+}
+
+fn read_usage_row(statement: &sqlite::Statement<'_>) -> Option<ZcodeUsageRow> {
+    Some(ZcodeUsageRow {
+        id: statement.read::<String, _>(0).ok()?,
+        session_id: statement.read::<String, _>(1).ok()?,
+        started_at: statement.read::<i64, _>(2).ok()?,
+        model_id: statement.read::<String, _>(3).ok()?,
+        input_tokens: read_token_column(statement, 4),
+        output_tokens: read_token_column(statement, 5),
+        // Index 6 is reasoning_tokens, which the parser does not consume.
+        cache_creation_input_tokens: read_token_column(statement, 7),
+        cache_read_input_tokens: read_token_column(statement, 8),
+        computed_total_tokens: read_token_column(statement, 9),
+        directory: statement.read::<Option<String>, _>(10).ok().flatten(),
+        version: statement.read::<Option<String>, _>(11).ok().flatten(),
+    })
+}
+
+fn read_token_column(statement: &sqlite::Statement<'_>, index: usize) -> u64 {
+    statement
+        .read::<i64, _>(index)
+        .map_or(0, |value| value.max(0) as u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use crate::{PricingMap, cli::CostMode};
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    fn create_db(path: &Path) {
+        let db = sqlite::open(path).unwrap();
+        db.execute(
+            "CREATE TABLE model_usage (
+                id TEXT PRIMARY KEY, session_id TEXT, started_at INTEGER, model_id TEXT,
+                status TEXT, input_tokens INTEGER, output_tokens INTEGER,
+                reasoning_tokens INTEGER, cache_creation_input_tokens INTEGER,
+                cache_read_input_tokens INTEGER, computed_total_tokens INTEGER
+            )",
+        )
+        .unwrap();
+        db.execute("CREATE TABLE session (id TEXT PRIMARY KEY, directory TEXT, version TEXT)")
+            .unwrap();
+    }
+
+    struct UsageCounts {
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read: i64,
+        computed_total: i64,
+    }
+
+    fn insert_usage(
+        path: &Path,
+        id: &str,
+        session_id: &str,
+        started_at: i64,
+        status: &str,
+        counts: UsageCounts,
+    ) {
+        let db = sqlite::open(path).unwrap();
+        let mut statement = db
+            .prepare(
+                "INSERT INTO model_usage (id, session_id, started_at, model_id, status,
+                 input_tokens, output_tokens, reasoning_tokens,
+                 cache_creation_input_tokens, cache_read_input_tokens, computed_total_tokens)
+                 VALUES (?1, ?2, ?3, 'GLM-5.3', ?4, ?5, ?6, 0, 0, ?7, ?8)",
+            )
+            .unwrap();
+        statement.bind((1, id)).unwrap();
+        statement.bind((2, session_id)).unwrap();
+        statement.bind((3, started_at)).unwrap();
+        statement.bind((4, status)).unwrap();
+        statement.bind((5, counts.input_tokens)).unwrap();
+        statement.bind((6, counts.output_tokens)).unwrap();
+        statement.bind((7, counts.cache_read)).unwrap();
+        statement.bind((8, counts.computed_total)).unwrap();
+        statement.next().unwrap();
+    }
+
+    fn insert_session(path: &Path, id: &str, directory: &str, version: &str) {
+        let db = sqlite::open(path).unwrap();
+        let mut statement = db
+            .prepare("INSERT INTO session (id, directory, version) VALUES (?1, ?2, ?3)")
+            .unwrap();
+        statement.bind((1, id)).unwrap();
+        statement.bind((2, directory)).unwrap();
+        statement.bind((3, version)).unwrap();
+        statement.next().unwrap();
+    }
+
+    fn fixture_with_db() -> (ccusage_test_support::Fixture, std::path::PathBuf) {
+        let fixture = fs_fixture!({});
+        let _ = fixture.create_dir_all("cli/db");
+        let db_file = fixture.path(super::super::paths::ZCODE_DB_RELATIVE_PATH);
+        create_db(&db_file);
+        (fixture, db_file)
+    }
+
+    fn load(fixture_root: &Path, mode: CostMode) -> Vec<LoadedEntry> {
+        let _cleanup = EnvVarGuard::set(super::super::paths::ZCODE_HOME_ENV, fixture_root);
+        let shared = SharedArgs {
+            mode,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        load_entries(&shared, &PricingMap::load_embedded()).unwrap()
+    }
+
+    #[test]
+    fn carves_cache_reads_out_of_input_tokens_and_prices_the_model() {
+        let (fixture, db_file) = fixture_with_db();
+        insert_session(&db_file, "session-a", "/Users/aaron/code/proj", "0.16.3");
+        // input_tokens includes the cache-read slice; computed = input + output.
+        insert_usage(
+            &db_file,
+            "usage-1",
+            "session-a",
+            1_786_909_042_666,
+            "completed",
+            UsageCounts {
+                input_tokens: 16_507,
+                output_tokens: 59,
+                cache_read: 11_712,
+                computed_total: 16_566,
+            },
+        );
+
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert_eq!(entries.len(), 1);
+        let usage = entries[0].data.message.usage;
+        assert_eq!(usage.input_tokens, 16_507 - 11_712);
+        assert_eq!(usage.output_tokens, 59);
+        assert_eq!(usage.cache_read_input_tokens, 11_712);
+        assert_eq!(usage.cache_creation_input_tokens, 0);
+        assert_eq!(entries[0].date, "2026-08-16");
+        assert_eq!(entries[0].model.as_deref(), Some("glm-5.3"));
+        assert_eq!(entries[0].session_id.as_ref(), "session-a");
+        assert_eq!(entries[0].project_path.as_ref(), "/Users/aaron/code/proj");
+        assert_eq!(entries[0].data.version.as_deref(), Some("0.16.3"));
+        // glm-5.3 is in the embedded pricing snapshot, so the cost derives
+        // from it instead of reporting a missing-pricing model.
+        assert!(entries[0].cost > 0.0);
+        assert!(entries[0].missing_pricing_model.is_none());
+    }
+
+    #[test]
+    fn loads_only_completed_requests() {
+        let (fixture, db_file) = fixture_with_db();
+        insert_usage(
+            &db_file,
+            "usage-1",
+            "session-a",
+            1_786_909_042_666,
+            "completed",
+            UsageCounts {
+                input_tokens: 100,
+                output_tokens: 10,
+                cache_read: 0,
+                computed_total: 110,
+            },
+        );
+        insert_usage(
+            &db_file,
+            "usage-2",
+            "session-a",
+            1_786_909_043_000,
+            "error",
+            UsageCounts {
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read: 0,
+                computed_total: 0,
+            },
+        );
+        insert_usage(
+            &db_file,
+            "usage-3",
+            "session-a",
+            1_786_909_044_000,
+            "cancelled",
+            UsageCounts {
+                input_tokens: 0,
+                output_tokens: 0,
+                cache_read: 0,
+                computed_total: 0,
+            },
+        );
+
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.id.as_deref(), Some("usage-1"));
+    }
+
+    #[test]
+    fn missing_database_returns_no_entries() {
+        let fixture = fs_fixture!({});
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn unexpected_schema_returns_no_entries() {
+        let fixture = fs_fixture!({});
+        let _ = fixture.create_dir_all("cli/db");
+        let db_file = fixture.path(super::super::paths::ZCODE_DB_RELATIVE_PATH);
+        let db = sqlite::open(&db_file).unwrap();
+        db.execute("CREATE TABLE unrelated (id TEXT)").unwrap();
+
+        let entries = load(fixture.root(), CostMode::Auto);
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn deduplicates_usage_rows_across_zcode_homes() {
+        let (first, db_file) = fixture_with_db();
+        insert_usage(
+            &db_file,
+            "usage-1",
+            "session-a",
+            1,
+            "completed",
+            UsageCounts {
+                input_tokens: 100,
+                output_tokens: 10,
+                cache_read: 0,
+                computed_total: 110,
+            },
+        );
+        let second = fs_fixture!({});
+        let _ = second.create_dir_all("cli/db");
+        let second_db = second.path(super::super::paths::ZCODE_DB_RELATIVE_PATH);
+        std::fs::copy(&db_file, &second_db).unwrap();
+        insert_usage(
+            &second_db,
+            "usage-2",
+            "session-a",
+            2,
+            "completed",
+            UsageCounts {
+                input_tokens: 50,
+                output_tokens: 5,
+                cache_read: 0,
+                computed_total: 55,
+            },
+        );
+
+        let _cleanup = EnvVarGuard::set(
+            super::super::paths::ZCODE_HOME_ENV,
+            format!("{},{}", first.root().display(), second.root().display()),
+        );
+        let shared = SharedArgs {
+            mode: CostMode::Auto,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 2);
+        // The first root wins for the shared id.
+        assert_eq!(
+            entries
+                .iter()
+                .find(|entry| entry.data.message.id.as_deref() == Some("usage-1"))
+                .unwrap()
+                .data
+                .message
+                .usage
+                .input_tokens,
+            100
+        );
+    }
+}

--- a/rust/adapters/zcode/src/parser.rs
+++ b/rust/adapters/zcode/src/parser.rs
@@ -25,14 +25,13 @@ pub(super) struct ZcodeUsageRow {
     pub(super) cache_read_input_tokens: u64,
     pub(super) computed_total_tokens: u64,
     pub(super) directory: Option<String>,
-    pub(super) version: Option<String>,
 }
 
 /// Turns a row into a reportable entry.
 ///
-/// ZCode counts cache-read tokens *inside* `input_tokens` (its own
-/// `computed_total_tokens` is `input + output` exactly), so the cache-read
-/// slice is carved out of input to match the additive buckets ccusage reports.
+/// ZCode counts cache tokens *inside* `input_tokens` (its own
+/// `computed_total_tokens` is `input + output` exactly), so the cache slices
+/// are carved out of input to match the additive buckets ccusage reports.
 pub(super) fn row_to_entry(
     row: ZcodeUsageRow,
     tz: Option<&JiffTimeZone>,
@@ -42,11 +41,14 @@ pub(super) fn row_to_entry(
     if row.started_at <= 0 {
         return None;
     }
+    let cache_read_input_tokens = row.cache_read_input_tokens.min(row.input_tokens);
+    let input_tokens = row.input_tokens - cache_read_input_tokens;
+    let cache_creation_input_tokens = row.cache_creation_input_tokens.min(input_tokens);
     let usage = TokenUsageRaw {
-        input_tokens: row.input_tokens.saturating_sub(row.cache_read_input_tokens),
+        input_tokens: input_tokens - cache_creation_input_tokens,
         output_tokens: row.output_tokens,
-        cache_creation_input_tokens: row.cache_creation_input_tokens,
-        cache_read_input_tokens: row.cache_read_input_tokens,
+        cache_creation_input_tokens,
+        cache_read_input_tokens,
         speed: None,
         cache_creation: None,
     };
@@ -59,20 +61,21 @@ pub(super) fn row_to_entry(
     if total_usage_tokens(usage) == 0 && extra_total_tokens == 0 {
         return None;
     }
-    // Pricing keys are matched case-sensitively and the tables store
-    // lowercase ids (`glm-5.3`), while ZCode writes `GLM-5.3`.
-    let model = row.model_id.to_ascii_lowercase();
+    let model = row.model_id.trim().to_string();
+    if model.is_empty() {
+        return None;
+    }
     let timestamp = TimestampMs::from_millis(row.started_at);
     let data = UsageEntry {
         session_id: Some(row.session_id.clone()),
         timestamp: crate::format_rfc3339_millis(timestamp),
-        version: row.version.clone(),
+        version: None,
         message: UsageMessage {
             usage,
             model: Some(model.clone()),
             id: Some(row.id),
         },
-        // ZCode records no per-request cost; every mode derives from pricing.
+        // ZCode records no per-request cost.
         cost_usd: None,
         request_id: None,
         is_api_error_message: None,
@@ -82,24 +85,16 @@ pub(super) fn row_to_entry(
         output_tokens: usage.output_tokens.saturating_add(extra_total_tokens),
         ..usage
     };
-    let cost = if mode == CostMode::Display {
-        0.0
-    } else {
-        calculate_cost_for_usage(
-            Some(&model),
-            cost_usage,
-            None,
-            CostMode::Calculate,
-            Some(pricing),
-        )
-    };
+    let pricing_candidates = model_candidates(&model);
+    let pricing_model = pricing_model(&model, &pricing_candidates, pricing);
+    let cost = calculate_cost_for_usage(pricing_model, cost_usage, None, mode, Some(pricing));
     let missing_pricing_model = if mode == CostMode::Display {
         None
     } else {
         missing_pricing_model_for_candidates(
             &model,
-            [model.clone()],
-            total_usage_tokens(usage),
+            pricing_candidates,
+            total_usage_tokens(cost_usage),
             Some(pricing),
         )
     };
@@ -118,4 +113,93 @@ pub(super) fn row_to_entry(
         message_count: None,
         data,
     })
+}
+
+fn model_candidates(model: &str) -> [String; 4] {
+    let lowercase = model.to_ascii_lowercase();
+    [
+        model.to_string(),
+        format!("zai/{model}"),
+        lowercase.clone(),
+        format!("zai/{lowercase}"),
+    ]
+}
+
+fn pricing_model<'a>(
+    model: &'a str,
+    candidates: &'a [String; 4],
+    pricing: &PricingMap,
+) -> Option<&'a str> {
+    if pricing.find_exact(model).is_some() {
+        return Some(model);
+    }
+
+    // ZCode model ids omit the provider. Prefer Z.ai's provider-qualified
+    // entry before a generic fuzzy match, while preserving an exact raw-id
+    // override above for custom providers.
+    [1, 3, 2, 0].into_iter().find_map(|index| {
+        pricing
+            .find(&candidates[index])
+            .map(|_| candidates[index].as_str())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn row(model_id: &str) -> ZcodeUsageRow {
+        ZcodeUsageRow {
+            id: "usage-1".to_string(),
+            session_id: "session-1".to_string(),
+            started_at: 1_735_689_600_123,
+            model_id: model_id.to_string(),
+            input_tokens: 1_000,
+            output_tokens: 300,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: 200,
+            computed_total_tokens: 1_300,
+            directory: None,
+        }
+    }
+
+    #[test]
+    fn uses_zai_pricing_for_glm_5_2() {
+        let pricing = PricingMap::load_embedded();
+
+        let entry = row_to_entry(row("GLM-5.2"), None, CostMode::Calculate, &pricing).unwrap();
+
+        assert_eq!(entry.model.as_deref(), Some("GLM-5.2"));
+        assert!((entry.cost - 0.002_492).abs() < 1e-12);
+        assert!(entry.missing_pricing_model.is_none());
+    }
+
+    #[test]
+    fn unknown_models_report_missing_pricing() {
+        let pricing = PricingMap::load_embedded();
+
+        let entry = row_to_entry(
+            row("custom-zcode-provider-unknown-v1"),
+            None,
+            CostMode::Auto,
+            &pricing,
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 0.0);
+        assert_eq!(
+            entry.missing_pricing_model.as_deref(),
+            Some("custom-zcode-provider-unknown-v1")
+        );
+    }
+
+    #[test]
+    fn display_mode_reports_zero_without_missing_pricing() {
+        let pricing = PricingMap::load_embedded();
+
+        let entry = row_to_entry(row("GLM-5.2"), None, CostMode::Display, &pricing).unwrap();
+
+        assert_eq!(entry.cost, 0.0);
+        assert!(entry.missing_pricing_model.is_none());
+    }
 }

--- a/rust/adapters/zcode/src/parser.rs
+++ b/rust/adapters/zcode/src/parser.rs
@@ -1,0 +1,121 @@
+use std::sync::Arc;
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    apply_total_token_fallback, calculate_cost_for_usage, cli::CostMode, format_date_tz,
+    missing_pricing_model_for_candidates, total_usage_tokens,
+};
+
+/// One `model_usage` row joined with its session, as read by the loader. Token
+/// counts are already non-negative; the loader clamps negative columns.
+///
+/// `reasoning_tokens` is deliberately not carried: every observed row records
+/// zero and `computed_total_tokens` already encodes any tokens outside the
+/// counted buckets, which the fallback below routes safely.
+pub(super) struct ZcodeUsageRow {
+    pub(super) id: String,
+    pub(super) session_id: String,
+    pub(super) started_at: i64,
+    pub(super) model_id: String,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) computed_total_tokens: u64,
+    pub(super) directory: Option<String>,
+    pub(super) version: Option<String>,
+}
+
+/// Turns a row into a reportable entry.
+///
+/// ZCode counts cache-read tokens *inside* `input_tokens` (its own
+/// `computed_total_tokens` is `input + output` exactly), so the cache-read
+/// slice is carved out of input to match the additive buckets ccusage reports.
+pub(super) fn row_to_entry(
+    row: ZcodeUsageRow,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Option<LoadedEntry> {
+    if row.started_at <= 0 {
+        return None;
+    }
+    let usage = TokenUsageRaw {
+        input_tokens: row.input_tokens.saturating_sub(row.cache_read_input_tokens),
+        output_tokens: row.output_tokens,
+        cache_creation_input_tokens: row.cache_creation_input_tokens,
+        cache_read_input_tokens: row.cache_read_input_tokens,
+        speed: None,
+        cache_creation: None,
+    };
+    // ZCode records no reasoning separately today (computed_total == input +
+    // output, and the carved-out buckets sum back to exactly that). If a future
+    // version moves reasoning outside output, computed_total grows past the
+    // counted buckets and the fallback routes it to the extra bucket.
+    let (usage, extra_total_tokens) =
+        apply_total_token_fallback(usage, 0, row.computed_total_tokens);
+    if total_usage_tokens(usage) == 0 && extra_total_tokens == 0 {
+        return None;
+    }
+    // Pricing keys are matched case-sensitively and the tables store
+    // lowercase ids (`glm-5.3`), while ZCode writes `GLM-5.3`.
+    let model = row.model_id.to_ascii_lowercase();
+    let timestamp = TimestampMs::from_millis(row.started_at);
+    let data = UsageEntry {
+        session_id: Some(row.session_id.clone()),
+        timestamp: crate::format_rfc3339_millis(timestamp),
+        version: row.version.clone(),
+        message: UsageMessage {
+            usage,
+            model: Some(model.clone()),
+            id: Some(row.id),
+        },
+        // ZCode records no per-request cost; every mode derives from pricing.
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    let cost_usage = TokenUsageRaw {
+        output_tokens: usage.output_tokens.saturating_add(extra_total_tokens),
+        ..usage
+    };
+    let cost = if mode == CostMode::Display {
+        0.0
+    } else {
+        calculate_cost_for_usage(
+            Some(&model),
+            cost_usage,
+            None,
+            CostMode::Calculate,
+            Some(pricing),
+        )
+    };
+    let missing_pricing_model = if mode == CostMode::Display {
+        None
+    } else {
+        missing_pricing_model_for_candidates(
+            &model,
+            [model.clone()],
+            total_usage_tokens(usage),
+            Some(pricing),
+        )
+    };
+    Some(LoadedEntry {
+        date: format_date_tz(timestamp, tz),
+        timestamp,
+        project: Arc::from("zcode"),
+        session_id: Arc::from(row.session_id),
+        project_path: Arc::from(row.directory.as_deref().unwrap_or("ZCode")),
+        cost,
+        extra_total_tokens,
+        credits: None,
+        model: Some(model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        message_count: None,
+        data,
+    })
+}

--- a/rust/adapters/zcode/src/paths.rs
+++ b/rust/adapters/zcode/src/paths.rs
@@ -12,7 +12,9 @@ pub(super) const ZCODE_DB_RELATIVE_PATH: &str = "cli/db/db.sqlite";
 pub(super) fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
-    if let Ok(env_paths) = env::var(ZCODE_HOME_ENV) {
+    if let Ok(env_paths) = env::var(ZCODE_HOME_ENV)
+        && !env_paths.trim().is_empty()
+    {
         for raw in env_paths
             .split(',')
             .map(str::trim)
@@ -38,4 +40,26 @@ pub(super) fn paths() -> Result<Vec<PathBuf>> {
 pub(super) fn db_path(zcode_home: &Path) -> Option<PathBuf> {
     let path = zcode_home.join(ZCODE_DB_RELATIVE_PATH);
     path.is_file().then_some(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
+
+    use super::*;
+
+    #[test]
+    fn empty_zcode_home_falls_back_to_default_home() {
+        let fixture = fs_fixture!({ ".zcode/placeholder": "" });
+        let home = OsString::from(fixture.root().as_os_str());
+        let _guard = EnvVarsGuard::set_many([
+            (ZCODE_HOME_ENV, Some(OsString::from("  "))),
+            ("HOME", Some(home.clone())),
+            ("USERPROFILE", Some(home)),
+        ]);
+
+        assert_eq!(paths().unwrap(), vec![fixture.path(".zcode")]);
+    }
 }

--- a/rust/adapters/zcode/src/paths.rs
+++ b/rust/adapters/zcode/src/paths.rs
@@ -1,0 +1,41 @@
+use std::{
+    collections::HashSet,
+    env,
+    path::{Path, PathBuf},
+};
+
+use crate::Result;
+
+pub(super) const ZCODE_HOME_ENV: &str = "ZCODE_HOME";
+pub(super) const ZCODE_DB_RELATIVE_PATH: &str = "cli/db/db.sqlite";
+
+pub(super) fn paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    if let Ok(env_paths) = env::var(ZCODE_HOME_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+        return Ok(paths);
+    }
+
+    if let Some(home) = crate::home::home_dir() {
+        let path = home.join(".zcode");
+        if path.is_dir() && seen.insert(path.clone()) {
+            paths.push(path);
+        }
+    }
+    Ok(paths)
+}
+
+pub(super) fn db_path(zcode_home: &Path) -> Option<PathBuf> {
+    let path = zcode_home.join(ZCODE_DB_RELATIVE_PATH);
+    path.is_file().then_some(path)
+}

--- a/rust/adapters/zcode/src/report.rs
+++ b/rust/adapters/zcode/src/report.rs
@@ -1,0 +1,167 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, kind == AgentReportKind::Session))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        // Accumulating rather than grouping by key is what carries the activity
+        // range and project path onto the row, which the session table and JSON
+        // both report.
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(SessionAccumulator::into_summary)
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage};
+
+    fn entry(
+        session_id: &str,
+        date: &str,
+        millis: i64,
+        input: u64,
+        cache_read: u64,
+    ) -> LoadedEntry {
+        let timestamp = TimestampMs::from_millis(millis);
+        LoadedEntry {
+            data: UsageEntry {
+                session_id: Some(session_id.to_string()),
+                timestamp: format!("{date}T12:43:06.355Z"),
+                version: Some("0.16.3".to_string()),
+                message: UsageMessage {
+                    usage: TokenUsageRaw {
+                        input_tokens: input,
+                        output_tokens: 20,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: cache_read,
+                        speed: None,
+                        cache_creation: None,
+                    },
+                    model: Some("glm-5.3".to_string()),
+                    id: Some(format!("usage-{millis}")),
+                },
+                cost_usd: None,
+                request_id: None,
+                is_api_error_message: None,
+                is_sidechain: None,
+            },
+            timestamp,
+            date: date.to_string(),
+            project: Arc::from("zcode"),
+            session_id: Arc::from(session_id),
+            project_path: Arc::from("/work/proj"),
+            cost: 0.01,
+            credits: None,
+            model: Some("glm-5.3".to_string()),
+            usage_limit_reset_time: None,
+            missing_pricing_model: None,
+            extra_total_tokens: 0,
+            message_count: None,
+        }
+    }
+
+    #[test]
+    fn reports_cache_reads_separately_from_input_tokens() {
+        let rows = summarize_entries(
+            &[entry("sess-a", "2026-08-16", 1_786_909_042_666, 60, 40)],
+            AgentReportKind::Daily,
+        )
+        .unwrap();
+        let report = report_from_rows(&rows, AgentReportKind::Daily);
+
+        assert_eq!(report["daily"][0]["inputTokens"], 60);
+        assert_eq!(report["daily"][0]["outputTokens"], 20);
+        assert_eq!(report["daily"][0]["cacheReadTokens"], 40);
+        assert_eq!(report["daily"][0]["totalTokens"], 120);
+    }
+
+    #[test]
+    fn session_rows_carry_activity_range_and_project_path() {
+        let rows = summarize_entries(
+            &[
+                entry("sess-a", "2026-08-16", 1_786_909_042_000, 60, 0),
+                entry("sess-a", "2026-08-17", 1_786_995_442_000, 40, 20),
+            ],
+            AgentReportKind::Session,
+        )
+        .unwrap();
+        let report = report_from_rows(&rows, AgentReportKind::Session);
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(report["sessions"][0]["sessionId"], "sess-a");
+        assert_eq!(report["sessions"][0]["projectPath"], "/work/proj");
+        assert_eq!(
+            report["sessions"][0]["firstActivity"],
+            "2026-08-16T19:37:22.000Z"
+        );
+        assert_eq!(
+            report["sessions"][0]["lastActivity"],
+            "2026-08-17T19:37:22.000Z"
+        );
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -22,6 +22,7 @@ ccusage-adapter-openclaw.workspace = true
 ccusage-adapter-opencode.workspace = true
 ccusage-adapter-pi.workspace = true
 ccusage-adapter-qwen.workspace = true
+ccusage-adapter-zcode.workspace = true
 ccusage-cli.workspace = true
 ccusage-core.workspace = true
 serde.workspace = true

--- a/rust/crates/ccusage-adapter-all/README.md
+++ b/rust/crates/ccusage-adapter-all/README.md
@@ -10,7 +10,7 @@ into one table or JSON document.
 - `report.rs` — the unified row and total shapes.
 - `types.rs` — the accumulators the merge needs.
 
-This is the only crate that depends on all 16 adapters, which keeps the adapters
+This is the only crate that depends on all 17 adapters, which keeps the adapters
 themselves independent of each other.
 
 ## Public surface
@@ -29,6 +29,7 @@ themselves independent of each other.
 - `ccusage-adapter-gemini`
 - `ccusage-adapter-goose`
 - `ccusage-adapter-grok`
+- `ccusage-adapter-zcode`
 - `ccusage-adapter-hermes`
 - `ccusage-adapter-kilo`
 - `ccusage-adapter-kimi`

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -25,6 +25,7 @@ mod adapter {
     pub use ccusage_adapter_opencode as opencode;
     pub use ccusage_adapter_pi as pi;
     pub use ccusage_adapter_qwen as qwen;
+    pub use ccusage_adapter_zcode as zcode;
 }
 
 use crate::{

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -12,7 +12,7 @@ use crate::{
     SessionAccumulator, UsageSummary,
     adapter::{
         amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        openclaw, opencode, pi, qwen, zcode,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -323,6 +323,21 @@ fn load_base_rows(
                 )?;
                 rows.detected = rows.detected || grok::has_data();
                 Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("ZCode"),
+            load: Box::new(|| {
+                load_priced_summary_agent_rows(
+                    "zcode",
+                    load_kind,
+                    &loader_shared,
+                    pricing,
+                    zcode::load_entries,
+                    zcode::summarize_entries,
+                )
             }),
         },
     ];

--- a/rust/crates/ccusage-adapter-all/src/report.rs
+++ b/rust/crates/ccusage-adapter-all/src/report.rs
@@ -590,6 +590,7 @@ fn agent_label(agent: &str) -> &str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "grok" => "Grok",
+        "zcode" => "ZCode",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -560,6 +560,7 @@ fn isolated_agent_env(
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
         "GROK_HOME",
+        "ZCODE_HOME",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -104,6 +104,10 @@
 			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
+			},
+			{
+				"name": "zcode",
+				"description": "Show ZCode usage commands"
 			}
 		]
 	},
@@ -774,6 +778,43 @@
 			"path": ["grok", "session"],
 			"description": "Show Grok Build CLI usage grouped by session",
 			"usage": "ccusage grok session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["zcode"],
+			"description": "Usage reports for zcode.",
+			"usage": "ccusage zcode <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show ZCode usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show ZCode usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show ZCode usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["zcode", "daily"],
+			"description": "Show ZCode usage grouped by date",
+			"usage": "ccusage zcode daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["zcode", "monthly"],
+			"description": "Show ZCode usage grouped by month",
+			"usage": "ccusage zcode monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["zcode", "session"],
+			"description": "Show ZCode usage grouped by session",
+			"usage": "ccusage zcode session <OPTIONS>",
 			"options": "agent_options"
 		}
 	]

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -340,6 +340,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Grok,
         ),
+        "zcode" => parse_basic_agent_command(
+            parser,
+            shared,
+            "zcode",
+            STANDARD_AGENT_REPORTS,
+            Command::ZCode,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -771,6 +778,7 @@ fn is_command(arg: &str) -> bool {
             | "kimi"
             | "qwen"
             | "grok"
+            | "zcode"
     )
 }
 
@@ -931,6 +939,7 @@ fn is_agent_command(command: &str) -> bool {
             | "qwen"
             | "openclaw"
             | "grok"
+            | "zcode"
     )
 }
 
@@ -943,7 +952,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" | "zcode" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -968,6 +977,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
+        "zcode" => "ZCode",
         _ => unreachable!("agent is prevalidated"),
     }
 }
@@ -1048,7 +1058,8 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::ZCode(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };
     shared.last?;

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -29,6 +29,7 @@ COMMANDS:
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
   grok                       Show Grok Build CLI usage commands
+  zcode                      Show ZCode usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -53,6 +54,7 @@ For more info, run any command with the `--help` flag:
   ccusage qwen --help
   ccusage openclaw --help
   ccusage grok --help
+  ccusage zcode --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
@@ -437,6 +437,58 @@ expression: cases
     }
   },
   {
+    "case": "zcode daily",
+    "cli": {
+      "command": {
+        "byAgent": false,
+        "codexSpeed": "Auto",
+        "kind": "Daily",
+        "openClawPath": null,
+        "piPath": null,
+        "sections": null,
+        "shared": {
+          "breakdown": false,
+          "color": false,
+          "compact": false,
+          "config": null,
+          "debug": false,
+          "debugSamples": 5,
+          "jq": null,
+          "json": true,
+          "mode": "Auto",
+          "noColor": false,
+          "noOffline": false,
+          "offline": false,
+          "order": "Asc",
+          "since": null,
+          "singleThread": false,
+          "timezone": null,
+          "until": null
+        },
+        "type": "zcode"
+      },
+      "shared": {
+        "breakdown": false,
+        "color": false,
+        "compact": false,
+        "config": null,
+        "debug": false,
+        "debugSamples": 5,
+        "jq": null,
+        "json": false,
+        "mode": "Auto",
+        "noColor": false,
+        "noOffline": false,
+        "offline": false,
+        "order": "Asc",
+        "since": null,
+        "singleThread": false,
+        "timezone": null,
+        "until": null
+      }
+    }
+  },
+  {
     "case": "blocks active recent",
     "cli": {
       "command": {

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -205,6 +205,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
+        Some(Command::ZCode(args)) => agent_command_snapshot("zcode", args),
     }
 }
 
@@ -647,7 +648,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok", "zcode",
     ];
 
     for agent in agents {
@@ -862,6 +863,10 @@ fn snapshots_representative_cli_parse_shapes() {
         json!({
             "case": "grok daily",
             "cli": cli_snapshot(parse(&["ccusage", "grok", "daily", "--json"])),
+        }),
+        json!({
+            "case": "zcode daily",
+            "cli": cli_snapshot(parse(&["ccusage", "zcode", "daily", "--json"])),
         }),
         json!({
             "case": "blocks active recent",
@@ -1246,6 +1251,16 @@ fn parses_grok_daily_options() {
     let cli = parse(&["ccusage", "grok", "daily", "--json"]);
     let Some(Command::Grok(args)) = cli.command else {
         panic!("expected grok command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn parses_zcode_daily_options() {
+    let cli = parse(&["ccusage", "zcode", "daily", "--json"]);
+    let Some(Command::ZCode(args)) = cli.command else {
+        panic!("expected zcode command");
     };
     assert_eq!(args.kind, AgentReportKind::Daily);
     assert!(args.shared.json);

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -1257,16 +1257,6 @@ fn parses_grok_daily_options() {
 }
 
 #[test]
-fn parses_zcode_daily_options() {
-    let cli = parse(&["ccusage", "zcode", "daily", "--json"]);
-    let Some(Command::ZCode(args)) = cli.command else {
-        panic!("expected zcode command");
-    };
-    assert_eq!(args.kind, AgentReportKind::Daily);
-    assert!(args.shared.json);
-}
-
-#[test]
 fn rejects_grok_path_option() {
     let error = parse_error(&["ccusage", "grok", "daily", "--grok-path", "/tmp/grok-home"]);
 

--- a/rust/crates/ccusage-cli/README.md
+++ b/rust/crates/ccusage-cli/README.md
@@ -4,7 +4,7 @@ The plain argument types the runtime shares: `SharedArgs`, the per-command
 argument structs, and the enums the reports switch on.
 
 This crate deliberately has no dependencies, no build script, and no embedded
-assets. `ccusage-core` and all 16 adapters depend on it, so anything heavier
+assets. `ccusage-core` and all 17 adapters depend on it, so anything heavier
 would sit on every crate's critical path — that is why the parser, the help
 renderer, and the help JSON live in `ccusage-cli-parser` instead.
 

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    ZCode(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -995,27 +995,6 @@ mod tests {
     }
 
     #[test]
-    fn zcode_namespace_keeps_shared_report_options() {
-        let config = context(
-            json!({
-                "zcode": {
-                    "defaults": { "offline": true },
-                    "commands": { "session": { "json": true } }
-                }
-            }),
-            "zcode session",
-            Some("zcode"),
-            "session",
-        );
-        let mut shared = SharedArgs::default();
-
-        apply_config_to_shared(&mut shared, &config);
-
-        assert!(shared.offline);
-        assert!(shared.json);
-    }
-
-    #[test]
     fn grok_namespace_keeps_shared_report_options() {
         let config = context(
             json!({

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -995,6 +995,27 @@ mod tests {
     }
 
     #[test]
+    fn zcode_namespace_keeps_shared_report_options() {
+        let config = context(
+            json!({
+                "zcode": {
+                    "defaults": { "offline": true },
+                    "commands": { "session": { "json": true } }
+                }
+            }),
+            "zcode session",
+            Some("zcode"),
+            "session",
+        );
+        let mut shared = SharedArgs::default();
+
+        apply_config_to_shared(&mut shared, &config);
+
+        assert!(shared.offline);
+        assert!(shared.json);
+    }
+
+    #[test]
     fn grok_namespace_keeps_shared_report_options() {
         let config = context(
             json!({

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -52,6 +52,8 @@ pub struct CcusageConfig {
     pub qwen: Option<QwenConfig>,
     /// Grok Build CLI configuration.
     pub grok: Option<GrokConfig>,
+    /// ZCode configuration.
+    pub zcode: Option<ZCodeConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -316,6 +318,21 @@ pub struct GrokConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GrokCommandsConfig {
+    pub daily: Option<SharedOptions>,
+    pub monthly: Option<SharedOptions>,
+    pub session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ZCodeConfig {
+    pub defaults: Option<SharedOptions>,
+    pub commands: Option<ZCodeCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ZCodeCommandsConfig {
     pub daily: Option<SharedOptions>,
     pub monthly: Option<SharedOptions>,
     pub session: Option<SharedOptions>,
@@ -1093,6 +1110,7 @@ mod tests {
             &with_keys(&shared, &["openClawPath"]),
         );
         assert_schema_properties(&schema, &["grok", "defaults"], &shared);
+        assert_schema_properties(&schema, &["zcode", "defaults"], &shared);
     }
 
     #[test]
@@ -1148,7 +1166,7 @@ mod tests {
             &[
                 "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
                 "droid", "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode",
-                "openclaw", "pi", "qwen",
+                "openclaw", "pi", "qwen", "zcode",
             ],
         );
         assert!(
@@ -1431,6 +1449,7 @@ mod tests {
             "piDefaults": schema_node(&schema, &["pi", "defaults"]),
             "openclawDefaults": schema_node(&schema, &["openclaw", "defaults"]),
             "grokDefaults": schema_node(&schema, &["grok", "defaults"]),
+            "zcodeDefaults": schema_node(&schema, &["zcode", "defaults"]),
         }));
     }
 

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/ccusage-config/src/config_schema.rs
-expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]), \"grokDefaults\":\n    schema_node(&schema, &[\"grok\", \"defaults\"]),\n})"
+expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n    definition_properties(&schema, \"ccusage-config\"),\n    \"rootAdditionalProperties\":\n    schema[\"definitions\"][\"ccusage-config\"][\"additionalProperties\"],\n    \"defaults\": schema_node(&schema, &[\"defaults\"]), \"rootDaily\":\n    schema_node(&schema, &[\"commands\", \"daily\"]), \"claudeStatusline\":\n    schema_node(&schema, &[\"claude\", \"commands\", \"statusline\"]),\n    \"codexDefaults\": schema_node(&schema, &[\"codex\", \"defaults\"]),\n    \"opencodeWeekly\":\n    schema_node(&schema, &[\"opencode\", \"commands\", \"weekly\"]), \"piDefaults\":\n    schema_node(&schema, &[\"pi\", \"defaults\"]), \"openclawDefaults\":\n    schema_node(&schema, &[\"openclaw\", \"defaults\"]), \"grokDefaults\":\n    schema_node(&schema, &[\"grok\", \"defaults\"]), \"zcodeDefaults\":\n    schema_node(&schema, &[\"zcode\", \"defaults\"]),\n})"
 ---
 {
   "claudeStatusline": {
@@ -1313,7 +1313,181 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
     "openclaw",
     "opencode",
     "pi",
-    "qwen"
+    "qwen",
+    "zcode"
   ],
-  "rootRef": "#/definitions/ccusage-config"
+  "rootRef": "#/definitions/ccusage-config",
+  "zcodeDefaults": {
+    "additionalProperties": false,
+    "properties": {
+      "all": {
+        "default": false,
+        "description": "Accepted for compatibility; all detected supported agents are included by default.",
+        "markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+        "type": "boolean"
+      },
+      "breakdown": {
+        "default": false,
+        "description": "Show per-model cost breakdown.",
+        "markdownDescription": "Show per-model cost breakdown.",
+        "type": "boolean"
+      },
+      "color": {
+        "default": false,
+        "description": "Enable colored output.",
+        "markdownDescription": "Enable colored output.",
+        "type": "boolean"
+      },
+      "compact": {
+        "default": false,
+        "description": "Force compact table layout for narrow terminals.",
+        "markdownDescription": "Force compact table layout for narrow terminals.",
+        "type": "boolean"
+      },
+      "debug": {
+        "default": false,
+        "description": "Show pricing mismatch information for debugging.",
+        "markdownDescription": "Show pricing mismatch information for debugging.",
+        "type": "boolean"
+      },
+      "debugSamples": {
+        "default": 5,
+        "description": "Number of sample discrepancies to show in debug output.",
+        "format": "uint",
+        "markdownDescription": "Number of sample discrepancies to show in debug output.",
+        "minimum": 0.0,
+        "type": "integer"
+      },
+      "jq": {
+        "description": "jq filter to apply to JSON output.",
+        "markdownDescription": "jq filter to apply to JSON output.",
+        "type": "string"
+      },
+      "json": {
+        "default": false,
+        "description": "Output in JSON format.",
+        "markdownDescription": "Output in JSON format.",
+        "type": "boolean"
+      },
+      "mode": {
+        "default": "auto",
+        "description": "Cost calculation mode.",
+        "enum": [
+          "auto",
+          "calculate",
+          "display"
+        ],
+        "markdownDescription": "Cost calculation mode.",
+        "type": "string"
+      },
+      "noColor": {
+        "default": false,
+        "description": "Disable colored output.",
+        "markdownDescription": "Disable colored output.",
+        "type": "boolean"
+      },
+      "noCost": {
+        "default": false,
+        "description": "Hide cost information in table and JSON output.",
+        "markdownDescription": "Hide cost information in table and JSON output.",
+        "type": "boolean"
+      },
+      "noOffline": {
+        "default": false,
+        "description": "Disable cached pricing data where supported.",
+        "markdownDescription": "Disable cached pricing data where supported.",
+        "type": "boolean"
+      },
+      "offline": {
+        "default": false,
+        "description": "Use cached pricing data where supported.",
+        "markdownDescription": "Use cached pricing data where supported.",
+        "type": "boolean"
+      },
+      "order": {
+        "default": "asc",
+        "description": "Sort order.",
+        "enum": [
+          "desc",
+          "asc"
+        ],
+        "markdownDescription": "Sort order.",
+        "type": "string"
+      },
+      "pricingOverrides": {
+        "additionalProperties": {
+          "additionalProperties": false,
+          "properties": {
+            "cacheCreationInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheCreationInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "fastMultiplier": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "maxInputTokens": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "outputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "outputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "description": "Runtime pricing overrides keyed by raw model name.",
+        "markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+        "type": "object"
+      },
+      "since": {
+        "description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+        "markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+        "type": "string"
+      },
+      "singleThread": {
+        "default": false,
+        "description": "Disable parallel file processing.",
+        "markdownDescription": "Disable parallel file processing.",
+        "type": "boolean"
+      },
+      "timezone": {
+        "description": "Timezone for date grouping (IANA).",
+        "markdownDescription": "Timezone for date grouping (IANA).",
+        "type": "string"
+      },
+      "until": {
+        "description": "Filter until date (inclusive).",
+        "markdownDescription": "Filter until date (inclusive).",
+        "type": "string"
+      }
+    },
+    "type": "object"
+  }
 }

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok", "zcode",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -26,6 +26,7 @@ ccusage-adapter-droid.workspace = true
 ccusage-adapter-gemini.workspace = true
 ccusage-adapter-goose.workspace = true
 ccusage-adapter-grok.workspace = true
+ccusage-adapter-zcode.workspace = true
 ccusage-adapter-hermes.workspace = true
 ccusage-adapter-kilo.workspace = true
 ccusage-adapter-kimi.workspace = true

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -15,3 +15,4 @@ pub(crate) use ccusage_adapter_openclaw as openclaw;
 pub(crate) use ccusage_adapter_opencode as opencode;
 pub(crate) use ccusage_adapter_pi as pi;
 pub(crate) use ccusage_adapter_qwen as qwen;
+pub(crate) use ccusage_adapter_zcode as zcode;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,7 +49,8 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::ZCode(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,
     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::ZCode(args)) => adapter::zcode::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,7 +87,7 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
@@ -102,9 +103,10 @@ mod tests {
             ccusage_adapter_opencode::run,
             ccusage_adapter_pi::run,
             ccusage_adapter_qwen::run,
+            ccusage_adapter_zcode::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Add ZCode as a first-class ccusage data source for daily, monthly, session, and unified reports.

ZCode stores completed model usage in a local SQLite database. This adapter reads that database in read-only mode, normalizes ZCode's inclusive cache-token accounting into ccusage's additive token buckets, and estimates costs from the shared pricing tables.

## What changed

- add the Rust ZCode adapter and wire it into focused and unified reports
- discover `$ZCODE_HOME/cli/db/db.sqlite` (including multiple roots), with `~/.zcode` as the default
- load completed requests, deduplicate rows across roots, and preserve raw model labels
- support the confirmed legacy `session(id, directory)` schema without requiring a `version` column
- carve cache-read and cache-creation tokens out of ZCode's inclusive `input_tokens`
- prefer provider-qualified Z.ai pricing while honoring exact raw-model overrides
- add CLI/config schema integration, fixtures, snapshots, and user documentation
- document that `--mode display` is zero because ZCode records no per-request cost

## Validation

- `cargo test -p ccusage-adapter-zcode -p ccusage-cli-parser -p ccusage-config -p ccusage-adapter-all -p ccusage`
- `cargo clippy -p ccusage-adapter-zcode --all-targets -- -D warnings`
- `pnpm --dir docs build`
- `cargo fmt --all -- --check`
- `git diff --check`

## Context

Closes #1595.

The schema/token-accounting investigation and earlier implementation in [axisrow/ccusage#1](https://github.com/axisrow/ccusage/pull/1) were useful prior art. This implementation targets ccusage's current per-adapter Rust architecture and adds compatibility and pricing behavior for the schemas and models reported in that thread.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ZCode as a supported data source.
  * Added daily, monthly, and session usage reports with JSON and formatted output.
  * Added token, cache, pricing, date filtering, and parallel-processing options.
  * Added support for custom ZCode data locations through `ZCODE_HOME`.
  * Added ZCode configuration options and unified reporting support.

* **Documentation**
  * Added comprehensive ZCode setup, reporting, configuration, and troubleshooting guidance.
  * Updated supported-source lists and examples throughout the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->