### PR TITLE
docs: correct the viberank community entry (agent coverage)

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -23,7 +23,7 @@ These projects are maintained independently and are not affiliated with the ccus
 ## Web Applications
 
 - [Straude](https://straude.com) - Strava-style Claude Code telemetry for logging usage, tracking spend, and comparing pace
-- [viberank](https://viberank.app) - A community-driven leaderboard for Claude Code usage. ([GitHub](https://github.com/sculptdotfun/viberank))
+- [viberank](https://viberank.app) - Public leaderboard and open dataset for AI coding usage across the agents ccusage reads — Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Hermes, pi, Kimi and more. Per-tool boards, verified GitHub profiles, README badges, daily autosubmit, and a free JSON API publishing the spend distribution under CC BY 4.0. ([GitHub](https://github.com/sculptdotfun/viberank))
 - [CCWarriors](https://ccwarriors.xyz) - Live leaderboard of AI coding spend across Claude Code, Codex, Gemini, and other ccusage-readable agents, with per-tool filters and real-time updates. ([GitHub](https://github.com/distroinfinity/ccwarriors))
 - [Token Battle](https://tokenbattle.vercel.app) - AI coding cost leaderboard for comparing monthly ccusage exports from Claude Code, Codex CLI, and Gemini CLI, with dashboard uploads, public rankings, and shareable profiles.
 


### PR DESCRIPTION
Small correction to my own entry on the Community Projects page.

**Disclosure: I maintain viberank**, so treat this as a self-interested edit — happy for it to be trimmed or rejected.

The current line reads:

> viberank - A community-driven leaderboard for Claude Code usage.

That's inaccurate rather than just short. viberank ingests whatever ccusage emits, so it covers **17 distinct tools** today — Claude Code, Codex, Gemini CLI, Copilot, OpenCode, Hermes, pi, Kimi, Qwen, Grok, Droid and others. As currently written, the CCWarriors entry directly below implies broader agent coverage than viberank, which is backwards.

The updated entry also mentions the free JSON API and the published spend distribution (CC BY 4.0). That felt worth including because it's the part most likely to be useful to someone reading this page — it's data other people can build on, rather than another board to look at. If that reads as too much, I'm happy to cut it back to just the agent-coverage fix, which is the part that's actually wrong.

For context on scale: 1,126 developers, ~$10.9M in API-equivalent spend, ~12T tokens tracked. Every submission runs `npx ccusage@latest` under the hood, so ccusage is doing the real work here.

No other files touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Corrects the Community Projects entry for viberank to reflect coverage across all agents `ccusage` reads and surfaces its open dataset/API, avoiding the prior implication that it only tracked Claude Code usage.

- Replaces “leaderboard for Claude Code usage” with a description covering multiple agents read by `ccusage`, matching the neighboring `CCWarriors` scope.
- Adds details on per-tool boards, verified GitHub profiles, README badges, daily autosubmit, and a free JSON API publishing spend distribution under CC BY 4.0.

<sup>Written for commit 7f0720fa04a9a7596ecf62cd596c933b80071c5a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the VibeRank project listing to highlight multi-agent AI coding support, leaderboards, verified profiles, badges, automatic submissions, and a JSON API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->