### PR TITLE
docs: add coffee-paladin to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -15,6 +15,7 @@ These projects are maintained independently and are not affiliated with the ccus
 
 - [ccusage Raycast Extension](https://www.raycast.com/nyatinte/ccusage) - Raycast integration for quick usage checks
 - [ccusage.nvim](https://github.com/S1M0N38/ccusage.nvim) - Track Claude Code usage in Neovim
+- [coffee-paladin](https://github.com/pawelkwaczynski/coffee-paladin) - macOS menu bar thermal guard for AI agent workloads, showing today's ccusage totals next to chip temperature
 
 ## CLI Utilities
 


### PR DESCRIPTION
coffee-paladin is a thermal fuse for Macs running AI coding agents: it pauses heavy work with SIGSTOP when the chip gets hot and resumes it when the machine cools, instead of letting a laptop cook through a long job.

It calls `ccusage daily --json` (never vendoring any code) and shows today's spend in the menu bar's Agent activity submenu, right next to chip temperature and the running agent sessions, so "what is this costing me" and "what is this doing to the machine" are answered in the same place. Missing ccusage simply means that row does not exist.

Thanks for the tool.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `coffee-paladin` to the Community Projects page to surface a macOS menu bar thermal guard for agent workloads that shows today's `ccusage` totals next to chip temperature. Documentation-only change that improves discoverability; no runtime or API impact.

<sup>Written for commit aacf4ac26874f193616a0e39cd05274bcc96ece3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `coffee-paladin` to the Extensions & Integrations list.
  * Described it as a macOS menu bar thermal guard displaying daily usage totals and chip temperature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->