### PR TITLE
feat: add Antigravity (agy) usage adapter

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -75,7 +75,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -106,7 +110,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -241,7 +248,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -272,7 +283,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -407,7 +421,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -438,7 +456,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -576,7 +597,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -607,7 +632,716 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
+				"antigravity": {
+					"additionalProperties": false,
+					"description": "Antigravity configuration.",
+					"markdownDescription": "Antigravity configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"default": false,
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -750,7 +1484,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -776,7 +1514,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -924,7 +1665,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -950,7 +1695,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1094,7 +1842,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1125,7 +1877,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1260,7 +2015,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1291,7 +2050,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1399,7 +2161,12 @@
 										"costSource": {
 											"default": "auto",
 											"description": "Source for statusline cost calculation.",
-											"enum": ["auto", "ccusage", "cc", "both"],
+											"enum": [
+												"auto",
+												"ccusage",
+												"cc",
+												"both"
+											],
 											"markdownDescription": "Source for statusline cost calculation.",
 											"type": "string"
 										},
@@ -1451,7 +2218,12 @@
 										"visualBurnRate": {
 											"default": "off",
 											"description": "Visual burn-rate display mode.",
-											"enum": ["off", "emoji", "text", "emoji-text"],
+											"enum": [
+												"off",
+												"emoji",
+												"text",
+												"emoji-text"
+											],
 											"markdownDescription": "Visual burn-rate display mode.",
 											"type": "string"
 										}
@@ -1505,7 +2277,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1531,7 +2307,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1677,7 +2456,12 @@
 								},
 								"costSource": {
 									"description": "Source for statusline cost calculation.",
-									"enum": ["auto", "ccusage", "cc", "both"],
+									"enum": [
+										"auto",
+										"ccusage",
+										"cc",
+										"both"
+									],
 									"markdownDescription": "Source for statusline cost calculation.",
 									"type": "string"
 								},
@@ -1710,7 +2494,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -1749,7 +2537,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -1874,7 +2665,12 @@
 								},
 								"visualBurnRate": {
 									"description": "Visual burn-rate display mode.",
-									"enum": ["off", "emoji", "text", "emoji-text"],
+									"enum": [
+										"off",
+										"emoji",
+										"text",
+										"emoji-text"
+									],
 									"markdownDescription": "Visual burn-rate display mode.",
 									"type": "string"
 								}
@@ -1947,7 +2743,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1978,7 +2778,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2113,7 +2916,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2144,7 +2951,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2279,7 +3089,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2310,7 +3124,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2448,7 +3265,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -2479,7 +3300,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -2617,7 +3441,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2643,7 +3471,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2712,7 +3543,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -2776,7 +3611,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2802,7 +3641,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2871,7 +3713,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -2935,7 +3781,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2961,7 +3811,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -3030,7 +3883,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -3097,7 +3954,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3123,7 +3984,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3192,7 +4056,11 @@
 								"speed": {
 									"default": "auto",
 									"description": "Codex speed normalization strategy.",
-									"enum": ["auto", "standard", "fast"],
+									"enum": [
+										"auto",
+										"standard",
+										"fast"
+									],
 									"markdownDescription": "Codex speed normalization strategy.",
 									"type": "string"
 								},
@@ -3269,7 +4137,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3295,7 +4167,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3443,7 +4318,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3469,7 +4348,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3613,7 +4495,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3644,7 +4530,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3779,7 +4668,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3810,7 +4703,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3918,7 +4814,12 @@
 								"costSource": {
 									"default": "auto",
 									"description": "Source for statusline cost calculation.",
-									"enum": ["auto", "ccusage", "cc", "both"],
+									"enum": [
+										"auto",
+										"ccusage",
+										"cc",
+										"both"
+									],
 									"markdownDescription": "Source for statusline cost calculation.",
 									"type": "string"
 								},
@@ -3970,7 +4871,12 @@
 								"visualBurnRate": {
 									"default": "off",
 									"description": "Visual burn-rate display mode.",
-									"enum": ["off", "emoji", "text", "emoji-text"],
+									"enum": [
+										"off",
+										"emoji",
+										"text",
+										"emoji-text"
+									],
 									"markdownDescription": "Visual burn-rate display mode.",
 									"type": "string"
 								}
@@ -4024,7 +4930,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -4050,7 +4960,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -4210,7 +5123,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4241,7 +5158,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4376,7 +5296,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4407,7 +5331,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4542,7 +5469,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4573,7 +5504,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4711,7 +5645,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -4742,7 +5680,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -4882,7 +5823,11 @@
 						"mode": {
 							"default": "auto",
 							"description": "Cost calculation mode.",
-							"enum": ["auto", "calculate", "display"],
+							"enum": [
+								"auto",
+								"calculate",
+								"display"
+							],
 							"markdownDescription": "Cost calculation mode.",
 							"type": "string"
 						},
@@ -4913,7 +5858,10 @@
 						"order": {
 							"default": "asc",
 							"description": "Sort order.",
-							"enum": ["desc", "asc"],
+							"enum": [
+								"desc",
+								"asc"
+							],
 							"markdownDescription": "Sort order.",
 							"type": "string"
 						},
@@ -5056,7 +6004,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5087,7 +6039,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5222,7 +6177,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5253,7 +6212,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5388,7 +6350,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5419,7 +6385,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5557,7 +6526,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -5588,7 +6561,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -5734,7 +6710,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5765,7 +6745,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5900,7 +6883,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5931,7 +6918,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6066,7 +7056,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6097,7 +7091,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6235,7 +7232,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -6266,7 +7267,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -6412,7 +7416,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6443,7 +7451,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6578,7 +7589,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6609,7 +7624,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6744,7 +7762,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6775,7 +7797,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6913,7 +7938,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -6944,7 +7973,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -7090,7 +8122,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7121,7 +8157,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7256,7 +8295,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7287,7 +8330,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7422,7 +8468,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7453,7 +8503,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7591,7 +8644,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -7622,7 +8679,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -7768,7 +8828,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7799,7 +8863,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7934,7 +9001,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7965,7 +9036,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8100,7 +9174,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8131,7 +9209,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8269,7 +9350,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -8300,7 +9385,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -8446,7 +9534,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8477,7 +9569,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8612,7 +9707,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8643,7 +9742,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8778,7 +9880,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8809,7 +9915,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8947,7 +10056,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -8978,7 +10091,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -9124,7 +10240,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9155,7 +10275,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9290,7 +10413,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9321,7 +10448,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9456,7 +10586,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9487,7 +10621,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9625,7 +10762,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -9656,7 +10797,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -9794,7 +10938,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9825,7 +10973,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9951,7 +11102,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9982,7 +11137,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10108,7 +11266,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10139,7 +11301,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10268,7 +11433,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -10299,7 +11468,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -10444,7 +11616,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10475,7 +11651,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10610,7 +11789,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10641,7 +11824,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10776,7 +11962,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10807,7 +11997,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10942,7 +12135,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10973,7 +12170,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11111,7 +12311,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -11142,7 +12346,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -11280,7 +12487,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11306,7 +12517,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11437,7 +12651,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11463,7 +12681,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11594,7 +12815,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11620,7 +12845,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11754,7 +12982,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -11780,7 +13012,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -11881,7 +13116,10 @@
 										"type": "string"
 									}
 								},
