### PR TITLE
feat: include projectPath (workdir) in session reports for all agents

### DIFF
--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -524,7 +524,10 @@ fn load_summary_agent_rows(
     filter_loaded_entries_by_date(&mut entries, shared);
     let summaries = summarize_entries(&entries, kind)?;
     Ok(AgentRows {
-        rows: summary_rows(agent, summaries, false),
+        // Include projectPath (workdir) in session reports for every agent.
+        // summary_metadata() only emits it when a session_id is present, so
+        // daily/weekly/monthly aggregate rows are unaffected.
+        rows: summary_rows(agent, summaries, true),
         detected,
     })
 }
@@ -597,7 +600,7 @@ fn load_claude_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentR
         let mut summaries = summarize_entry_sessions(&entries)?;
         filter_session_summaries(&mut summaries, shared);
         return Ok(AgentRows {
-            rows: summary_rows("claude", summaries, false),
+            rows: summary_rows("claude", summaries, true),
             detected,
         });
     }
@@ -678,7 +681,7 @@ fn load_qwen_rows(kind: AgentReportKind, shared: &SharedArgs) -> Result<AgentRow
         let mut summaries = qwen::summarize_entries(&entries, kind)?;
         filter_session_summaries(&mut summaries, shared);
         return Ok(AgentRows {
-            rows: summary_rows("qwen", summaries, false),
+            rows: summary_rows("qwen", summaries, true),
             detected,
         });
     }


### PR DESCRIPTION
## Summary

Only the **pi** adapter was emitting `projectPath` (the workdir) in session reports, because the generic / claude / qwen loaders passed `include_project_path = false` to `summary_rows()`.

This PR flips those session-report call sites to `true`, so **all agents** get `metadata.projectPath` in `ccusage session --json`.

## Why

Tools built on top of ccusage (like dashboards) want to group sessions by working directory. Today that data only exists for pi — claude / openclaw / codex / qwen sessions are just opaque IDs.

## Safety

`summary_metadata()` already gates the field on `summary.session_id.is_some()`:

```rust
if summary.session_id.is_some() {
    ...
    if include_project_path && let Some(project_path) = summary.project_path.as_ref() {
        metadata.insert("projectPath".to_string(), json!(project_path));
    }
}
```

So daily / weekly / monthly aggregate rows (no session_id) are **unchanged**. Only session reports gain the field.

## Verified

- `cargo check -p ccusage-adapter-all` passes
- `cargo test -p ccusage-adapter-all --no-run` compiles
- Diff is 6 insertions / 3 deletions across a single file

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include metadata.projectPath (workdir) in session reports for all agents; previously only pi emitted it. Aggregated daily/weekly/monthly reports remain unchanged because the field only appears when a session_id is present.

- Affects `ccusage session --json` only; aggregated reports are unaffected.
- Changes are limited to `rust/crates/ccusage-adapter-all/src/loader.rs`, flipping include_project_path to true in three call sites.
- Dashboards can now group all agents’ sessions by working directory; no migration required.

<sup>Written for commit 39050983e5134cf613d230e69ce39dab69f71e24. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Session usage records now include project path metadata for improved context.
  * Applies to generic summaries, Claude, and Qwen session records.
  * Aggregate usage records remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->