-								"required": ["name", "path"],
+								"required": [
+									"name",
+									"path"
+								],
 								"type": "object"
 							},
 							"markdownDescription": "Additional named pi-format session stores included in all-agent reports.",
@@ -11953,7 +13191,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11984,7 +13226,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12119,7 +13364,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -12150,7 +13399,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12285,7 +13537,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -12316,7 +13572,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12454,7 +13713,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -12485,7 +13748,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,6 +121,7 @@ version = "0.0.0"
 dependencies = [
  "ccusage-adapter-all",
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -153,6 +154,7 @@ name = "ccusage-adapter-all"
 version = "0.0.0"
 dependencies = [
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -187,6 +189,18 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-antigravity"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde_json",
+ "sqlite",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 [workspace.dependencies]
 ccusage-adapter-all = { path = "crates/ccusage-adapter-all" }
 ccusage-adapter-amp = { path = "adapters/amp" }
+ccusage-adapter-antigravity = { path = "adapters/antigravity" }
 ccusage-adapter-claude = { path = "adapters/claude" }
 ccusage-adapter-codebuff = { path = "adapters/codebuff" }
 ccusage-adapter-codex = { path = "adapters/codex" }

--- a/rust/adapters/antigravity/Cargo.toml
+++ b/rust/adapters/antigravity/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccusage-adapter-antigravity"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde_json.workspace = true
+sqlite.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/antigravity/README.md
+++ b/rust/adapters/antigravity/README.md
@@ -1,0 +1,6 @@
+# ccusage-adapter-antigravity
+
+Adapter for mining token telemetry from Antigravity session databases.
+
+Antigravity stores session state and generation telemetry in SQLite databases located at `~/.gemini/antigravity-cli/conversations/<conversation-id>.db` (or overridden via `ANTIGRAVITY_HOME` / `ANTIGRAVITY_DATA_DIR`).
+Telemetry records are encoded in Protobuf binary format inside the `steps` and `gen_metadata` tables.

--- a/rust/adapters/antigravity/src/lib.rs
+++ b/rust/adapters/antigravity/src/lib.rs
@@ -1,0 +1,45 @@
+use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::{has_data, load_entries};
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, ccusage_core::summary_period);
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Antigravity Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/antigravity/src/loader.rs
+++ b/rust/adapters/antigravity/src/loader.rs
@@ -1,0 +1,262 @@
+use std::{collections::HashSet, fs, path::Path};
+
+use crate::{LoadedEntry, PricingMap, Result, TimestampMs, cli::SharedArgs, read_files_parallel};
+
+use super::{
+    parser::{
+        AntigravityEntry, DEFAULT_ANTIGRAVITY_MODEL, RawTokenStats, build_entry,
+        parse_gen_metadata, parse_step_metadata, to_loaded_entry,
+    },
+    paths::antigravity_db_paths,
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Antigravity"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = crate::parse_tz(shared.timezone.as_deref());
+    let db_paths = antigravity_db_paths()?;
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_conversation_db(db_path, shared)
+    });
+
+    let mut entries = Vec::new();
+    let mut seen_sessions = HashSet::new();
+
+    for db_entries in loaded {
+        for entry in db_entries {
+            if !seen_sessions.insert(entry.session_id.clone()) {
+                // If we already saw this session from a prior path, skip
+            }
+            entries.push(to_loaded_entry(entry, tz.as_ref(), pricing));
+        }
+    }
+
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+pub fn has_data() -> bool {
+    antigravity_db_paths().is_ok_and(|files| !files.is_empty())
+}
+
+fn file_modified_timestamp(path: &Path) -> TimestampMs {
+    fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+        .and_then(|duration| i64::try_from(duration.as_millis()).ok())
+        .map(TimestampMs::from_millis)
+        .unwrap_or(TimestampMs::UNIX_EPOCH)
+}
+
+pub(super) fn load_conversation_db(db_path: &Path, shared: &SharedArgs) -> Vec<AntigravityEntry> {
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        crate::debug_log(
+            shared,
+            format!(
+                "Failed to open Antigravity conversation database: {}",
+                db_path.display()
+            ),
+        );
+        return Vec::new();
+    };
+
+    let fallback_timestamp = file_modified_timestamp(db_path);
+    let default_session_id = db_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut detected_model = None;
+    let mut gen_stats_map = Vec::new();
+
+    if let Ok(mut stmt) = connection.prepare("SELECT idx, data FROM gen_metadata ORDER BY idx ASC")
+    {
+        while let Ok(sqlite::State::Row) = stmt.next() {
+            if let Ok(data) = stmt.read::<Vec<u8>, _>(1) {
+                let (model_opt, stats) = parse_gen_metadata(&data);
+                if let Some(m) = model_opt {
+                    detected_model = Some(m);
+                }
+                if !stats.is_zero() {
+                    gen_stats_map.push(stats);
+                }
+            }
+        }
+    }
+
+    let model_name = detected_model.unwrap_or_else(|| DEFAULT_ANTIGRAVITY_MODEL.to_string());
+    let mut entries = Vec::new();
+    let mut step_count = 0u64;
+    let mut accumulated_stats = RawTokenStats::default();
+    let mut session_id = default_session_id;
+    let mut earliest_timestamp = None;
+
+    if let Ok(mut stmt) = connection
+        .prepare("SELECT idx, metadata FROM steps WHERE metadata IS NOT NULL ORDER BY idx ASC")
+    {
+        while let Ok(sqlite::State::Row) = stmt.next() {
+            step_count += 1;
+            if let Ok(metadata) = stmt.read::<Vec<u8>, _>(1) {
+                let (ts_opt, sess_opt, stats) = parse_step_metadata(&metadata);
+                if let Some(s) = sess_opt {
+                    session_id = s;
+                }
+                if ts_opt.is_some() && earliest_timestamp.is_none() {
+                    earliest_timestamp = ts_opt;
+                }
+                if !stats.is_zero() {
+                    accumulated_stats.input_tokens += stats.input_tokens;
+                    accumulated_stats.output_tokens += stats.output_tokens;
+                    accumulated_stats.cache_read_tokens += stats.cache_read_tokens;
+                    accumulated_stats.reasoning_tokens += stats.reasoning_tokens;
+                    accumulated_stats.generation_tokens += stats.generation_tokens;
+                }
+            }
+        }
+    }
+
+    if accumulated_stats.is_zero() && !gen_stats_map.is_empty() {
+        for stats in gen_stats_map {
+            accumulated_stats.input_tokens += stats.input_tokens;
+            accumulated_stats.output_tokens += stats.output_tokens;
+            accumulated_stats.cache_read_tokens += stats.cache_read_tokens;
+            accumulated_stats.reasoning_tokens += stats.reasoning_tokens;
+            accumulated_stats.generation_tokens += stats.generation_tokens;
+        }
+    }
+
+    if !accumulated_stats.is_zero() {
+        let timestamp = earliest_timestamp.unwrap_or(fallback_timestamp);
+        entries.push(build_entry(
+            timestamp,
+            session_id,
+            model_name,
+            accumulated_stats,
+            step_count.max(1),
+        ));
+    }
+
+    entries
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+
+    fn create_antigravity_db(path: &Path) {
+        let db = sqlite::open(path).unwrap();
+        db.execute(
+            "
+                CREATE TABLE steps (
+                    idx INTEGER PRIMARY KEY,
+                    metadata BLOB
+                );
+                CREATE TABLE gen_metadata (
+                    idx INTEGER PRIMARY KEY,
+                    data BLOB
+                );
+            ",
+        )
+        .unwrap();
+    }
+
+    fn encode_varint(val: u64, buf: &mut Vec<u8>) {
+        let mut v = val;
+        while v >= 0x80 {
+            buf.push(((v & 0x7F) as u8) | 0x80);
+            v >>= 7;
+        }
+        buf.push((v & 0x7F) as u8);
+    }
+
+    fn encode_tag(field: u32, wire_type: u8, buf: &mut Vec<u8>) {
+        let key = ((field as u64) << 3) | (wire_type as u64);
+        encode_varint(key, buf);
+    }
+
+    fn encode_bytes_field(field: u32, data: &[u8], buf: &mut Vec<u8>) {
+        encode_tag(field, 2, buf);
+        encode_varint(data.len() as u64, buf);
+        buf.extend_from_slice(data);
+    }
+
+    #[test]
+    fn loads_entries_from_antigravity_db() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("session-123.db");
+        create_antigravity_db(&db_path);
+
+        // Build a mock gen_metadata blob with model "gemini-3.7-flash"
+        let mut gen_blob = Vec::new();
+        let mut gen_sub1 = Vec::new();
+        encode_bytes_field(19, b"gemini-3.7-flash", &mut gen_sub1);
+        encode_bytes_field(1, &gen_sub1, &mut gen_blob);
+
+        // Build a mock step metadata blob with timestamp and token stats
+        let mut step_blob = Vec::new();
+        // Timestamp: seconds = 1750000000 (2025-06-15T15:06:40Z)
+        let mut ts_sub = Vec::new();
+        encode_tag(1, 0, &mut ts_sub);
+        encode_varint(1750000000, &mut ts_sub);
+        encode_bytes_field(1, &ts_sub, &mut step_blob);
+
+        // Generation stats (field 9): input=1500, output=300, cache_read=200, reasoning=50
+        let mut stats_sub = Vec::new();
+        encode_tag(2, 0, &mut stats_sub);
+        encode_varint(1500, &mut stats_sub);
+        encode_tag(3, 0, &mut stats_sub);
+        encode_varint(300, &mut stats_sub);
+        encode_tag(5, 0, &mut stats_sub);
+        encode_varint(200, &mut stats_sub);
+        encode_tag(9, 0, &mut stats_sub);
+        encode_varint(50, &mut stats_sub);
+        encode_bytes_field(9, &stats_sub, &mut step_blob);
+
+        let db = sqlite::open(&db_path).unwrap();
+        let mut stmt1 = db
+            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (0, ?1)")
+            .unwrap();
+        stmt1.bind((1, gen_blob.as_slice())).unwrap();
+        stmt1.next().unwrap();
+
+        let mut stmt2 = db
+            .prepare("INSERT INTO steps (idx, metadata) VALUES (0, ?1)")
+            .unwrap();
+        stmt2.bind((1, step_blob.as_slice())).unwrap();
+        stmt2.next().unwrap();
+
+        let pricing = PricingMap::load_embedded();
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let tz = crate::parse_tz(shared.timezone.as_deref());
+        let entries = load_conversation_db(&db_path, &shared)
+            .into_iter()
+            .map(|e| to_loaded_entry(e, tz.as_ref(), &pricing))
+            .collect::<Vec<_>>();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2025-06-15");
+        assert_eq!(entries[0].session_id.as_ref(), "session-123");
+        assert_eq!(entries[0].model.as_deref(), Some("gemini-3.7-flash"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 1500);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 300);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 200);
+        assert_eq!(entries[0].extra_total_tokens, 50);
+        assert!(entries[0].cost > 0.0);
+    }
+}

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -1,0 +1,480 @@
+use std::{collections::HashSet, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
+    missing_pricing_model_for_candidates,
+};
+
+pub(super) const DEFAULT_ANTIGRAVITY_MODEL: &str = "gemini-3.7-flash";
+
+#[derive(Clone, Debug, Default)]
+pub(super) struct RawTokenStats {
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_tokens: u64,
+    pub(super) reasoning_tokens: u64,
+    pub(super) generation_tokens: u64,
+}
+
+impl RawTokenStats {
+    pub(super) fn is_zero(&self) -> bool {
+        self.input_tokens == 0
+            && self.output_tokens == 0
+            && self.cache_read_tokens == 0
+            && self.reasoning_tokens == 0
+            && self.generation_tokens == 0
+    }
+}
+
+pub(super) struct AntigravityEntry {
+    pub(super) timestamp: TimestampMs,
+    pub(super) timestamp_text: String,
+    pub(super) session_id: String,
+    pub(super) model: String,
+    pub(super) usage: TokenUsageRaw,
+    pub(super) reasoning_tokens: u64,
+    pub(super) message_count: u64,
+}
+
+pub(super) struct ProtoReader<'a> {
+    data: &'a [u8],
+    cursor: usize,
+}
+
+impl<'a> ProtoReader<'a> {
+    pub(super) fn new(data: &'a [u8]) -> Self {
+        Self { data, cursor: 0 }
+    }
+
+    pub(super) fn read_varint(&mut self) -> Option<u64> {
+        let mut result = 0u64;
+        let mut shift = 0;
+        while self.cursor < self.data.len() {
+            let byte = self.data[self.cursor];
+            self.cursor += 1;
+            result |= u64::from(byte & 0x7F) << shift;
+            if (byte & 0x80) == 0 {
+                return Some(result);
+            }
+            shift += 7;
+            if shift >= 64 {
+                return None;
+            }
+        }
+        None
+    }
+
+    pub(super) fn next_tag(&mut self) -> Option<(u32, u8)> {
+        let key = self.read_varint()?;
+        let field_num = (key >> 3) as u32;
+        let wire_type = (key & 0x07) as u8;
+        Some((field_num, wire_type))
+    }
+
+    pub(super) fn read_bytes(&mut self) -> Option<&'a [u8]> {
+        let len = self.read_varint()? as usize;
+        if self.cursor + len > self.data.len() {
+            return None;
+        }
+        let slice = &self.data[self.cursor..self.cursor + len];
+        self.cursor += len;
+        Some(slice)
+    }
+
+    pub(super) fn skip_field(&mut self, wire_type: u8) -> bool {
+        match wire_type {
+            0 => self.read_varint().is_some(),
+            1 => {
+                if self.cursor + 8 <= self.data.len() {
+                    self.cursor += 8;
+                    true
+                } else {
+                    false
+                }
+            }
+            2 => {
+                if let Some(len) = self.read_varint() {
+                    let len = len as usize;
+                    if self.cursor + len <= self.data.len() {
+                        self.cursor += len;
+                        true
+                    } else {
+                        false
+                    }
+                } else {
+                    false
+                }
+            }
+            5 if self.cursor + 4 <= self.data.len() => {
+                self.cursor += 4;
+                true
+            }
+            5 => false,
+            _ => false,
+        }
+    }
+}
+
+pub(super) fn parse_token_stats_proto(bytes: &[u8]) -> RawTokenStats {
+    let mut reader = ProtoReader::new(bytes);
+    let mut stats = RawTokenStats::default();
+
+    while let Some((field, wire_type)) = reader.next_tag() {
+        match (field, wire_type) {
+            (2, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    stats.input_tokens = val;
+                }
+            }
+            (3, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    stats.output_tokens = val;
+                }
+            }
+            (5, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    stats.cache_read_tokens = val;
+                }
+            }
+            (9, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    stats.reasoning_tokens = val;
+                }
+            }
+            (10, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    stats.generation_tokens = val;
+                }
+            }
+            _ => {
+                if !reader.skip_field(wire_type) {
+                    break;
+                }
+            }
+        }
+    }
+    stats
+}
+
+pub(super) fn parse_timestamp_proto(bytes: &[u8]) -> Option<TimestampMs> {
+    let mut reader = ProtoReader::new(bytes);
+    let mut seconds = 0u64;
+    let mut nanos = 0u64;
+
+    while let Some((field, wire_type)) = reader.next_tag() {
+        match (field, wire_type) {
+            (1, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    seconds = val;
+                }
+            }
+            (2, 0) => {
+                if let Some(val) = reader.read_varint() {
+                    nanos = val;
+                }
+            }
+            _ => {
+                if !reader.skip_field(wire_type) {
+                    break;
+                }
+            }
+        }
+    }
+
+    if seconds > 0 {
+        let millis = (seconds as i64) * 1000 + (nanos as i64) / 1_000_000;
+        Some(TimestampMs::from_millis(millis))
+    } else {
+        None
+    }
+}
+
+pub(super) fn parse_step_metadata(
+    bytes: &[u8],
+) -> (Option<TimestampMs>, Option<String>, RawTokenStats) {
+    let mut reader = ProtoReader::new(bytes);
+    let mut timestamp = None;
+    let mut session_id = None;
+    let mut stats = RawTokenStats::default();
+
+    while let Some((field, wire_type)) = reader.next_tag() {
+        match (field, wire_type) {
+            (1, 2) => {
+                if let Some(sub_bytes) = reader.read_bytes() {
+                    timestamp = parse_timestamp_proto(sub_bytes);
+                }
+            }
+            (9 | 28, 2) => {
+                if let Some(sub_bytes) = reader.read_bytes() {
+                    let sub_stats = parse_token_stats_proto(sub_bytes);
+                    if !sub_stats.is_zero() {
+                        stats = sub_stats;
+                    } else {
+                        let mut sub_reader = ProtoReader::new(sub_bytes);
+                        while let Some((sub_f, sub_w)) = sub_reader.next_tag() {
+                            if sub_f == 2 && sub_w == 2 {
+                                if let Some(nested) = sub_reader.read_bytes() {
+                                    let nested_stats = parse_token_stats_proto(nested);
+                                    if !nested_stats.is_zero() {
+                                        stats = nested_stats;
+                                    }
+                                }
+                            } else if !sub_reader.skip_field(sub_w) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            (20, 2) => {
+                if let Some(sub_bytes) = reader.read_bytes() {
+                    let mut sub_reader = ProtoReader::new(sub_bytes);
+                    while let Some((sub_f, sub_w)) = sub_reader.next_tag() {
+                        if sub_f == 4 && sub_w == 2 {
+                            if let Some(text) = sub_reader
+                                .read_bytes()
+                                .and_then(|val| std::str::from_utf8(val).ok())
+                            {
+                                session_id = Some(text.trim().to_string());
+                            }
+                        } else if !sub_reader.skip_field(sub_w) {
+                            break;
+                        }
+                    }
+                }
+            }
+            _ => {
+                if !reader.skip_field(wire_type) {
+                    break;
+                }
+            }
+        }
+    }
+
+    (timestamp, session_id, stats)
+}
+
+pub(super) fn parse_gen_metadata(bytes: &[u8]) -> (Option<String>, RawTokenStats) {
+    let mut reader = ProtoReader::new(bytes);
+    let mut model = None;
+    let mut stats = RawTokenStats::default();
+
+    while let Some((field, wire_type)) = reader.next_tag() {
+        if field == 1 && wire_type == 2 {
+            if let Some(sub_bytes) = reader.read_bytes() {
+                let mut sub_reader = ProtoReader::new(sub_bytes);
+                while let Some((sub_f, sub_w)) = sub_reader.next_tag() {
+                    match (sub_f, sub_w) {
+                        (4, 2) => {
+                            if let Some(stats_bytes) = sub_reader.read_bytes() {
+                                stats = parse_token_stats_proto(stats_bytes);
+                            }
+                        }
+                        (19, 2) => {
+                            if let Some(text) = sub_reader
+                                .read_bytes()
+                                .and_then(|str_bytes| std::str::from_utf8(str_bytes).ok())
+                            {
+                                let trimmed = text.trim();
+                                if !trimmed.is_empty() {
+                                    model = Some(trimmed.to_string());
+                                }
+                            }
+                        }
+                        _ => {
+                            if !sub_reader.skip_field(sub_w) {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        } else if !reader.skip_field(wire_type) {
+            break;
+        }
+    }
+
+    (model, stats)
+}
+
+pub(super) fn to_loaded_entry(
+    entry: AntigravityEntry,
+    tz: Option<&JiffTimeZone>,
+    pricing: &PricingMap,
+) -> LoadedEntry {
+    let cost = calculate_antigravity_cost(&entry, pricing);
+    let missing_pricing_model = missing_antigravity_pricing(&entry, pricing);
+    let data = UsageEntry {
+        session_id: Some(entry.session_id.clone()),
+        timestamp: entry.timestamp_text.clone(),
+        version: None,
+        message: UsageMessage {
+            usage: entry.usage,
+            model: Some(entry.model.clone()),
+            id: Some(format!("antigravity:{}", entry.session_id)),
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        date: format_date_tz(entry.timestamp, tz),
+        timestamp: entry.timestamp,
+        project: Arc::from("antigravity"),
+        session_id: Arc::from(entry.session_id.as_str()),
+        project_path: Arc::from("Antigravity"),
+        cost,
+        credits: None,
+        extra_total_tokens: entry.reasoning_tokens,
+        message_count: Some(entry.message_count),
+        model: Some(entry.model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        data,
+    }
+}
+
+pub(super) fn build_entry(
+    timestamp: TimestampMs,
+    session_id: String,
+    model: String,
+    stats: RawTokenStats,
+    message_count: u64,
+) -> AntigravityEntry {
+    let usage = TokenUsageRaw {
+        input_tokens: stats.input_tokens,
+        output_tokens: stats.output_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: stats.cache_read_tokens,
+        speed: None,
+        cache_creation: None,
+    };
+    AntigravityEntry {
+        timestamp,
+        timestamp_text: format_rfc3339_millis(timestamp),
+        session_id,
+        model,
+        usage,
+        reasoning_tokens: stats.reasoning_tokens,
+        message_count,
+    }
+}
+
+fn calculate_antigravity_cost(entry: &AntigravityEntry, pricing: &PricingMap) -> f64 {
+    let usage = TokenUsageRaw {
+        output_tokens: entry.usage.output_tokens + entry.reasoning_tokens,
+        cache_creation: None,
+        ..entry.usage
+    };
+    for candidate in model_candidates(entry) {
+        let cost = calculate_cost_for_usage(
+            Some(&candidate),
+            usage,
+            None,
+            CostMode::Calculate,
+            Some(pricing),
+        );
+        if cost.is_finite() && cost > 0.0 {
+            return cost;
+        }
+    }
+    0.0
+}
+
+fn missing_antigravity_pricing(entry: &AntigravityEntry, pricing: &PricingMap) -> Option<String> {
+    let usage = TokenUsageRaw {
+        output_tokens: entry.usage.output_tokens + entry.reasoning_tokens,
+        cache_creation: None,
+        ..entry.usage
+    };
+    missing_pricing_model_for_candidates(
+        &entry.model,
+        model_candidates(entry),
+        crate::total_usage_tokens(usage),
+        Some(pricing),
+    )
+}
+
+fn model_candidates(entry: &AntigravityEntry) -> Vec<String> {
+    let mut candidates = Vec::new();
+    let model = &entry.model;
+    if !model.starts_with("google/") && !model.starts_with("gemini/") {
+        candidates.push(format!("google/{model}"));
+        candidates.push(format!("gemini/{model}"));
+    }
+    candidates.push(model.clone());
+    let mut seen = HashSet::new();
+    candidates
+        .into_iter()
+        .filter(|candidate| seen.insert(candidate.clone()))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_proto_varint_and_tags() {
+        let mut buf = Vec::new();
+        // field 2 (wire type 0): varint 1200
+        // tag = (2 << 3) | 0 = 16 (0x10)
+        buf.push(0x10);
+        buf.extend_from_slice(&[0xb0, 0x09]); // 1200
+
+        // field 3 (wire type 0): varint 300
+        // tag = (3 << 3) | 0 = 24 (0x18)
+        buf.push(0x18);
+        buf.extend_from_slice(&[0xac, 0x02]); // 300
+
+        let stats = parse_token_stats_proto(&buf);
+        assert_eq!(stats.input_tokens, 1200);
+        assert_eq!(stats.output_tokens, 300);
+        assert_eq!(stats.cache_read_tokens, 0);
+    }
+
+    #[test]
+    fn calculates_cost_for_gemini_models_from_pricing() {
+        let pricing = PricingMap::load_embedded();
+        let entry = build_entry(
+            crate::parse_ts_timestamp("2026-05-19T00:00:00.000Z").unwrap(),
+            "test-session".to_string(),
+            "gemini-2.5-flash".to_string(),
+            RawTokenStats {
+                input_tokens: 10_000,
+                output_tokens: 1_000,
+                cache_read_tokens: 5_000,
+                reasoning_tokens: 200,
+                generation_tokens: 800,
+            },
+            1,
+        );
+
+        let cost = calculate_antigravity_cost(&entry, &pricing);
+        assert!(cost > 0.0, "gemini-2.5-flash should have non-zero cost");
+    }
+
+    #[test]
+    fn candidate_models_include_google_and_gemini_prefixes() {
+        let entry = build_entry(
+            TimestampMs::UNIX_EPOCH,
+            "session-1".to_string(),
+            "gemini-3.7-flash".to_string(),
+            RawTokenStats::default(),
+            1,
+        );
+        let candidates = model_candidates(&entry);
+        assert_eq!(
+            candidates,
+            vec![
+                "google/gemini-3.7-flash".to_string(),
+                "gemini/gemini-3.7-flash".to_string(),
+                "gemini-3.7-flash".to_string(),
+            ]
+        );
+    }
+}

--- a/rust/adapters/antigravity/src/paths.rs
+++ b/rust/adapters/antigravity/src/paths.rs
@@ -1,0 +1,75 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::Result;
+
+pub const ANTIGRAVITY_HOME_ENV: &str = "ANTIGRAVITY_HOME";
+pub const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
+pub const AGY_HOME_ENV: &str = "AGY_HOME";
+
+pub(super) fn antigravity_db_paths() -> Result<Vec<PathBuf>> {
+    let mut candidate_dirs = Vec::new();
+
+    for var in [ANTIGRAVITY_HOME_ENV, ANTIGRAVITY_DATA_DIR_ENV, AGY_HOME_ENV] {
+        if let Ok(val) = env::var(var) {
+            for part in val.split(',').map(str::trim).filter(|p| !p.is_empty()) {
+                let path = PathBuf::from(part);
+                if path.join("conversations").is_dir() {
+                    candidate_dirs.push(path.join("conversations"));
+                } else if path.is_dir() {
+                    candidate_dirs.push(path);
+                }
+            }
+        }
+    }
+
+    if candidate_dirs.is_empty()
+        && let Some(home) = crate::home::home_dir()
+    {
+        let primary = home
+            .join(".gemini")
+            .join("antigravity-cli")
+            .join("conversations");
+        if primary.is_dir() {
+            candidate_dirs.push(primary);
+        }
+        let config_alt = home
+            .join(".config")
+            .join("antigravity")
+            .join("conversations");
+        if config_alt.is_dir() {
+            candidate_dirs.push(config_alt);
+        }
+    }
+
+    let mut seen = HashSet::new();
+    let mut db_paths = Vec::new();
+
+    for dir in candidate_dirs {
+        collect_db_files(&dir, &mut db_paths, &mut seen);
+    }
+
+    Ok(db_paths)
+}
+
+fn collect_db_files(dir: &Path, db_paths: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.filter_map(std::result::Result::ok) {
+        let path = entry.path();
+        if path.is_file()
+            && path.extension().is_some_and(|ext| ext == "db")
+            && path
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| !name.contains("summary") && !name.contains("summaries"))
+            && seen.insert(path.clone())
+        {
+            db_paths.push(path);
+        }
+    }
+}

--- a/rust/adapters/antigravity/src/report.rs
+++ b/rust/adapters/antigravity/src/report.rs
@@ -1,0 +1,120 @@
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{TokenUsageRaw, UsageEntry, UsageMessage};
+
+    #[test]
+    fn report_includes_message_count_and_reasoning_total() {
+        let entry = LoadedEntry {
+            data: UsageEntry {
+                session_id: Some("session-1".to_string()),
+                timestamp: "2025-06-15T15:06:40.250Z".to_string(),
+                version: None,
+                message: UsageMessage {
+                    usage: TokenUsageRaw {
+                        input_tokens: 1200,
+                        output_tokens: 300,
+                        cache_creation_input_tokens: 0,
+                        cache_read_input_tokens: 50,
+                        speed: None,
+                        cache_creation: None,
+                    },
+                    model: Some("gemini-3.7-flash".to_string()),
+                    id: Some("antigravity:session-1".to_string()),
+                },
+                cost_usd: None,
+                request_id: None,
+                is_api_error_message: None,
+                is_sidechain: None,
+            },
+            timestamp: crate::parse_ts_timestamp("2025-06-15T15:06:40.250Z").unwrap(),
+            date: "2025-06-15".to_string(),
+            project: Arc::from("antigravity"),
+            session_id: Arc::from("session-1"),
+            project_path: Arc::from("Antigravity"),
+            cost: 0.05,
+            credits: None,
+            extra_total_tokens: 10,
+            message_count: Some(15),
+            model: Some("gemini-3.7-flash".to_string()),
+            usage_limit_reset_time: None,
+            missing_pricing_model: None,
+        };
+        let rows = summarize_entries(&[entry], AgentReportKind::Daily).unwrap();
+        let report = report_from_rows(&rows, AgentReportKind::Daily);
+
+        assert_eq!(report["daily"][0]["totalTokens"], json!(1560));
+        assert_eq!(report["daily"][0]["messageCount"], json!(15));
+        assert_eq!(report["totals"]["totalTokens"], json!(1560));
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage-adapter-all/README.md
+++ b/rust/crates/ccusage-adapter-all/README.md
@@ -10,7 +10,7 @@ into one table or JSON document.
 - `report.rs` — the unified row and total shapes.
 - `types.rs` — the accumulators the merge needs.
 
-This is the only crate that depends on all 16 adapters, which keeps the adapters
+This is the only crate that depends on all 17 adapters, which keeps the adapters
 themselves independent of each other.
 
 ## Public surface
@@ -20,6 +20,7 @@ themselves independent of each other.
 ## Depends on
 
 - `ccusage-adapter-amp`
+- `ccusage-adapter-antigravity`
 - `ccusage-adapter-claude`
 - `ccusage-adapter-codebuff`
 - `ccusage-adapter-codex`

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -10,6 +10,7 @@ use ccusage_core::*;
 
 mod adapter {
     pub use ccusage_adapter_amp as amp;
+    pub use ccusage_adapter_antigravity as antigravity;
     pub use ccusage_adapter_claude as claude;
     pub use ccusage_adapter_codebuff as codebuff;
     pub use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -11,8 +11,8 @@ use crate::{
     BUILT_IN_AGENT_NAMES, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result,
     SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        amp, antigravity, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes,
+        kilo, kimi, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -322,6 +322,22 @@ fn load_base_rows(
                     grok::summarize_entries,
                 )?;
                 rows.detected = rows.detected || grok::has_data();
+                Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("Antigravity"),
+            load: Box::new(|| {
+                let mut rows = load_summary_agent_rows(
+                    "antigravity",
+                    load_kind,
+                    &loader_shared,
+                    || antigravity::load_entries(&loader_shared, pricing),
+                    antigravity::summarize_entries,
+                )?;
+                rows.detected = rows.detected || antigravity::has_data();
                 Ok(rows)
             }),
         },

--- a/rust/crates/ccusage-adapter-all/src/report.rs
+++ b/rust/crates/ccusage-adapter-all/src/report.rs
@@ -590,6 +590,7 @@ fn agent_label(agent: &str) -> &str {
         "kimi" => "Kimi",
         "qwen" => "Qwen",
         "grok" => "Grok",
+        "antigravity" => "Antigravity",
         _ => agent,
     }
 }

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -560,6 +560,9 @@ fn isolated_agent_env(
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
         "GROK_HOME",
+        "ANTIGRAVITY_HOME",
+        "ANTIGRAVITY_DATA_DIR",
+        "AGY_HOME",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -104,6 +104,10 @@
 			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
+			},
+			{
+				"name": "antigravity",
+				"description": "Show Antigravity usage commands"
 			}
 		]
 	},
@@ -774,6 +778,43 @@
 			"path": ["grok", "session"],
 			"description": "Show Grok Build CLI usage grouped by session",
 			"usage": "ccusage grok session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity"],
+			"description": "Usage reports for Antigravity.",
+			"usage": "ccusage antigravity <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Antigravity usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Antigravity usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Antigravity usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["antigravity", "daily"],
+			"description": "Show Antigravity usage grouped by date",
+			"usage": "ccusage antigravity daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "monthly"],
+			"description": "Show Antigravity usage grouped by month",
+			"usage": "ccusage antigravity monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "session"],
+			"description": "Show Antigravity usage grouped by session",
+			"usage": "ccusage antigravity session <OPTIONS>",
 			"options": "agent_options"
 		}
 	]

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -340,6 +340,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Grok,
         ),
+        "antigravity" | "agy" => parse_basic_agent_command(
+            parser,
+            shared,
+            "antigravity",
+            STANDARD_AGENT_REPORTS,
+            Command::Antigravity,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -771,6 +778,8 @@ fn is_command(arg: &str) -> bool {
             | "kimi"
             | "qwen"
             | "grok"
+            | "antigravity"
+            | "agy"
     )
 }
 
@@ -931,6 +940,8 @@ fn is_agent_command(command: &str) -> bool {
             | "qwen"
             | "openclaw"
             | "grok"
+            | "antigravity"
+            | "agy"
     )
 }
 
@@ -943,7 +954,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" | "antigravity" | "agy" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -968,6 +979,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
+        "antigravity" | "agy" => "Antigravity",
         _ => unreachable!("agent is prevalidated"),
     }
 }
@@ -1048,7 +1060,8 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::Antigravity(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };
     shared.last?;

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -29,6 +29,7 @@ COMMANDS:
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
   grok                       Show Grok Build CLI usage commands
+  antigravity                Show Antigravity usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -53,6 +54,7 @@ For more info, run any command with the `--help` flag:
   ccusage qwen --help
   ccusage openclaw --help
   ccusage grok --help
+  ccusage antigravity --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -205,6 +205,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
+        Some(Command::Antigravity(args)) => agent_command_snapshot("antigravity", args),
     }
 }
 
@@ -646,8 +647,23 @@ fn applies_schema_documented_config_file_options() {
 fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
-        "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
+        "claude",
+        "codex",
+        "opencode",
+        "amp",
+        "droid",
+        "codebuff",
+        "hermes",
+        "pi",
+        "goose",
+        "kilo",
+        "copilot",
+        "gemini",
+        "kimi",
+        "qwen",
+        "openclaw",
+        "grok",
+        "antigravity",
     ];
 
     for agent in agents {
@@ -1256,6 +1272,26 @@ fn rejects_grok_path_option() {
     let error = parse_error(&["ccusage", "grok", "daily", "--grok-path", "/tmp/grok-home"]);
 
     assert_eq!(error, "Unknown option '--grok-path'");
+}
+
+#[test]
+fn parses_antigravity_daily_options() {
+    let cli = parse(&["ccusage", "antigravity", "daily", "--json"]);
+    let Some(Command::Antigravity(args)) = cli.command else {
+        panic!("expected antigravity command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert!(args.shared.json);
+}
+
+#[test]
+fn parses_agy_alias_command() {
+    let cli = parse(&["ccusage", "agy", "session", "--json"]);
+    let Some(Command::Antigravity(args)) = cli.command else {
+        panic!("expected antigravity command via agy alias");
+    };
+    assert_eq!(args.kind, AgentReportKind::Session);
+    assert!(args.shared.json);
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    Antigravity(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -52,6 +52,8 @@ pub struct CcusageConfig {
     pub qwen: Option<QwenConfig>,
     /// Grok Build CLI configuration.
     pub grok: Option<GrokConfig>,
+    /// Antigravity configuration.
+    pub antigravity: Option<AntigravityConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -316,6 +318,21 @@ pub struct GrokConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GrokCommandsConfig {
+    pub daily: Option<SharedOptions>,
+    pub monthly: Option<SharedOptions>,
+    pub session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AntigravityConfig {
+    pub defaults: Option<SharedOptions>,
+    pub commands: Option<AntigravityCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AntigravityCommandsConfig {
     pub daily: Option<SharedOptions>,
     pub monthly: Option<SharedOptions>,
     pub session: Option<SharedOptions>,
@@ -1093,6 +1110,7 @@ mod tests {
             &with_keys(&shared, &["openClawPath"]),
         );
         assert_schema_properties(&schema, &["grok", "defaults"], &shared);
+        assert_schema_properties(&schema, &["antigravity", "defaults"], &shared);
     }
 
     #[test]
@@ -1113,6 +1131,9 @@ mod tests {
         assert!(schema_property(&schema, &["kimi", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["qwen", "defaults", "openClawPath"]).is_none());
         assert!(schema_property(&schema, &["grok", "defaults", "grokPath"]).is_none());
+        assert!(
+            schema_property(&schema, &["antigravity", "defaults", "antigravityPath"]).is_none()
+        );
         assert!(schema_property(&schema, &["openclaw", "defaults", "grokPath"]).is_none());
     }
 
@@ -1146,9 +1167,26 @@ mod tests {
             &schema,
             "ccusage-config",
             &[
-                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
-                "droid", "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode",
-                "openclaw", "pi", "qwen",
+                "$schema",
+                "amp",
+                "antigravity",
+                "claude",
+                "codebuff",
+                "codex",
+                "commands",
+                "copilot",
+                "defaults",
+                "droid",
+                "gemini",
+                "goose",
+                "grok",
+                "hermes",
+                "kilo",
+                "kimi",
+                "opencode",
+                "openclaw",
+                "pi",
+                "qwen",
             ],
         );
         assert!(

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1297,6 +1297,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
   "rootProperties": [
     "$schema",
     "amp",
+    "antigravity",
     "claude",
     "codebuff",
     "codex",

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -55,8 +55,23 @@ pub const DEFAULT_RECENT_DAYS: i64 = 3;
 pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
-    "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "claude",
+    "codex",
+    "opencode",
+    "amp",
+    "droid",
+    "codebuff",
+    "hermes",
+    "pi",
+    "goose",
+    "openclaw",
+    "kilo",
+    "copilot",
+    "gemini",
+    "kimi",
+    "qwen",
+    "grok",
+    "antigravity",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -17,6 +17,7 @@ fetch-litellm-pricing = ["ccusage-core/fetch-litellm-pricing"]
 [dependencies]
 ccusage-adapter-all.workspace = true
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage/README.md
+++ b/rust/crates/ccusage/README.md
@@ -20,6 +20,7 @@ source in its own `ccusage-adapter-*` crate.
 
 - `ccusage-adapter-all`
 - `ccusage-adapter-amp`
+- `ccusage-adapter-antigravity`
 - `ccusage-adapter-claude`
 - `ccusage-adapter-codebuff`
 - `ccusage-adapter-codex`

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use ccusage_adapter_all as all;
 pub(crate) use ccusage_adapter_amp as amp;
+pub(crate) use ccusage_adapter_antigravity as antigravity;
 pub(crate) use ccusage_adapter_claude as claude;
 pub(crate) use ccusage_adapter_codebuff as codebuff;
 pub(crate) use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,7 +49,8 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::Antigravity(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,
     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::Antigravity(args)) => adapter::antigravity::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,8 +87,9 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
+            ccusage_adapter_antigravity::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
             ccusage_adapter_copilot::run,
@@ -104,7 +106,7 @@ mod tests {
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Adds support for tracking token usage and cost metrics from Antigravity (`agy` / `antigravity-cli`).

- Introduces `ccusage-adapter-antigravity` crate to discover and read SQLite conversation databases (`~/.gemini/antigravity-cli/conversations/*.db`, with `ANTIGRAVITY_HOME`, `ANTIGRAVITY_DATA_DIR`, and `AGY_HOME` environment overrides).
- Decodes Protobuf wire fields from `steps.metadata` and `gen_metadata.data` to extract input, output, cache read, and reasoning/thinking tokens, timestamps, session IDs, and model names.
- Integrates `antigravity` and its alias `agy` into the CLI argument parser, config schema (`apps/ccusage/config-schema.json`), unified reports (`ccusage-adapter-all`), and the main binary.
- Adds comprehensive unit tests, parser snapshot tests, and schema validation.

## Test plan
- Ran `cargo test --workspace` — all workspace unit and snapshot tests pass.
- Ran `cargo clippy --workspace -- -D warnings` — no lints or warnings.
- Ran `cargo fmt --check` — formatted according to project standards.
- Verified standalone reports (`ccusage antigravity daily`, `ccusage antigravity session --json`) and unified reports against local conversation SQLite databases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Antigravity usage support to `ccusage`, enabling token and cost reporting from local Antigravity (`agy`) conversation databases. Previously Antigravity usage was not reported; now `ccusage` discovers SQLite conversations, decodes Protobuf metadata, and includes Antigravity in both standalone and unified reports.

- Introduces `ccusage-adapter-antigravity` to read `~/.gemini/antigravity-cli/conversations/*.db` with `ANTIGRAVITY_HOME`, `ANTIGRAVITY_DATA_DIR`, and `AGY_HOME` overrides; extracts input, output, cache read, reasoning, and generation tokens, timestamps, sessions, and model names (defaults to `gemini-3.7-flash` when absent).
- Adds `antigravity` (alias `agy`) CLI namespace with `daily`, `monthly`, and `session` reports; updates `ccusage` parser snapshots.
- Extends config schema to include `antigravity` defaults and per-command options; updates schema snapshots.
- Integrates Antigravity into unified loader `ccusage-adapter-all` as the 17th agent; unified outputs show the agent label "Antigravity".
- Keeps existing behavior for other agents; unified tables/JSON now include Antigravity rows when data is present.

- Required actions:
  - None. To use, run `ccusage antigravity ...` or set the above env vars if Antigravity data lives outside the default path.

<sup>Written for commit b12b38fa89783913e2b0ff4c1087390456270597. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1619?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity usage tracking and reporting.
  * Added `antigravity` and `agy` CLI commands with daily, monthly, and session reports.
  * Added Antigravity data discovery, token and cost reporting, model detection, and reasoning-token support.
  * Added configuration options for Antigravity commands and paths.
* **Documentation**
  * Added setup and data-location documentation for Antigravity usage reporting.
* **Tests**
  * Added coverage for parsing, pricing, reporting, CLI commands, aliases, and configuration schema support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->