### PR TITLE
feat(adapter): add Google Antigravity agent source

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -77,8 +77,9 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Kimi               | `ccusage kimi daily`     |
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
-| Gemini CLI         | `ccusage gemini daily`   |
-| Grok Build CLI     | `ccusage grok daily`     |
+| Gemini CLI         | `ccusage gemini daily`      |
+| Grok Build CLI     | `ccusage grok daily`        |
+| Antigravity        | `ccusage antigravity daily` |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 

--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -75,7 +75,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -106,7 +110,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -241,7 +248,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -272,7 +283,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -407,7 +421,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -438,7 +456,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -576,7 +597,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -607,7 +632,716 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
+									"markdownDescription": "Sort order.",
+									"type": "string"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
+								},
+								"since": {
+									"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+									"type": "string"
+								},
+								"singleThread": {
+									"default": false,
+									"description": "Disable parallel file processing.",
+									"markdownDescription": "Disable parallel file processing.",
+									"type": "boolean"
+								},
+								"timezone": {
+									"description": "Timezone for date grouping (IANA).",
+									"markdownDescription": "Timezone for date grouping (IANA).",
+									"type": "string"
+								},
+								"until": {
+									"description": "Filter until date (inclusive).",
+									"markdownDescription": "Filter until date (inclusive).",
+									"type": "string"
+								}
+							},
+							"type": "object"
+						}
+					},
+					"type": "object"
+				},
+				"antigravity": {
+					"additionalProperties": false,
+					"description": "Google Antigravity configuration.",
+					"markdownDescription": "Google Antigravity configuration.",
+					"properties": {
+						"commands": {
+							"additionalProperties": false,
+							"properties": {
+								"daily": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"monthly": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								},
+								"session": {
+									"additionalProperties": false,
+									"properties": {
+										"all": {
+											"default": false,
+											"description": "Accepted for compatibility; all detected supported agents are included by default.",
+											"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+											"type": "boolean"
+										},
+										"breakdown": {
+											"default": false,
+											"description": "Show per-model cost breakdown.",
+											"markdownDescription": "Show per-model cost breakdown.",
+											"type": "boolean"
+										},
+										"color": {
+											"default": false,
+											"description": "Enable colored output.",
+											"markdownDescription": "Enable colored output.",
+											"type": "boolean"
+										},
+										"compact": {
+											"default": false,
+											"description": "Force compact table layout for narrow terminals.",
+											"markdownDescription": "Force compact table layout for narrow terminals.",
+											"type": "boolean"
+										},
+										"debug": {
+											"default": false,
+											"description": "Show pricing mismatch information for debugging.",
+											"markdownDescription": "Show pricing mismatch information for debugging.",
+											"type": "boolean"
+										},
+										"debugSamples": {
+											"default": 5,
+											"description": "Number of sample discrepancies to show in debug output.",
+											"format": "uint",
+											"markdownDescription": "Number of sample discrepancies to show in debug output.",
+											"minimum": 0.0,
+											"type": "integer"
+										},
+										"jq": {
+											"description": "jq filter to apply to JSON output.",
+											"markdownDescription": "jq filter to apply to JSON output.",
+											"type": "string"
+										},
+										"json": {
+											"default": false,
+											"description": "Output in JSON format.",
+											"markdownDescription": "Output in JSON format.",
+											"type": "boolean"
+										},
+										"mode": {
+											"default": "auto",
+											"description": "Cost calculation mode.",
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
+											"markdownDescription": "Cost calculation mode.",
+											"type": "string"
+										},
+										"noColor": {
+											"default": false,
+											"description": "Disable colored output.",
+											"markdownDescription": "Disable colored output.",
+											"type": "boolean"
+										},
+										"noCost": {
+											"default": false,
+											"description": "Hide cost information in table and JSON output.",
+											"markdownDescription": "Hide cost information in table and JSON output.",
+											"type": "boolean"
+										},
+										"noOffline": {
+											"default": false,
+											"description": "Disable cached pricing data where supported.",
+											"markdownDescription": "Disable cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"offline": {
+											"default": false,
+											"description": "Use cached pricing data where supported.",
+											"markdownDescription": "Use cached pricing data where supported.",
+											"type": "boolean"
+										},
+										"order": {
+											"default": "asc",
+											"description": "Sort order.",
+											"enum": [
+												"desc",
+												"asc"
+											],
+											"markdownDescription": "Sort order.",
+											"type": "string"
+										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
+										"since": {
+											"description": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"markdownDescription": "Filter from date (YYYY-MM-DD or YYYYMMDD).",
+											"type": "string"
+										},
+										"singleThread": {
+											"default": false,
+											"description": "Disable parallel file processing.",
+											"markdownDescription": "Disable parallel file processing.",
+											"type": "boolean"
+										},
+										"timezone": {
+											"description": "Timezone for date grouping (IANA).",
+											"markdownDescription": "Timezone for date grouping (IANA).",
+											"type": "string"
+										},
+										"until": {
+											"description": "Filter until date (inclusive).",
+											"markdownDescription": "Filter until date (inclusive).",
+											"type": "string"
+										}
+									},
+									"type": "object"
+								}
+							},
+							"type": "object"
+						},
+						"defaults": {
+							"additionalProperties": false,
+							"properties": {
+								"all": {
+									"default": false,
+									"description": "Accepted for compatibility; all detected supported agents are included by default.",
+									"markdownDescription": "Accepted for compatibility; all detected supported agents are included by default.",
+									"type": "boolean"
+								},
+								"breakdown": {
+									"default": false,
+									"description": "Show per-model cost breakdown.",
+									"markdownDescription": "Show per-model cost breakdown.",
+									"type": "boolean"
+								},
+								"color": {
+									"default": false,
+									"description": "Enable colored output.",
+									"markdownDescription": "Enable colored output.",
+									"type": "boolean"
+								},
+								"compact": {
+									"default": false,
+									"description": "Force compact table layout for narrow terminals.",
+									"markdownDescription": "Force compact table layout for narrow terminals.",
+									"type": "boolean"
+								},
+								"debug": {
+									"default": false,
+									"description": "Show pricing mismatch information for debugging.",
+									"markdownDescription": "Show pricing mismatch information for debugging.",
+									"type": "boolean"
+								},
+								"debugSamples": {
+									"default": 5,
+									"description": "Number of sample discrepancies to show in debug output.",
+									"format": "uint",
+									"markdownDescription": "Number of sample discrepancies to show in debug output.",
+									"minimum": 0.0,
+									"type": "integer"
+								},
+								"jq": {
+									"description": "jq filter to apply to JSON output.",
+									"markdownDescription": "jq filter to apply to JSON output.",
+									"type": "string"
+								},
+								"json": {
+									"default": false,
+									"description": "Output in JSON format.",
+									"markdownDescription": "Output in JSON format.",
+									"type": "boolean"
+								},
+								"mode": {
+									"default": "auto",
+									"description": "Cost calculation mode.",
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
+									"markdownDescription": "Cost calculation mode.",
+									"type": "string"
+								},
+								"noColor": {
+									"default": false,
+									"description": "Disable colored output.",
+									"markdownDescription": "Disable colored output.",
+									"type": "boolean"
+								},
+								"noCost": {
+									"default": false,
+									"description": "Hide cost information in table and JSON output.",
+									"markdownDescription": "Hide cost information in table and JSON output.",
+									"type": "boolean"
+								},
+								"noOffline": {
+									"default": false,
+									"description": "Disable cached pricing data where supported.",
+									"markdownDescription": "Disable cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"offline": {
+									"default": false,
+									"description": "Use cached pricing data where supported.",
+									"markdownDescription": "Use cached pricing data where supported.",
+									"type": "boolean"
+								},
+								"order": {
+									"default": "asc",
+									"description": "Sort order.",
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -750,7 +1484,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -776,7 +1514,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -924,7 +1665,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -950,7 +1695,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1094,7 +1842,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1125,7 +1877,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1260,7 +2015,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1291,7 +2050,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1399,7 +2161,12 @@
 										"costSource": {
 											"default": "auto",
 											"description": "Source for statusline cost calculation.",
-											"enum": ["auto", "ccusage", "cc", "both"],
+											"enum": [
+												"auto",
+												"ccusage",
+												"cc",
+												"both"
+											],
 											"markdownDescription": "Source for statusline cost calculation.",
 											"type": "string"
 										},
@@ -1451,7 +2218,12 @@
 										"visualBurnRate": {
 											"default": "off",
 											"description": "Visual burn-rate display mode.",
-											"enum": ["off", "emoji", "text", "emoji-text"],
+											"enum": [
+												"off",
+												"emoji",
+												"text",
+												"emoji-text"
+											],
 											"markdownDescription": "Visual burn-rate display mode.",
 											"type": "string"
 										}
@@ -1505,7 +2277,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1531,7 +2307,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -1677,7 +2456,12 @@
 								},
 								"costSource": {
 									"description": "Source for statusline cost calculation.",
-									"enum": ["auto", "ccusage", "cc", "both"],
+									"enum": [
+										"auto",
+										"ccusage",
+										"cc",
+										"both"
+									],
 									"markdownDescription": "Source for statusline cost calculation.",
 									"type": "string"
 								},
@@ -1710,7 +2494,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -1749,7 +2537,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -1874,7 +2665,12 @@
 								},
 								"visualBurnRate": {
 									"description": "Visual burn-rate display mode.",
-									"enum": ["off", "emoji", "text", "emoji-text"],
+									"enum": [
+										"off",
+										"emoji",
+										"text",
+										"emoji-text"
+									],
 									"markdownDescription": "Visual burn-rate display mode.",
 									"type": "string"
 								}
@@ -1947,7 +2743,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -1978,7 +2778,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2113,7 +2916,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2144,7 +2951,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2279,7 +3089,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2310,7 +3124,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2448,7 +3265,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -2479,7 +3300,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -2617,7 +3441,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2643,7 +3471,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2712,7 +3543,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -2776,7 +3611,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2802,7 +3641,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -2871,7 +3713,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -2935,7 +3781,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -2961,7 +3811,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -3030,7 +3883,11 @@
 										"speed": {
 											"default": "auto",
 											"description": "Codex speed normalization strategy.",
-											"enum": ["auto", "standard", "fast"],
+											"enum": [
+												"auto",
+												"standard",
+												"fast"
+											],
 											"markdownDescription": "Codex speed normalization strategy.",
 											"type": "string"
 										},
@@ -3097,7 +3954,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3123,7 +3984,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3192,7 +4056,11 @@
 								"speed": {
 									"default": "auto",
 									"description": "Codex speed normalization strategy.",
-									"enum": ["auto", "standard", "fast"],
+									"enum": [
+										"auto",
+										"standard",
+										"fast"
+									],
 									"markdownDescription": "Codex speed normalization strategy.",
 									"type": "string"
 								},
@@ -3269,7 +4137,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3295,7 +4167,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3443,7 +4318,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3469,7 +4348,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3613,7 +4495,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3644,7 +4530,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3779,7 +4668,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -3810,7 +4703,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -3918,7 +4814,12 @@
 								"costSource": {
 									"default": "auto",
 									"description": "Source for statusline cost calculation.",
-									"enum": ["auto", "ccusage", "cc", "both"],
+									"enum": [
+										"auto",
+										"ccusage",
+										"cc",
+										"both"
+									],
 									"markdownDescription": "Source for statusline cost calculation.",
 									"type": "string"
 								},
@@ -3970,7 +4871,12 @@
 								"visualBurnRate": {
 									"default": "off",
 									"description": "Visual burn-rate display mode.",
-									"enum": ["off", "emoji", "text", "emoji-text"],
+									"enum": [
+										"off",
+										"emoji",
+										"text",
+										"emoji-text"
+									],
 									"markdownDescription": "Visual burn-rate display mode.",
 									"type": "string"
 								}
@@ -4024,7 +4930,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -4050,7 +4960,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -4210,7 +5123,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4241,7 +5158,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4376,7 +5296,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4407,7 +5331,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4542,7 +5469,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -4573,7 +5504,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -4711,7 +5645,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -4742,7 +5680,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -4882,7 +5823,11 @@
 						"mode": {
 							"default": "auto",
 							"description": "Cost calculation mode.",
-							"enum": ["auto", "calculate", "display"],
+							"enum": [
+								"auto",
+								"calculate",
+								"display"
+							],
 							"markdownDescription": "Cost calculation mode.",
 							"type": "string"
 						},
@@ -4913,7 +5858,10 @@
 						"order": {
 							"default": "asc",
 							"description": "Sort order.",
-							"enum": ["desc", "asc"],
+							"enum": [
+								"desc",
+								"asc"
+							],
 							"markdownDescription": "Sort order.",
 							"type": "string"
 						},
@@ -5056,7 +6004,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5087,7 +6039,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5222,7 +6177,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5253,7 +6212,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5388,7 +6350,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5419,7 +6385,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5557,7 +6526,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -5588,7 +6561,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -5734,7 +6710,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5765,7 +6745,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -5900,7 +6883,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -5931,7 +6918,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6066,7 +7056,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6097,7 +7091,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6235,7 +7232,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -6266,7 +7267,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -6412,7 +7416,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6443,7 +7451,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6578,7 +7589,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6609,7 +7624,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6744,7 +7762,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -6775,7 +7797,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -6913,7 +7938,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -6944,7 +7973,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -7090,7 +8122,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7121,7 +8157,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7256,7 +8295,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7287,7 +8330,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7422,7 +8468,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7453,7 +8503,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7591,7 +8644,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -7622,7 +8679,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -7768,7 +8828,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7799,7 +8863,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -7934,7 +9001,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -7965,7 +9036,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8100,7 +9174,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8131,7 +9209,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8269,7 +9350,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -8300,7 +9385,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -8446,7 +9534,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8477,7 +9569,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8612,7 +9707,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8643,7 +9742,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8778,7 +9880,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -8809,7 +9915,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -8947,7 +10056,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -8978,7 +10091,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -9124,7 +10240,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9155,7 +10275,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9290,7 +10413,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9321,7 +10448,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9456,7 +10586,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9487,7 +10621,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9625,7 +10762,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -9656,7 +10797,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -9794,7 +10938,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9825,7 +10973,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -9951,7 +11102,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -9982,7 +11137,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10108,7 +11266,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10139,7 +11301,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10268,7 +11433,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -10299,7 +11468,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -10444,7 +11616,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10475,7 +11651,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10610,7 +11789,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10641,7 +11824,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10776,7 +11962,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10807,7 +11997,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -10942,7 +12135,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -10973,7 +12170,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11111,7 +12311,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -11142,7 +12346,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -11280,7 +12487,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11306,7 +12517,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11437,7 +12651,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11463,7 +12681,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11594,7 +12815,11 @@
 										},
 										"mode": {
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11620,7 +12845,10 @@
 										},
 										"order": {
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -11754,7 +12982,11 @@
 								},
 								"mode": {
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -11780,7 +13012,10 @@
 								},
 								"order": {
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},
@@ -11881,7 +13116,10 @@
 										"type": "string"
 									}
 								},
-								"required": ["name", "path"],
+								"required": [
+									"name",
+									"path"
+								],
 								"type": "object"
 							},
 							"markdownDescription": "Additional named pi-format session stores included in all-agent reports.",
@@ -11953,7 +13191,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -11984,7 +13226,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12119,7 +13364,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -12150,7 +13399,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12285,7 +13537,11 @@
 										"mode": {
 											"default": "auto",
 											"description": "Cost calculation mode.",
-											"enum": ["auto", "calculate", "display"],
+											"enum": [
+												"auto",
+												"calculate",
+												"display"
+											],
 											"markdownDescription": "Cost calculation mode.",
 											"type": "string"
 										},
@@ -12316,7 +13572,10 @@
 										"order": {
 											"default": "asc",
 											"description": "Sort order.",
-											"enum": ["desc", "asc"],
+											"enum": [
+												"desc",
+												"asc"
+											],
 											"markdownDescription": "Sort order.",
 											"type": "string"
 										},
@@ -12454,7 +13713,11 @@
 								"mode": {
 									"default": "auto",
 									"description": "Cost calculation mode.",
-									"enum": ["auto", "calculate", "display"],
+									"enum": [
+										"auto",
+										"calculate",
+										"display"
+									],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
 								},
@@ -12485,7 +13748,10 @@
 								"order": {
 									"default": "asc",
 									"description": "Sort order.",
-									"enum": ["desc", "asc"],
+									"enum": [
+										"desc",
+										"asc"
+									],
 									"markdownDescription": "Sort order.",
 									"type": "string"
 								},

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
 						{ text: 'Grok Build CLI', link: '/guide/grok/' },
+						{ text: 'Antigravity', link: '/guide/antigravity/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],
 				},

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -62,8 +62,9 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 | Kimi           | `kimi`     | `ccusage kimi daily`      |
 | Qwen           | `qwen`     | `ccusage qwen daily`      |
 | Copilot CLI    | `copilot`  | `ccusage copilot daily`   |
-| Gemini CLI     | `gemini`   | `ccusage gemini daily`    |
-| Grok Build CLI | `grok`     | `ccusage grok daily`      |
+| Gemini CLI     | `gemini`      | `ccusage gemini daily`      |
+| Grok Build CLI | `grok`        | `ccusage grok daily`        |
+| Antigravity    | `antigravity` | `ccusage antigravity daily` |
 
 ## When to Focus a Source
 

--- a/docs/guide/antigravity/index.md
+++ b/docs/guide/antigravity/index.md
@@ -1,0 +1,38 @@
+# Antigravity
+
+> Antigravity support reads local conversation SQLite databases.
+
+## Quick Start
+
+```sh
+# Daily usage report
+ccusage antigravity daily
+
+# Monthly usage report
+ccusage antigravity monthly
+
+# Session usage report
+ccusage antigravity session
+```
+
+## Data Source
+
+The CLI reads Antigravity conversation databases from:
+- `~/.gemini/antigravity/conversations/*.db`
+- `~/.gemini/antigravity-ide/conversations/*.db`
+- `~/.gemini/antigravity-cli/conversations/*.db`
+- `~/.gemini/antigravity-backup/conversations/*.db`
+
+You can override the discovery path using `ANTIGRAVITY_DATA_DIR` (supports single root or comma-separated list of roots):
+
+```sh
+ANTIGRAVITY_DATA_DIR="$HOME/.gemini/antigravity" ccusage antigravity daily
+```
+
+## Supported Reports
+
+| Command                     | Description                     | Documentation Reference                  |
+| --------------------------- | ------------------------------- | ---------------------------------------- |
+| `ccusage antigravity daily`   | Group usage by day              | [Daily Usage](/guide/daily-reports)     |
+| `ccusage antigravity monthly` | Group usage by month            | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage antigravity session` | Group usage by session UUID     | [Session Usage](/guide/session-reports) |

--- a/docs/guide/config-files.md
+++ b/docs/guide/config-files.md
@@ -180,7 +180,7 @@ Override shared defaults for specific unified reports and legacy Claude commands
 
 ### Source-Specific Configuration
 
-Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, `gemini`, and `grok`.
+Use data source namespaces to set defaults and report overrides. Supported namespaces are `claude`, `codex`, `opencode`, `amp`, `droid`, `codebuff`, `hermes`, `pi`, `goose`, `openclaw`, `kilo`, `kimi`, `qwen`, `copilot`, `gemini`, `grok`, and `antigravity`.
 
 ```json
 {
@@ -257,6 +257,11 @@ Use data source namespaces to set defaults and report overrides. Supported names
 		}
 	},
 	"gemini": {
+		"defaults": {
+			"offline": true
+		}
+	},
+	"antigravity": {
 		"defaults": {
 			"offline": true
 		}

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -24,6 +24,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI    | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI     | `~/.gemini/tmp`                    |
 | `GROK_HOME`                       | Grok Build CLI | `~/.grok`                          |
+| `ANTIGRAVITY_DATA_DIR`            | Antigravity    | `~/.gemini/antigravity`, `~/.gemini/antigravity-ide`, `~/.gemini/antigravity-cli`, `~/.gemini/antigravity-backup` |
 
 Example:
 
@@ -43,6 +44,7 @@ export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GEMINI_DATA_DIR="/path/to/gemini/tmp,/archive/gemini/tmp"
 export GROK_HOME="/path/to/grok-home"
+export ANTIGRAVITY_DATA_DIR="/path/to/antigravity,/archive/antigravity"
 ccusage daily
 ```
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -177,6 +177,7 @@ If ccusage shows no data, check:
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
    - Grok Build CLI: `${GROK_HOME:-~/.grok}`
+   - Antigravity: `${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity}` (also scans `~/.gemini/antigravity-ide`, `~/.gemini/antigravity-cli`, `~/.gemini/antigravity-backup`)
 
 ### Custom Data Directory
 
@@ -198,6 +199,7 @@ export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GROK_HOME="/path/to/grok-home"
+export ANTIGRAVITY_DATA_DIR="/path/to/antigravity"
 ```
 
 Each source-specific path variable can also contain comma-separated directories, except `GROK_HOME`, which takes a single root:
@@ -215,6 +217,7 @@ export OPENCLAW_DIR="/path/to/openclaw,/archive/openclaw"
 export KILO_DATA_DIR="/path/to/kilo,/archive/kilo"
 export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
+export ANTIGRAVITY_DATA_DIR="/path/to/antigravity,/archive/antigravity"
 ```
 
 ## Getting Help

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -88,13 +88,14 @@ ccusage reads from local coding CLI data directories:
 | Kimi           | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`) |
 | Qwen           | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
 | Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
-| Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
-| Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                           |
+| Gemini CLI     | `gemini`      | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
+| Grok Build CLI | `grok`        | `${GROK_HOME:-~/.grok}`                           |
+| Antigravity    | `antigravity` | `${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity}` (also `~/.gemini/antigravity-ide`, `~/.gemini/antigravity-cli`, `~/.gemini/antigravity-backup`) |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, legacy Grok CLI SQLite data, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Devin CLI.
 
 ## Report Shape
 
@@ -126,6 +127,7 @@ ccusage qwen daily
 ccusage copilot daily
 ccusage gemini daily
 ccusage grok daily
+ccusage antigravity daily
 ```
 
 Use `ccusage <source> <report>` only when you want to narrow a report to one source.

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -19,16 +19,6 @@ Local transcript text alone is not enough. A transcript can be useful for debugg
 
 ## Unsupported Sources Investigated
 
-::: details Why is Antigravity CLI not supported?
-Antigravity CLI is separate from Gemini CLI. The Antigravity CLI binary is exposed as `agy`, and it stores state under `~/.gemini/antigravity-cli/`.
-
-The current local data has conversation files such as `conversations/<conversation-id>.pb`, plus lightweight history and cache JSON files. The `.pb` files are opaque binary payloads and do not expose readable token usage, model usage, or per-turn accounting without Antigravity's private schema and storage semantics.
-
-The CLI log files include operational events such as conversation creation, streaming, prompt length, auth, and model configuration messages. They do not include input, output, cache, or reasoning token counts. Quota-oriented tools can inspect remaining Antigravity quota, but quota snapshots are not the same as historical per-session token usage.
-
-Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
-:::
-
 ::: details Why is Devin CLI not supported?
 Devin CLI usage information appears to live in Devin's cloud service rather than in a local usage log that ccusage can read. The locally available data did not provide direct access to historical token usage or costs.
 
@@ -36,6 +26,10 @@ ccusage is a local, read-only analyzer. It does not scrape private cloud service
 :::
 
 ## Previously Unsupported, Now Supported
+
+::: details Antigravity
+Earlier investigations looked at binary payload files without full decoding semantics. Antigravity is now supported: ccusage reads conversation databases from `~/.gemini/antigravity/conversations/*.db`, `~/.gemini/antigravity-ide/conversations/*.db`, `~/.gemini/antigravity-cli/conversations/*.db`, and `~/.gemini/antigravity-backup/conversations/*.db` (or `ANTIGRAVITY_DATA_DIR`), extracting per-turn token usage, models, and timestamps from protobuf metadata blobs in SQLite records. See [Antigravity](/guide/antigravity/).
+:::
 
 ::: details Grok Build CLI
 Earlier investigations looked at local Grok data that did not expose usable token

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,6 +121,7 @@ version = "0.0.0"
 dependencies = [
  "ccusage-adapter-all",
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -153,6 +154,7 @@ name = "ccusage-adapter-all"
 version = "0.0.0"
 dependencies = [
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -187,6 +189,19 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-antigravity"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde",
+ "serde_json",
+ "sqlite",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 [workspace.dependencies]
 ccusage-adapter-all = { path = "crates/ccusage-adapter-all" }
 ccusage-adapter-amp = { path = "adapters/amp" }
+ccusage-adapter-antigravity = { path = "adapters/antigravity" }
 ccusage-adapter-claude = { path = "adapters/claude" }
 ccusage-adapter-codebuff = { path = "adapters/codebuff" }
 ccusage-adapter-codex = { path = "adapters/codex" }

--- a/rust/adapters/antigravity/Cargo.toml
+++ b/rust/adapters/antigravity/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ccusage-adapter-antigravity"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+sqlite.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/antigravity/README.md
+++ b/rust/adapters/antigravity/README.md
@@ -1,0 +1,87 @@
+# Antigravity Source
+
+Tracks [Google Antigravity](https://antigravity.google) (agentic IDE + CLI,
+Windsurf-derived) usage from local SQLite conversation databases.
+
+Data source:
+
+```text
+${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity}/conversations/<uuid>.db
+~/.gemini/antigravity-cli/conversations/<uuid>.db
+~/.gemini/antigravity-ide/conversations/<uuid>.db
+~/.gemini/antigravity-backup/conversations/<uuid>.db
+```
+
+`ANTIGRAVITY_DATA_DIR` accepts one root or a comma-separated list of roots
+and replaces the default `~/.gemini/antigravity*` set. Missing roots are
+skipped. `*.db-wal`/`*.db-shm` sidecars and legacy `.pb` conversation files
+(compressed/encrypted, unsupported) are ignored. A database without a
+`gen_metadata` table is not an Antigravity conversation DB and yields nothing.
+
+Commands:
+
+```sh
+ccusage antigravity daily
+ccusage antigravity monthly
+ccusage antigravity session
+ccusage antigravity daily --json
+```
+
+## Protobuf field map
+
+`gen_metadata.data` (ordered by `idx`) holds one `GeneratorMetadata` message
+per generation, decoded with a hand-rolled wire-format reader (no .proto):
+
+- field 1 (LEN message) → chatModel
+  - field 19 (LEN string) → raw model id
+  - field 9 (LEN message) → generation info; its field 4 → timestamp
+    `{1: seconds varint, 2: nanos varint}` (nanos must be `0..=999_999_999`)
+  - field 4 (LEN message) → usage
+    - field 1 (varint) → fixed system-prompt input tokens
+    - field 2 (varint) → fresh (non-cached) input tokens
+    - field 5 (varint) → cache-read tokens
+    - field 9 (varint) → output (text) tokens
+    - field 10 (varint) → thinking/reasoning tokens
+    - field 11 (LEN string) → responseId (dedup key, within and across DBs)
+
+`trajectory_metadata_blob.data` (first row) holds session fallbacks:
+
+- field 2 (LEN message) → `{1: seconds, 2: nanos}` session created-at
+  (fallback when a generation has no timestamp; final fallback is file mtime)
+- field 1 (LEN message) → field 1 (LEN string) → workspace `file://` URI
+  (percent-decoded; project/session identifier)
+
+## Token semantics
+
+- `input_tokens` = system-prompt (#1) + fresh input (#2). The system-prompt
+  component is a fixed per-generation charge (~1016–1266 tokens).
+- `cache_creation_input_tokens` is always 0.
+- Thinking tokens (#10) are excluded from the displayed `output_tokens` (#9),
+  ride in `extra_total_tokens` (so they still count toward total tokens), and
+  are folded into billable output tokens for cost calculation.
+- Rows where input + output + cache-read + thinking are all 0 are skipped.
+- The source stores no cost; cost comes from the shared pricing pipeline.
+
+## Model aliases
+
+Raw ids are mapped to LiteLLM-priced names case-insensitively; unknown ids
+pass through unchanged:
+
+```text
+model_placeholder_m26 → claude-opus-4-6
+model_placeholder_m35 → claude-sonnet-4-6
+model_placeholder_m36/m37/m16 → gemini-3.1-pro
+model_placeholder_m18/m84/m47 → gemini-3-flash-preview
+model_placeholder_m132/m133 → gemini-3.5-flash-high
+model_placeholder_m187 → gemini-3.5-flash-extra-low
+model_placeholder_m20 → gemini-3.5-flash-medium
+model_openai_gpt_oss_120b_medium → gpt-oss-120b-medium
+gemini-pro-default, gemini-pro-agent → gemini-3.1-pro
+gemini-3-flash-agent/-a/-b → gemini-3.5-flash-high
+gemini-3-flash-c, gemini-3-flash → gemini-3-flash-preview
+gemini-3.5-flash-low → gemini-3.5-flash-medium
+gemini-3.1-pro-high/-low → gemini-3.1-pro
+gemini-3-pro-high/-low → gemini-3-pro
+claude-opus-4-6-thinking → claude-opus-4-6
+claude-sonnet-4-6-thinking → claude-sonnet-4-6
+```

--- a/rust/adapters/antigravity/src/lib.rs
+++ b/rust/adapters/antigravity/src/lib.rs
@@ -1,0 +1,48 @@
+use ccusage_adapter_common::filter_loaded_entries_by_date;
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod proto;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        ccusage_core::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Antigravity Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/antigravity/src/loader.rs
+++ b/rust/adapters/antigravity/src/loader.rs
@@ -1,0 +1,402 @@
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use super::{
+    parser::{self, TrajectoryMetadata},
+    paths,
+};
+use ccusage_adapter_common::read_files_parallel;
+use ccusage_core::cli::{CostMode, SharedArgs};
+use ccusage_core::*;
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Antigravity"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let roots = paths::paths()?;
+    // Fast detection: without Antigravity data roots there is nothing to do.
+    if roots.is_empty() {
+        return Ok(Vec::new());
+    }
+    load_entries_from_roots(&roots, shared, pricing)
+}
+
+pub(super) fn load_entries_from_roots(
+    roots: &[PathBuf],
+    shared: &SharedArgs,
+    pricing: &PricingMap,
+) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let mut db_paths = Vec::new();
+    for root in roots {
+        db_paths.extend(paths::conversation_db_paths(root));
+    }
+    // Open each database in parallel (a fresh read-only connection per DB),
+    // then run the sequential responseId dedup over the original path order so
+    // the surviving record per id matches the single-threaded read.
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        load_entries_from_database(db_path, tz.as_ref(), shared.mode, Some(pricing), shared)
+    });
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for db_entries in loaded {
+        for entry in db_entries {
+            if let Some(id) = entry.data.message.id.as_deref().filter(|id| !id.is_empty())
+                && !seen.insert(id.to_string())
+            {
+                continue;
+            }
+            entries.push(entry);
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_entries_from_database(
+    db_path: &Path,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+    shared: &SharedArgs,
+) -> Vec<LoadedEntry> {
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        debug_log(
+            shared,
+            format!("Failed to open Antigravity database: {}", db_path.display()),
+        );
+        return Vec::new();
+    };
+    // A database without gen_metadata is not an Antigravity conversation DB.
+    let Ok(mut statement) = connection.prepare("SELECT data FROM gen_metadata ORDER BY idx") else {
+        return Vec::new();
+    };
+    let trajectory = read_trajectory_metadata(&connection);
+    let context = parser::session_context(db_path, &trajectory, file_mtime_ms(db_path));
+
+    let mut entries = Vec::new();
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                let Ok(blob) = statement.read::<Vec<u8>, _>(0) else {
+                    continue;
+                };
+                let record = parser::decode_generation(&blob);
+                if let Some(entry) =
+                    parser::generation_to_entry(&record, &context, tz, mode, pricing)
+                {
+                    entries.push(entry);
+                }
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => {
+                debug_log(
+                    shared,
+                    format!(
+                        "Failed to query Antigravity database: {}",
+                        db_path.display()
+                    ),
+                );
+                break;
+            }
+        }
+    }
+    entries
+}
+
+fn read_trajectory_metadata(connection: &sqlite::Connection) -> TrajectoryMetadata {
+    let Ok(mut statement) = connection.prepare("SELECT data FROM trajectory_metadata_blob LIMIT 1")
+    else {
+        return TrajectoryMetadata::default();
+    };
+    if let Ok(sqlite::State::Row) = statement.next()
+        && let Ok(blob) = statement.read::<Vec<u8>, _>(0)
+    {
+        return parser::decode_trajectory_metadata(&blob);
+    }
+    TrajectoryMetadata::default()
+}
+
+fn file_mtime_ms(db_path: &Path) -> Option<i64> {
+    let modified = fs::metadata(db_path).ok()?.modified().ok()?;
+    let millis = modified
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_millis();
+    i64::try_from(millis).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::Path;
+
+    use super::{super::parser::encode, *};
+    use crate::cli::SharedArgs;
+    use ccusage_test_support::fs_fixture;
+
+    fn create_conversation_db(path: &Path, generations: &[Vec<u8>], trajectory: Option<&[u8]>) {
+        let db = sqlite::open(path).unwrap();
+        db.execute("CREATE TABLE gen_metadata (idx INTEGER, data BLOB)")
+            .unwrap();
+        let mut statement = db
+            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (?1, ?2)")
+            .unwrap();
+        for (index, blob) in generations.iter().enumerate() {
+            statement.bind((1, index as i64)).unwrap();
+            statement.bind((2, blob.as_slice())).unwrap();
+            statement.next().unwrap();
+            statement.reset().unwrap();
+        }
+        if let Some(trajectory) = trajectory {
+            db.execute("CREATE TABLE trajectory_metadata_blob (data BLOB)")
+                .unwrap();
+            let mut statement = db
+                .prepare("INSERT INTO trajectory_metadata_blob (data) VALUES (?1)")
+                .unwrap();
+            statement.bind((1, trajectory)).unwrap();
+            statement.next().unwrap();
+        }
+    }
+
+    fn generation(
+        model: &'static str,
+        response_id: &'static str,
+        input: u64,
+        output: u64,
+    ) -> Vec<u8> {
+        encode::generation_blob(&encode::Generation {
+            model,
+            timestamp: Some((1_767_312_000, 0)),
+            system_input: 1000,
+            fresh_input: input,
+            cache_read: 10,
+            output,
+            thinking: 5,
+            response_id,
+        })
+    }
+
+    fn load(roots: &[PathBuf]) -> Vec<LoadedEntry> {
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        load_entries_from_roots(roots, &shared, &PricingMap::default()).unwrap()
+    }
+
+    #[test]
+    fn loads_generation_entries_from_conversation_db() {
+        let fixture = fs_fixture!({});
+        let root = fixture.create_dir_all("antigravity/conversations");
+        create_conversation_db(
+            &root.join("conv-1.db"),
+            &[generation("gemini-3.1-pro-low", "resp-1", 6321, 604)],
+            Some(&encode::trajectory_blob(
+                Some((1_767_312_000, 0)),
+                "file:///Users/test/My%20Projects/app",
+            )),
+        );
+
+        let entries = load(&[fixture.path("antigravity")]);
+
+        assert_eq!(entries.len(), 1);
+        let entry = &entries[0];
+        assert_eq!(entry.session_id.as_ref(), "conv-1");
+        assert_eq!(entry.project.as_ref(), "app");
+        assert_eq!(entry.project_path.as_ref(), "/Users/test/My Projects/app");
+        assert_eq!(entry.model.as_deref(), Some("gemini-3.1-pro"));
+        assert_eq!(entry.data.message.id.as_deref(), Some("resp-1"));
+        assert_eq!(entry.data.message.usage.input_tokens, 1000 + 6321);
+        assert_eq!(entry.data.message.usage.output_tokens, 604);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 10);
+        assert_eq!(entry.extra_total_tokens, 5);
+        assert_eq!(entry.date, "2026-01-02");
+    }
+
+    #[test]
+    fn dedupes_response_ids_within_and_across_dbs() {
+        let fixture = fs_fixture!({});
+        let root_a = fixture.create_dir_all("antigravity/conversations");
+        let root_b = fixture.create_dir_all("antigravity-cli/conversations");
+        create_conversation_db(
+            &root_a.join("conv-a.db"),
+            &[
+                generation("gemini-3.1-pro-low", "resp-1", 100, 1),
+                generation("gemini-3.1-pro-low", "resp-1", 999, 9),
+                generation("gemini-3.1-pro-low", "resp-2", 200, 2),
+            ],
+            None,
+        );
+        create_conversation_db(
+            &root_b.join("conv-b.db"),
+            &[
+                generation("gemini-pro-default", "resp-2", 888, 8),
+                generation("gemini-pro-default", "resp-3", 300, 3),
+            ],
+            None,
+        );
+
+        let entries = load(&[fixture.path("antigravity"), fixture.path("antigravity-cli")]);
+
+        assert_eq!(entries.len(), 3);
+        // First occurrence wins, both within one DB and across DBs.
+        let tokens: Vec<u64> = entries
+            .iter()
+            .map(|entry| entry.data.message.usage.input_tokens)
+            .collect();
+        assert_eq!(tokens, vec![1100, 1200, 1300]);
+    }
+
+    #[test]
+    fn keeps_generations_without_response_id() {
+        let fixture = fs_fixture!({});
+        let root = fixture.create_dir_all("antigravity/conversations");
+        create_conversation_db(
+            &root.join("conv-1.db"),
+            &[
+                generation("gemini-3.1-pro-low", "", 100, 1),
+                generation("gemini-3.1-pro-low", "", 100, 1),
+            ],
+            None,
+        );
+
+        let entries = load(&[fixture.path("antigravity")]);
+
+        assert_eq!(entries.len(), 2);
+    }
+
+    #[test]
+    fn skips_all_zero_generations() {
+        let fixture = fs_fixture!({});
+        let root = fixture.create_dir_all("antigravity/conversations");
+        create_conversation_db(
+            &root.join("conv-1.db"),
+            &[
+                encode::generation_blob(&encode::Generation {
+                    model: "gemini-3.1-pro-low",
+                    timestamp: Some((1_767_312_000, 0)),
+                    system_input: 0,
+                    fresh_input: 0,
+                    cache_read: 0,
+                    output: 0,
+                    thinking: 0,
+                    response_id: "resp-zero",
+                }),
+                generation("gemini-3.1-pro-low", "resp-1", 100, 1),
+            ],
+            None,
+        );
+
+        let entries = load(&[fixture.path("antigravity")]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.id.as_deref(), Some("resp-1"));
+    }
+
+    #[test]
+    fn ignores_databases_without_gen_metadata() {
+        let fixture = fs_fixture!({});
+        let root = fixture.create_dir_all("antigravity/conversations");
+        let db = sqlite::open(root.join("other.db")).unwrap();
+        db.execute("CREATE TABLE steps (idx INTEGER, data BLOB)")
+            .unwrap();
+
+        let entries = load(&[fixture.path("antigravity")]);
+
+        assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn falls_back_to_trajectory_created_at_then_file_mtime() {
+        let fixture = fs_fixture!({});
+        let root = fixture.create_dir_all("antigravity/conversations");
+        let no_timestamp = |response_id: &'static str| {
+            encode::generation_blob(&encode::Generation {
+                model: "gemini-3.1-pro-low",
+                timestamp: None,
+                system_input: 1000,
+                fresh_input: 100,
+                cache_read: 0,
+                output: 1,
+                thinking: 0,
+                response_id,
+            })
+        };
+        create_conversation_db(
+            &root.join("conv-with-trajectory.db"),
+            &[no_timestamp("resp-1")],
+            Some(&encode::trajectory_blob(
+                Some((1_767_312_000, 0)),
+                "file:///Users/test/app",
+            )),
+        );
+        create_conversation_db(&root.join("conv-mtime.db"), &[no_timestamp("resp-2")], None);
+
+        let entries = load(&[fixture.path("antigravity")]);
+
+        assert_eq!(entries.len(), 2);
+        let with_trajectory = entries
+            .iter()
+            .find(|entry| entry.session_id.as_ref() == "conv-with-trajectory")
+            .unwrap();
+        assert_eq!(
+            with_trajectory.timestamp,
+            crate::TimestampMs::from_millis(1_767_312_000_000)
+        );
+        let with_mtime = entries
+            .iter()
+            .find(|entry| entry.session_id.as_ref() == "conv-mtime")
+            .unwrap();
+        let mtime_ms = i64::try_from(
+            std::fs::metadata(root.join("conv-mtime.db"))
+                .unwrap()
+                .modified()
+                .unwrap()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_millis(),
+        )
+        .unwrap();
+        assert_eq!(
+            with_mtime.timestamp,
+            crate::TimestampMs::from_millis(mtime_ms)
+        );
+    }
+
+    #[test]
+    fn discovers_default_roots_under_home() {
+        let fixture = fs_fixture!({
+            ".gemini/antigravity/conversations/.keep": "",
+            ".gemini/antigravity-cli/conversations/.keep": "",
+            ".gemini/antigravity-ide/conversations/.keep": "",
+        });
+        let _env = ccusage_test_support::EnvVarsGuard::set_many([
+            ("HOME", Some(fixture.root().as_os_str().to_os_string())),
+            (paths::ANTIGRAVITY_DATA_DIR_ENV, None),
+        ]);
+
+        let roots = paths::paths().unwrap();
+
+        assert_eq!(
+            roots,
+            vec![
+                fixture.path(".gemini/antigravity"),
+                fixture.path(".gemini/antigravity-cli"),
+                fixture.path(".gemini/antigravity-ide"),
+            ]
+        );
+    }
+}

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -1,0 +1,650 @@
+use std::{borrow::Cow, path::Path};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use super::proto::{FieldValue, read_fields};
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
+    missing_pricing_model_for_usage,
+};
+
+/// Token counts, model id, timestamp, and response id decoded from one
+/// `gen_metadata` row of an Antigravity conversation database.
+#[derive(Debug, Default)]
+pub(super) struct GenerationMetadata {
+    pub(super) raw_model: Option<String>,
+    pub(super) timestamp_ms: Option<i64>,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_read_tokens: u64,
+    pub(super) thinking_tokens: u64,
+    pub(super) response_id: Option<String>,
+}
+
+/// Session-level fallbacks decoded from `trajectory_metadata_blob`.
+#[derive(Debug, Default)]
+pub(super) struct TrajectoryMetadata {
+    pub(super) created_ms: Option<i64>,
+    pub(super) workspace_uri: Option<String>,
+}
+
+/// Shared per-database context used to shape every generation entry.
+pub(super) struct SessionContext {
+    pub(super) session_id: String,
+    pub(super) project: String,
+    pub(super) project_path: String,
+    pub(super) fallback_timestamp: TimestampMs,
+}
+
+impl GenerationMetadata {
+    fn total_tokens(&self) -> u64 {
+        self.input_tokens
+            .saturating_add(self.output_tokens)
+            .saturating_add(self.cache_read_tokens)
+            .saturating_add(self.thinking_tokens)
+    }
+}
+
+/// Decodes one `GeneratorMetadata` blob. Layout (hand-verified, no .proto):
+///
+/// - field 1 (LEN message) → chatModel
+///   - field 19 (LEN string) → raw model id
+///   - field 9 (LEN message) → generation info; its field 4 → timestamp
+///     message `{1: seconds varint, 2: nanos varint}`
+///   - field 4 (LEN message) → usage
+///     - field 1 (varint) → fixed system-prompt input tokens
+///     - field 2 (varint) → fresh (non-cached) input tokens
+///     - field 5 (varint) → cache-read tokens
+///     - field 9 (varint) → output (text) tokens
+///     - field 10 (varint) → thinking/reasoning tokens
+///     - field 11 (LEN string) → responseId (dedup key)
+pub(super) fn decode_generation(bytes: &[u8]) -> GenerationMetadata {
+    let mut metadata = GenerationMetadata::default();
+    for (number, value) in read_fields(bytes) {
+        if number != 1 {
+            continue;
+        }
+        let FieldValue::LengthDelimited(chat_model) = value else {
+            continue;
+        };
+        for (number, value) in read_fields(chat_model) {
+            match (number, value) {
+                (19, FieldValue::LengthDelimited(model)) => {
+                    metadata.raw_model = utf8_string(model);
+                }
+                (9, FieldValue::LengthDelimited(info)) => {
+                    metadata.timestamp_ms = decode_generation_timestamp(info);
+                }
+                (4, FieldValue::LengthDelimited(usage)) => decode_usage(usage, &mut metadata),
+                _ => {}
+            }
+        }
+    }
+    metadata
+}
+
+fn decode_generation_timestamp(info: &[u8]) -> Option<i64> {
+    for (number, value) in read_fields(info) {
+        if number == 4
+            && let FieldValue::LengthDelimited(timestamp) = value
+        {
+            return decode_timestamp(timestamp);
+        }
+    }
+    None
+}
+
+/// Decodes `{1: seconds varint, 2: nanos varint}` into Unix epoch
+/// milliseconds. Nanos outside `0..=999_999_999` reject the timestamp.
+fn decode_timestamp(bytes: &[u8]) -> Option<i64> {
+    let mut seconds = None;
+    let mut nanos = None;
+    for (number, value) in read_fields(bytes) {
+        let FieldValue::Varint(value) = value else {
+            continue;
+        };
+        match number {
+            1 => seconds = Some(clamp_varint(value)),
+            2 => nanos = Some(value),
+            _ => {}
+        }
+    }
+    let seconds = i64::try_from(seconds?).ok()?;
+    let nanos = nanos.unwrap_or(0);
+    if nanos > 999_999_999 {
+        return None;
+    }
+    let millis = i64::try_from(nanos / 1_000_000).ok()?;
+    seconds.checked_mul(1_000)?.checked_add(millis)
+}
+
+fn decode_usage(usage: &[u8], metadata: &mut GenerationMetadata) {
+    let mut system_input = 0_u64;
+    let mut fresh_input = 0_u64;
+    for (number, value) in read_fields(usage) {
+        match (number, value) {
+            (1, FieldValue::Varint(value)) => system_input = clamp_varint(value),
+            (2, FieldValue::Varint(value)) => fresh_input = clamp_varint(value),
+            (5, FieldValue::Varint(value)) => metadata.cache_read_tokens = clamp_varint(value),
+            (9, FieldValue::Varint(value)) => metadata.output_tokens = clamp_varint(value),
+            (10, FieldValue::Varint(value)) => metadata.thinking_tokens = clamp_varint(value),
+            (11, FieldValue::LengthDelimited(id)) => metadata.response_id = utf8_string(id),
+            _ => {}
+        }
+    }
+    metadata.input_tokens = system_input.saturating_add(fresh_input);
+}
+
+/// Decodes a `trajectory_metadata_blob` row: field 2 holds the session
+/// created-at timestamp, field 1 → field 1 holds the workspace `file://` URI.
+pub(super) fn decode_trajectory_metadata(bytes: &[u8]) -> TrajectoryMetadata {
+    let mut metadata = TrajectoryMetadata::default();
+    for (number, value) in read_fields(bytes) {
+        match (number, value) {
+            (2, FieldValue::LengthDelimited(timestamp)) => {
+                metadata.created_ms = decode_timestamp(timestamp);
+            }
+            (1, FieldValue::LengthDelimited(inner)) => {
+                for (number, value) in read_fields(inner) {
+                    if number == 1
+                        && let FieldValue::LengthDelimited(uri) = value
+                    {
+                        metadata.workspace_uri = utf8_string(uri);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    metadata
+}
+
+fn utf8_string(bytes: &[u8]) -> Option<String> {
+    std::str::from_utf8(bytes)
+        .ok()
+        .filter(|value| !value.is_empty())
+        .map(str::to_string)
+}
+
+/// Token varints are clamped to `i64::MAX` so corrupt blobs cannot wrap the
+/// counters into negative or overflowing values downstream.
+fn clamp_varint(value: u64) -> u64 {
+    value.min(i64::MAX as u64)
+}
+
+/// Maps Antigravity's raw model ids to LiteLLM-priced names
+/// (case-insensitive). Unknown ids pass through unchanged; the pricing lookup
+/// handles misses gracefully.
+pub(super) fn resolve_model_name(raw: &str) -> Cow<'_, str> {
+    let resolved = match raw.to_ascii_lowercase().as_str() {
+        "model_placeholder_m26" => "claude-opus-4-6",
+        "model_placeholder_m35" => "claude-sonnet-4-6",
+        "model_placeholder_m36" | "model_placeholder_m37" | "model_placeholder_m16" => {
+            "gemini-3.1-pro"
+        }
+        "model_placeholder_m18" | "model_placeholder_m84" | "model_placeholder_m47" => {
+            "gemini-3-flash-preview"
+        }
+        "model_placeholder_m132" | "model_placeholder_m133" => "gemini-3.5-flash-high",
+        "model_placeholder_m187" => "gemini-3.5-flash-extra-low",
+        "model_placeholder_m20" => "gemini-3.5-flash-medium",
+        "model_openai_gpt_oss_120b_medium" => "gpt-oss-120b-medium",
+        "gemini-pro-default" | "gemini-pro-agent" => "gemini-3.1-pro",
+        "gemini-3-flash-agent" | "gemini-3-flash-a" | "gemini-3-flash-b" => "gemini-3.5-flash-high",
+        "gemini-3-flash-c" | "gemini-3-flash" => "gemini-3-flash-preview",
+        "gemini-3.5-flash-low" => "gemini-3.5-flash-medium",
+        "gemini-3.1-pro-high" | "gemini-3.1-pro-low" => "gemini-3.1-pro",
+        "gemini-3-pro-high" | "gemini-3-pro-low" => "gemini-3-pro",
+        "claude-opus-4-6-thinking" => "claude-opus-4-6",
+        "claude-sonnet-4-6-thinking" => "claude-sonnet-4-6",
+        _ => return Cow::Borrowed(raw),
+    };
+    Cow::Borrowed(resolved)
+}
+
+/// Builds the per-database context: conversation id from the file name,
+/// project from the percent-decoded workspace URI, and the timestamp fallback
+/// chain (session created-at, then file mtime).
+pub(super) fn session_context(
+    db_path: &Path,
+    trajectory: &TrajectoryMetadata,
+    file_mtime_ms: Option<i64>,
+) -> SessionContext {
+    let session_id = db_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let workspace_path = trajectory
+        .workspace_uri
+        .as_deref()
+        .and_then(workspace_path_from_uri);
+    let project = workspace_path
+        .as_deref()
+        .and_then(|path| {
+            Path::new(path)
+                .file_name()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| "unknown".to_string());
+    let fallback_ms = trajectory.created_ms.or(file_mtime_ms).unwrap_or_default();
+    SessionContext {
+        session_id,
+        project,
+        project_path: workspace_path.unwrap_or_else(|| "unknown".to_string()),
+        fallback_timestamp: TimestampMs::from_millis(fallback_ms),
+    }
+}
+
+/// Decodes a `file://` workspace URI into a filesystem path. Only `%XX`
+/// sequences are decoded; the URI authority (always empty for local
+/// workspaces) is skipped.
+pub(super) fn workspace_path_from_uri(uri: &str) -> Option<String> {
+    let path = uri.strip_prefix("file://")?;
+    if path.is_empty() {
+        return None;
+    }
+    Some(percent_decode(path))
+}
+
+fn percent_decode(input: &str) -> String {
+    let bytes = input.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%'
+            && index + 2 < bytes.len()
+            && let (Some(high), Some(low)) =
+                (hex_digit(bytes[index + 1]), hex_digit(bytes[index + 2]))
+        {
+            decoded.push(high << 4 | low);
+            index += 3;
+        } else {
+            decoded.push(bytes[index]);
+            index += 1;
+        }
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Shapes one decoded generation into a [`LoadedEntry`]. Rows whose input,
+/// output, cache-read, and thinking tokens are all zero carry no usage and
+/// are skipped. Thinking tokens ride in `extra_total_tokens` (like other
+/// agents with reasoning tokens) and are folded into billable output tokens
+/// for pricing.
+pub(super) fn generation_to_entry(
+    record: &GenerationMetadata,
+    context: &SessionContext,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<LoadedEntry> {
+    if record.total_tokens() == 0 {
+        return None;
+    }
+    let timestamp = record
+        .timestamp_ms
+        .map(TimestampMs::from_millis)
+        .unwrap_or(context.fallback_timestamp);
+    let timestamp_text = format_rfc3339_millis(timestamp);
+    let usage = TokenUsageRaw {
+        input_tokens: record.input_tokens,
+        output_tokens: record.output_tokens,
+        cache_creation_input_tokens: 0,
+        cache_read_input_tokens: record.cache_read_tokens,
+        speed: None,
+        cache_creation: None,
+    };
+    let billable_usage = TokenUsageRaw {
+        output_tokens: record.output_tokens.saturating_add(record.thinking_tokens),
+        ..usage
+    };
+    let model = record
+        .raw_model
+        .as_deref()
+        .map(|raw| resolve_model_name(raw).into_owned());
+    let cost = calculate_cost_for_usage(model.as_deref(), billable_usage, None, mode, pricing);
+    let missing_pricing_model =
+        missing_pricing_model_for_usage(model.as_deref(), billable_usage, None, mode, pricing);
+    let data = UsageEntry {
+        session_id: Some(context.session_id.clone()),
+        timestamp: timestamp_text,
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: model.clone(),
+            id: record.response_id.clone(),
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    Some(LoadedEntry {
+        date: format_date_tz(timestamp, tz),
+        timestamp,
+        project: std::sync::Arc::from(context.project.as_str()),
+        session_id: std::sync::Arc::from(context.session_id.as_str()),
+        project_path: std::sync::Arc::from(context.project_path.as_str()),
+        cost,
+        extra_total_tokens: record.thinking_tokens,
+        credits: None,
+        message_count: None,
+        model,
+        data,
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+    })
+}
+
+#[cfg(test)]
+pub(super) mod encode {
+    //! Tiny test-only protobuf encoder (varint + length-delimited fields).
+
+    pub fn varint_field(out: &mut Vec<u8>, field: u64, value: u64) {
+        key(out, field, 0);
+        varint(out, value);
+    }
+
+    pub fn len_field(out: &mut Vec<u8>, field: u64, bytes: &[u8]) {
+        key(out, field, 2);
+        varint(out, bytes.len() as u64);
+        out.extend_from_slice(bytes);
+    }
+
+    fn key(out: &mut Vec<u8>, field: u64, wire: u64) {
+        varint(out, field << 3 | wire);
+    }
+
+    fn varint(out: &mut Vec<u8>, mut value: u64) {
+        loop {
+            let mut byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value != 0 {
+                byte |= 0x80;
+            }
+            out.push(byte);
+            if value == 0 {
+                break;
+            }
+        }
+    }
+
+    pub struct Generation {
+        pub model: &'static str,
+        pub timestamp: Option<(u64, u64)>,
+        pub system_input: u64,
+        pub fresh_input: u64,
+        pub cache_read: u64,
+        pub output: u64,
+        pub thinking: u64,
+        pub response_id: &'static str,
+    }
+
+    pub fn generation_blob(generation: &Generation) -> Vec<u8> {
+        let mut chat_model = Vec::new();
+        len_field(&mut chat_model, 19, generation.model.as_bytes());
+        if let Some((seconds, nanos)) = generation.timestamp {
+            let mut timestamp = Vec::new();
+            varint_field(&mut timestamp, 1, seconds);
+            varint_field(&mut timestamp, 2, nanos);
+            let mut info = Vec::new();
+            len_field(&mut info, 4, &timestamp);
+            len_field(&mut chat_model, 9, &info);
+        }
+        let mut usage = Vec::new();
+        varint_field(&mut usage, 1, generation.system_input);
+        varint_field(&mut usage, 2, generation.fresh_input);
+        varint_field(&mut usage, 5, generation.cache_read);
+        varint_field(&mut usage, 9, generation.output);
+        varint_field(&mut usage, 10, generation.thinking);
+        len_field(&mut usage, 11, generation.response_id.as_bytes());
+        len_field(&mut chat_model, 4, &usage);
+        let mut blob = Vec::new();
+        len_field(&mut blob, 1, &chat_model);
+        blob
+    }
+
+    pub fn trajectory_blob(created: Option<(u64, u64)>, workspace_uri: &str) -> Vec<u8> {
+        let mut blob = Vec::new();
+        if let Some((seconds, nanos)) = created {
+            let mut timestamp = Vec::new();
+            varint_field(&mut timestamp, 1, seconds);
+            varint_field(&mut timestamp, 2, nanos);
+            len_field(&mut blob, 2, &timestamp);
+        }
+        let mut inner = Vec::new();
+        len_field(&mut inner, 1, workspace_uri.as_bytes());
+        len_field(&mut blob, 1, &inner);
+        blob
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode::*, *};
+
+    fn sample_generation() -> Generation {
+        Generation {
+            model: "gemini-3.1-pro-low",
+            timestamp: Some((1_767_312_000, 429_476_000)),
+            system_input: 1036,
+            fresh_input: 6321,
+            cache_read: 36491,
+            output: 604,
+            thinking: 117,
+            response_id: "resp-1",
+        }
+    }
+
+    #[test]
+    fn decodes_all_generation_fields() {
+        let metadata = decode_generation(&generation_blob(&sample_generation()));
+
+        assert_eq!(metadata.raw_model.as_deref(), Some("gemini-3.1-pro-low"));
+        assert_eq!(metadata.timestamp_ms, Some(1_767_312_000_429));
+        assert_eq!(metadata.input_tokens, 1036 + 6321);
+        assert_eq!(metadata.output_tokens, 604);
+        assert_eq!(metadata.cache_read_tokens, 36491);
+        assert_eq!(metadata.thinking_tokens, 117);
+        assert_eq!(metadata.response_id.as_deref(), Some("resp-1"));
+    }
+
+    #[test]
+    fn rejects_timestamp_with_out_of_range_nanos() {
+        let generation = Generation {
+            timestamp: Some((1_767_312_000, 1_000_000_000)),
+            ..sample_generation()
+        };
+        let metadata = decode_generation(&generation_blob(&generation));
+
+        assert_eq!(metadata.timestamp_ms, None);
+    }
+
+    #[test]
+    fn decodes_trajectory_metadata() {
+        let blob = trajectory_blob(
+            Some((1_767_312_000, 207_595_000)),
+            "file:///Users/test/My%20Projects/app",
+        );
+        let metadata = decode_trajectory_metadata(&blob);
+
+        assert_eq!(metadata.created_ms, Some(1_767_312_000_207));
+        assert_eq!(
+            metadata.workspace_uri.as_deref(),
+            Some("file:///Users/test/My%20Projects/app")
+        );
+    }
+
+    #[test]
+    fn workspace_uri_decodes_percent_escapes() {
+        assert_eq!(
+            workspace_path_from_uri("file:///Users/test/My%20Projects/app").as_deref(),
+            Some("/Users/test/My Projects/app")
+        );
+        assert_eq!(
+            workspace_path_from_uri("file:///home/user/%E2%82%ACrates").as_deref(),
+            Some("/home/user/€rates")
+        );
+        assert_eq!(
+            workspace_path_from_uri("file:///trailing%2").as_deref(),
+            Some("/trailing%2")
+        );
+        assert_eq!(workspace_path_from_uri("vscode://file/app"), None);
+    }
+
+    #[test]
+    fn session_context_uses_workspace_basename_as_project() {
+        let trajectory = TrajectoryMetadata {
+            created_ms: Some(1_767_312_000_207),
+            workspace_uri: Some("file:///Users/test/My%20Projects/app".to_string()),
+        };
+        let context = session_context(
+            Path::new("/data/conversations/conv-1.db"),
+            &trajectory,
+            Some(1_700_000_000_000),
+        );
+
+        assert_eq!(context.session_id, "conv-1");
+        assert_eq!(context.project, "app");
+        assert_eq!(context.project_path, "/Users/test/My Projects/app");
+        assert_eq!(
+            context.fallback_timestamp,
+            TimestampMs::from_millis(1_767_312_000_207)
+        );
+    }
+
+    #[test]
+    fn session_context_falls_back_to_file_mtime_and_unknown_project() {
+        let context = session_context(
+            Path::new("/data/conversations/conv-2.db"),
+            &TrajectoryMetadata::default(),
+            Some(1_700_000_000_000),
+        );
+
+        assert_eq!(context.project, "unknown");
+        assert_eq!(context.project_path, "unknown");
+        assert_eq!(
+            context.fallback_timestamp,
+            TimestampMs::from_millis(1_700_000_000_000)
+        );
+    }
+
+    #[test]
+    fn maps_model_aliases_case_insensitively() {
+        let cases = [
+            ("model_placeholder_m26", "claude-opus-4-6"),
+            ("MODEL_PLACEHOLDER_M26", "claude-opus-4-6"),
+            ("model_placeholder_m35", "claude-sonnet-4-6"),
+            ("model_placeholder_m36", "gemini-3.1-pro"),
+            ("model_placeholder_m37", "gemini-3.1-pro"),
+            ("model_placeholder_m16", "gemini-3.1-pro"),
+            ("MODEL_PLACEHOLDER_M16", "gemini-3.1-pro"),
+            ("model_placeholder_m18", "gemini-3-flash-preview"),
+            ("model_placeholder_m84", "gemini-3-flash-preview"),
+            ("model_placeholder_m47", "gemini-3-flash-preview"),
+            ("model_placeholder_m132", "gemini-3.5-flash-high"),
+            ("model_placeholder_m133", "gemini-3.5-flash-high"),
+            ("model_placeholder_m187", "gemini-3.5-flash-extra-low"),
+            ("model_placeholder_m20", "gemini-3.5-flash-medium"),
+            ("model_openai_gpt_oss_120b_medium", "gpt-oss-120b-medium"),
+            ("gemini-pro-default", "gemini-3.1-pro"),
+            ("gemini-pro-agent", "gemini-3.1-pro"),
+            ("gemini-3-flash-agent", "gemini-3.5-flash-high"),
+            ("gemini-3-flash-a", "gemini-3.5-flash-high"),
+            ("gemini-3-flash-b", "gemini-3.5-flash-high"),
+            ("gemini-3-flash-c", "gemini-3-flash-preview"),
+            ("gemini-3-flash", "gemini-3-flash-preview"),
+            ("gemini-3.5-flash-low", "gemini-3.5-flash-medium"),
+            ("gemini-3.1-pro-high", "gemini-3.1-pro"),
+            ("gemini-3.1-pro-low", "gemini-3.1-pro"),
+            ("gemini-3-pro-high", "gemini-3-pro"),
+            ("gemini-3-pro-low", "gemini-3-pro"),
+            ("claude-opus-4-6-thinking", "claude-opus-4-6"),
+            ("claude-sonnet-4-6-thinking", "claude-sonnet-4-6"),
+        ];
+        for (raw, expected) in cases {
+            assert_eq!(resolve_model_name(raw), expected, "raw: {raw}");
+        }
+    }
+
+    #[test]
+    fn passes_unknown_models_through_unchanged() {
+        assert_eq!(resolve_model_name("gemini-9-ultra"), "gemini-9-ultra");
+        assert_eq!(resolve_model_name("Some-Custom-Model"), "Some-Custom-Model");
+    }
+
+    #[test]
+    fn skips_generation_with_all_zero_tokens() {
+        let record = decode_generation(&generation_blob(&Generation {
+            system_input: 0,
+            fresh_input: 0,
+            cache_read: 0,
+            output: 0,
+            thinking: 0,
+            ..sample_generation()
+        }));
+        let context = session_context(
+            Path::new("/data/conversations/conv.db"),
+            &TrajectoryMetadata::default(),
+            None,
+        );
+
+        assert!(generation_to_entry(&record, &context, None, CostMode::Display, None).is_none());
+    }
+
+    #[test]
+    fn entry_carries_thinking_tokens_as_extra_total() {
+        let record = decode_generation(&generation_blob(&sample_generation()));
+        let context = session_context(
+            Path::new("/data/conversations/conv.db"),
+            &TrajectoryMetadata::default(),
+            None,
+        );
+        let tz = crate::parse_tz(Some("UTC"));
+
+        let entry =
+            generation_to_entry(&record, &context, tz.as_ref(), CostMode::Display, None).unwrap();
+
+        assert_eq!(entry.data.message.usage.input_tokens, 7357);
+        assert_eq!(entry.data.message.usage.output_tokens, 604);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 36491);
+        assert_eq!(entry.data.message.usage.cache_creation_input_tokens, 0);
+        assert_eq!(entry.extra_total_tokens, 117);
+        assert_eq!(entry.model.as_deref(), Some("gemini-3.1-pro"));
+        assert_eq!(entry.data.message.id.as_deref(), Some("resp-1"));
+        assert_eq!(entry.data.timestamp, "2026-01-02T00:00:00.429Z");
+        assert_eq!(entry.date, "2026-01-02");
+    }
+
+    #[test]
+    fn entry_falls_back_to_context_timestamp() {
+        let record = decode_generation(&generation_blob(&Generation {
+            timestamp: None,
+            ..sample_generation()
+        }));
+        let trajectory = TrajectoryMetadata {
+            created_ms: Some(1_767_312_000_207),
+            workspace_uri: None,
+        };
+        let context = session_context(Path::new("/data/conversations/conv.db"), &trajectory, None);
+        let tz = crate::parse_tz(Some("UTC"));
+
+        let entry =
+            generation_to_entry(&record, &context, tz.as_ref(), CostMode::Display, None).unwrap();
+
+        assert_eq!(entry.timestamp, TimestampMs::from_millis(1_767_312_000_207));
+        assert_eq!(entry.date, "2026-01-02");
+    }
+}

--- a/rust/adapters/antigravity/src/paths.rs
+++ b/rust/adapters/antigravity/src/paths.rs
@@ -1,0 +1,120 @@
+use std::{
+    collections::HashSet,
+    env,
+    path::{Path, PathBuf},
+};
+
+use ccusage_adapter_common::collect_files_with_extension;
+use ccusage_core::Result;
+
+pub(super) const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
+
+/// Default Antigravity data roots under `~/.gemini`. The CLI, IDE, and backup
+/// variants share the same `<root>/conversations/<uuid>.db` layout.
+const DEFAULT_ROOT_NAMES: [&str; 4] = [
+    "antigravity",
+    "antigravity-cli",
+    "antigravity-ide",
+    "antigravity-backup",
+];
+
+/// Returns the Antigravity data roots that exist. `ANTIGRAVITY_DATA_DIR`
+/// overrides the defaults with one root or a comma-separated list of roots.
+pub(super) fn paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+    if let Ok(env_paths) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+        return Ok(paths);
+    }
+
+    if let Some(home) = crate::home::home_dir() {
+        for root_name in DEFAULT_ROOT_NAMES {
+            let path = home.join(".gemini").join(root_name);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
+}
+
+/// Lists conversation databases under `<root>/conversations`. The `.db`
+/// extension filter already skips `*.db-wal`/`*.db-shm` sidecars and the
+/// legacy compressed/encrypted `.pb` conversation files, which are
+/// unsupported.
+pub(super) fn conversation_db_paths(root: &Path) -> Vec<PathBuf> {
+    let mut files = Vec::new();
+    collect_files_with_extension(&root.join("conversations"), "db", &mut files);
+    files.sort();
+    files
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    #[test]
+    fn env_override_accepts_comma_separated_roots() {
+        let fixture = fs_fixture!({
+            "first/conversations/a.db": "",
+            "second/conversations/b.db": "",
+        });
+        let raw = format!(
+            " {}, {}, {}",
+            fixture.path("first").display(),
+            fixture.path("missing").display(),
+            fixture.path("second").display()
+        );
+        let _guard = EnvVarGuard::set(ANTIGRAVITY_DATA_DIR_ENV, &raw);
+
+        let paths = paths().unwrap();
+
+        assert_eq!(paths, vec![fixture.path("first"), fixture.path("second")]);
+    }
+
+    #[test]
+    fn env_override_dedupes_roots() {
+        let fixture = fs_fixture!({
+            "root/conversations/a.db": "",
+        });
+        let raw = format!("{0},{0}", fixture.path("root").display());
+        let _guard = EnvVarGuard::set(ANTIGRAVITY_DATA_DIR_ENV, &raw);
+
+        let paths = paths().unwrap();
+
+        assert_eq!(paths, vec![fixture.path("root")]);
+    }
+
+    #[test]
+    fn discovers_conversation_dbs_and_skips_sidecars_and_pb_files() {
+        let fixture = fs_fixture!({
+            "conversations/a.db": "",
+            "conversations/b.db": "",
+            "conversations/b.db-wal": "",
+            "conversations/b.db-shm": "",
+            "conversations/legacy.pb": "",
+            "conversations/notes.txt": "",
+        });
+
+        let files = conversation_db_paths(fixture.root());
+
+        assert_eq!(
+            files,
+            vec![
+                fixture.path("conversations/a.db"),
+                fixture.path("conversations/b.db")
+            ]
+        );
+    }
+}

--- a/rust/adapters/antigravity/src/proto.rs
+++ b/rust/adapters/antigravity/src/proto.rs
@@ -1,0 +1,149 @@
+//! Minimal protobuf wire-format reader for Antigravity's `GeneratorMetadata`
+//! and trajectory metadata blobs. Supports varint, fixed64, length-delimited,
+//! and fixed32 fields; group wire types terminate parsing (Antigravity does
+//! not emit them) and truncated input stops iteration instead of failing.
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum FieldValue<'a> {
+    Varint(u64),
+    Fixed64(u64),
+    LengthDelimited(&'a [u8]),
+    Fixed32(u32),
+}
+
+/// Reads all top-level fields of a protobuf message. Malformed or unsupported
+/// wire types end the read and return the fields decoded so far.
+pub(super) fn read_fields(bytes: &[u8]) -> Vec<(u32, FieldValue<'_>)> {
+    let mut fields = Vec::new();
+    let mut rest = bytes;
+    while !rest.is_empty() {
+        let Some((key, tail)) = read_varint(rest) else {
+            break;
+        };
+        rest = tail;
+        let field_number = u32::try_from(key >> 3).unwrap_or(u32::MAX);
+        match key & 0x7 {
+            0 => {
+                let Some((value, tail)) = read_varint(rest) else {
+                    break;
+                };
+                fields.push((field_number, FieldValue::Varint(value)));
+                rest = tail;
+            }
+            1 => {
+                if rest.len() < 8 {
+                    break;
+                }
+                let (value, tail) = rest.split_at(8);
+                fields.push((
+                    field_number,
+                    FieldValue::Fixed64(u64::from_le_bytes(value.try_into().unwrap_or([0; 8]))),
+                ));
+                rest = tail;
+            }
+            2 => {
+                let Some((length, tail)) = read_varint(rest) else {
+                    break;
+                };
+                let Ok(length) = usize::try_from(length) else {
+                    break;
+                };
+                if tail.len() < length {
+                    break;
+                }
+                let (value, tail) = tail.split_at(length);
+                fields.push((field_number, FieldValue::LengthDelimited(value)));
+                rest = tail;
+            }
+            5 => {
+                if rest.len() < 4 {
+                    break;
+                }
+                let (value, tail) = rest.split_at(4);
+                fields.push((
+                    field_number,
+                    FieldValue::Fixed32(u32::from_le_bytes(value.try_into().unwrap_or([0; 4]))),
+                ));
+                rest = tail;
+            }
+            // Groups (3, 4) and padding wire types are unsupported; stop here.
+            _ => break,
+        }
+    }
+    fields
+}
+
+fn read_varint(bytes: &[u8]) -> Option<(u64, &[u8])> {
+    let mut value = 0_u64;
+    let mut shift = 0_u32;
+    for (index, byte) in bytes.iter().enumerate() {
+        value |= u64::from(byte & 0x7f) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, &bytes[index + 1..]));
+        }
+        shift += 7;
+        if shift >= 64 {
+            return None;
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reads_varint_and_length_delimited_fields() {
+        // field 1 varint 150, field 2 LEN "ab"
+        let bytes = [0x08, 0x96, 0x01, 0x12, 0x02, b'a', b'b'];
+        let fields = read_fields(&bytes);
+
+        assert_eq!(
+            fields,
+            vec![
+                (1, FieldValue::Varint(150)),
+                (2, FieldValue::LengthDelimited(b"ab")),
+            ]
+        );
+    }
+
+    #[test]
+    fn stops_on_group_wire_type() {
+        // field 1 varint 1, then field 2 with wire type 3 (start group)
+        let bytes = [0x08, 0x01, 0x13, 0x08, 0x02];
+        let fields = read_fields(&bytes);
+
+        assert_eq!(fields, vec![(1, FieldValue::Varint(1))]);
+    }
+
+    #[test]
+    fn stops_on_truncated_length_delimited_field() {
+        let bytes = [0x12, 0x05, b'a'];
+        let fields = read_fields(&bytes);
+
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn stops_on_unterminated_varint() {
+        let bytes = [0x08, 0x80];
+        let fields = read_fields(&bytes);
+
+        assert!(fields.is_empty());
+    }
+
+    #[test]
+    fn reads_fixed_width_fields() {
+        let mut bytes = vec![0x09];
+        bytes.extend_from_slice(&42_u64.to_le_bytes());
+        bytes.push(0x15);
+        bytes.extend_from_slice(&7_u32.to_le_bytes());
+        let fields = read_fields(&bytes);
+
+        assert_eq!(
+            fields,
+            vec![(1, FieldValue::Fixed64(42)), (2, FieldValue::Fixed32(7))]
+        );
+    }
+}

--- a/rust/adapters/antigravity/src/report.rs
+++ b/rust/adapters/antigravity/src/report.rs
@@ -1,0 +1,73 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| {
+            ccusage_core::agent_summary_json(row, kind, kind == AgentReportKind::Session)
+        })
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(|group| group.into_summary())
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -10,6 +10,7 @@ use ccusage_core::*;
 
 mod adapter {
     pub use ccusage_adapter_amp as amp;
+    pub use ccusage_adapter_antigravity as antigravity;
     pub use ccusage_adapter_claude as claude;
     pub use ccusage_adapter_codebuff as codebuff;
     pub use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -11,8 +11,8 @@ use crate::{
     BUILT_IN_AGENT_NAMES, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result,
     SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        amp, antigravity, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo,
+        kimi, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -323,6 +323,21 @@ fn load_base_rows(
                 )?;
                 rows.detected = rows.detected || grok::has_data();
                 Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("Antigravity"),
+            load: Box::new(|| {
+                load_priced_summary_agent_rows(
+                    "antigravity",
+                    load_kind,
+                    &loader_shared,
+                    pricing,
+                    antigravity::load_entries,
+                    antigravity::summarize_entries,
+                )
             }),
         },
     ];
@@ -860,7 +875,7 @@ pub(super) fn aggregate_rows(rows: Vec<AllRow>, kind: AgentReportKind) -> Vec<Al
 mod tests {
     use super::*;
     use ccusage_cli::NamedPiStore;
-    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
 
     fn usage_summary(date: &str, input_tokens: u64) -> UsageSummary {
         UsageSummary {
@@ -980,7 +995,13 @@ mod tests {
             "omp/sessions/project-a/agent_inside-session.jsonl": r#"{"type":"message","timestamp":"2026-07-04T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":1}}}"#,
             "omp/sessions/project-a/agent_outside-session.jsonl": r#"{"type":"message","timestamp":"2026-07-05T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":20,"output":2}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("empty-default"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path("empty-default").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let store_path = fixture.path("omp/sessions").to_string_lossy().into_owned();
         let shared = SharedArgs {
             json: true,
@@ -1058,7 +1079,13 @@ mod tests {
             "pi/sessions/project-a/agent_until-day.jsonl": r#"{"type":"message","timestamp":"2026-07-04T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":1}}}"#,
             "pi/sessions/project-a/agent_after-day.jsonl": r#"{"type":"message","timestamp":"2026-07-05T18:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":20,"output":2}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("pi/sessions"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path("pi/sessions").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let shared = SharedArgs {
             json: true,
             mode: crate::cli::CostMode::Display,
@@ -1214,7 +1241,13 @@ mod tests {
         let fixture = fs_fixture!({
             ".pi/agent/sessions/project-a/agent_pi-session.jsonl": r#"{"type":"message","timestamp":"2099-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":20}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path(".pi/agent/sessions"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path(".pi/agent/sessions").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let shared = SharedArgs {
             json: true,
             mode: crate::cli::CostMode::Display,
@@ -1246,7 +1279,13 @@ mod tests {
         let fixture = fs_fixture!({
             "shared/sessions/project-a/agent_pi-session.jsonl": r#"{"type":"message","timestamp":"2099-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":20}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("empty-default"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path("empty-default").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let path = fixture
             .path("shared/sessions")
             .to_string_lossy()
@@ -1284,7 +1323,13 @@ mod tests {
         let fixture = fs_fixture!({
             ".pi/agent/sessions/project-a/agent_pi-session.jsonl": r#"{"type":"message","timestamp":"2099-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":20}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path(".pi/agent/sessions"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path(".pi/agent/sessions").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let shared = SharedArgs {
             json: true,
             mode: crate::cli::CostMode::Display,
@@ -1316,7 +1361,13 @@ mod tests {
         let fixture = fs_fixture!({
             "shared/sessions/project-a/agent_pi-session.jsonl": r#"{"type":"message","timestamp":"2099-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":10,"output":20}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("empty-default"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path("empty-default").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let shared_path = fixture
             .path("shared/sessions")
             .to_string_lossy()
@@ -1355,7 +1406,13 @@ mod tests {
         let fixture = fs_fixture!({
             "omp/sessions/project-a/agent_omp-session.jsonl": r#"{"type":"message","timestamp":"2099-01-02T00:00:00.000Z","message":{"role":"assistant","model":"gpt-5","usage":{"input":30,"output":40}}}"#,
         });
-        let _pi_agent_dir = EnvVarGuard::set("PI_AGENT_DIR", fixture.path("empty-default"));
+        let _env = EnvVarsGuard::set_many([
+            (
+                "PI_AGENT_DIR",
+                Some(fixture.path("empty-default").into_os_string()),
+            ),
+            ("HOME", Some(fixture.path("empty-home").into_os_string())),
+        ]);
         let shared = SharedArgs {
             json: true,
             mode: crate::cli::CostMode::Display,

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -560,6 +560,7 @@ fn isolated_agent_env(
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
         "GROK_HOME",
+        "ANTIGRAVITY_DATA_DIR",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -104,6 +104,10 @@
 			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
+			},
+			{
+				"name": "antigravity",
+				"description": "Show Antigravity usage commands"
 			}
 		]
 	},
@@ -774,6 +778,43 @@
 			"path": ["grok", "session"],
 			"description": "Show Grok Build CLI usage grouped by session",
 			"usage": "ccusage grok session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity"],
+			"description": "Usage reports for Google Antigravity.",
+			"usage": "ccusage antigravity <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Antigravity usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Antigravity usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Antigravity usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["antigravity", "daily"],
+			"description": "Show Antigravity usage grouped by date",
+			"usage": "ccusage antigravity daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "monthly"],
+			"description": "Show Antigravity usage grouped by month",
+			"usage": "ccusage antigravity monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "session"],
+			"description": "Show Antigravity usage grouped by session",
+			"usage": "ccusage antigravity session <OPTIONS>",
 			"options": "agent_options"
 		}
 	]

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -340,6 +340,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Grok,
         ),
+        "antigravity" => parse_basic_agent_command(
+            parser,
+            shared,
+            "antigravity",
+            STANDARD_AGENT_REPORTS,
+            Command::Antigravity,
+        ),
         _ => Err(format!("Unknown command '{command}'")),
     }
 }
@@ -771,6 +778,7 @@ fn is_command(arg: &str) -> bool {
             | "kimi"
             | "qwen"
             | "grok"
+            | "antigravity"
     )
 }
 
@@ -931,6 +939,7 @@ fn is_agent_command(command: &str) -> bool {
             | "qwen"
             | "openclaw"
             | "grok"
+            | "antigravity"
     )
 }
 
@@ -943,7 +952,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" | "antigravity" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -968,6 +977,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
+        "antigravity" => "Antigravity",
         _ => unreachable!("agent is prevalidated"),
     }
 }
@@ -1048,7 +1058,8 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::Antigravity(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };
     shared.last?;

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -29,6 +29,7 @@ COMMANDS:
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
   grok                       Show Grok Build CLI usage commands
+  antigravity                Show Antigravity usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -53,6 +54,7 @@ For more info, run any command with the `--help` flag:
   ccusage qwen --help
   ccusage openclaw --help
   ccusage grok --help
+  ccusage antigravity --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -205,6 +205,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
+        Some(Command::Antigravity(args)) => agent_command_snapshot("antigravity", args),
     }
 }
 
@@ -1256,6 +1257,16 @@ fn rejects_grok_path_option() {
     let error = parse_error(&["ccusage", "grok", "daily", "--grok-path", "/tmp/grok-home"]);
 
     assert_eq!(error, "Unknown option '--grok-path'");
+}
+
+#[test]
+fn parses_antigravity_daily_options() {
+    let cli = parse(&["ccusage", "antigravity", "daily", "--json"]);
+    let Some(Command::Antigravity(args)) = cli.command else {
+        panic!("expected antigravity command");
+    };
+    assert_eq!(args.kind, AgentReportKind::Daily);
+    assert!(args.shared.json);
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    Antigravity(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -52,6 +52,8 @@ pub struct CcusageConfig {
     pub qwen: Option<QwenConfig>,
     /// Grok Build CLI configuration.
     pub grok: Option<GrokConfig>,
+    /// Google Antigravity configuration.
+    pub antigravity: Option<AntigravityConfig>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -316,6 +318,21 @@ pub struct GrokConfig {
 #[derive(Debug, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct GrokCommandsConfig {
+    pub daily: Option<SharedOptions>,
+    pub monthly: Option<SharedOptions>,
+    pub session: Option<SharedOptions>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AntigravityConfig {
+    pub defaults: Option<SharedOptions>,
+    pub commands: Option<AntigravityCommandsConfig>,
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AntigravityCommandsConfig {
     pub daily: Option<SharedOptions>,
     pub monthly: Option<SharedOptions>,
     pub session: Option<SharedOptions>,
@@ -1146,7 +1163,7 @@ mod tests {
             &schema,
             "ccusage-config",
             &[
-                "$schema", "amp", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
+                "$schema", "amp", "antigravity", "claude", "codebuff", "codex", "commands", "copilot", "defaults",
                 "droid", "gemini", "goose", "grok", "hermes", "kilo", "kimi", "opencode",
                 "openclaw", "pi", "qwen",
             ],

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -1297,6 +1297,7 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
   "rootProperties": [
     "$schema",
     "amp",
+    "antigravity",
     "claude",
     "codebuff",
     "codex",

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok", "antigravity",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -17,6 +17,7 @@ fetch-litellm-pricing = ["ccusage-core/fetch-litellm-pricing"]
 [dependencies]
 ccusage-adapter-all.workspace = true
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use ccusage_adapter_all as all;
 pub(crate) use ccusage_adapter_amp as amp;
+pub(crate) use ccusage_adapter_antigravity as antigravity;
 pub(crate) use ccusage_adapter_claude as claude;
 pub(crate) use ccusage_adapter_codebuff as codebuff;
 pub(crate) use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,7 +49,8 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
-            | Command::Grok(args),
+            | Command::Grok(args)
+            | Command::Antigravity(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,
     }

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::Antigravity(args)) => adapter::antigravity::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,8 +87,9 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
+            ccusage_adapter_antigravity::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
             ccusage_adapter_copilot::run,
@@ -104,7 +106,7 @@ mod tests {
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds Google Antigravity as a supported agent source in `ccusage`, resolving https://github.com/ccusage/ccusage/issues/1488.

### Changes
1. **New Adapter (`ccusage-adapter-antigravity`)**:
   - Discovers local Antigravity conversation databases across default roots:
     - `~/.gemini/antigravity/conversations/*.db`
     - `~/.gemini/antigravity-ide/conversations/*.db`
     - `~/.gemini/antigravity-cli/conversations/*.db`
     - `~/.gemini/antigravity-backup/conversations/*.db`
     - Custom path overrides via `ANTIGRAVITY_DATA_DIR`
   - Zero-copy protobuf wire-format decoder for SQLite metadata blobs:
     - `gen_metadata` for per-turn generation token usage (input tokens, output tokens, cache read/write tokens, thinking tokens, model aliases, timestamps, response IDs).
     - `trajectory_metadata_blob` for conversation-level metadata (creation timestamps, workspace URIs).
2. **Unified Integration**:
   - Registered `antigravity` into `ccusage-core` (`BUILT_IN_AGENT_NAMES`), `ccusage-adapter-all`, and `ccusage-config`.
   - CLI subcommands: `ccusage antigravity daily`, `ccusage antigravity monthly`, `ccusage antigravity session`.
   - Supports unified aggregation reports (`ccusage daily`, etc.) including Antigravity sessions.
3. **Documentation & Schema**:
   - Added `docs/guide/antigravity/index.md` guide and updated documentation pages (`docs/.vitepress/config.ts`, `docs/guide/index.md`, `docs/guide/environment-variables.md`, `docs/guide/config-files.md`, `docs/guide/source-support-qa.md`, `README.md`).
   - Regenerated `config-schema.json`.
4. **Testing**:
   - Unit tests covering protobuf wire decoding, SQLite database loading, deduplication, timestamp fallbacks, config schema, and CLI options parsing.

Closes #1488

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google Antigravity as a supported agent source so `ccusage` can read its local conversation SQLite databases and include them in per-source and unified reports. Previously Antigravity was excluded; now `ccusage antigravity {daily|monthly|session}` is available and unified reports include Antigravity sessions.

- New `ccusage-adapter-antigravity` loads `~/.gemini/antigravity*/conversations/*.db` (overridable via `ANTIGRAVITY_DATA_DIR`), decodes protobuf wire-format fields from `gen_metadata` and `trajectory_metadata_blob`, and aggregates per-turn token usage, models, timestamps, and session metadata.
- Integrated across the stack: registered in `BUILT_IN_AGENT_NAMES`, wired into `ccusage-adapter-all`, CLI parser and help, and `ccusage-config` (schema regenerated). Docs add a new Antigravity guide and env var references.
- Behavior: unified `daily|weekly|monthly|session` reports now include Antigravity when data is present; JSON/table output shapes match other agents; pricing uses existing cost modes and per-model mapping.
- Rollout: no breaking changes. Optional `ANTIGRAVITY_DATA_DIR` (supports comma-separated roots) controls discovery. Test coverage added for SQLite loading, protobuf decoding, CLI dispatch, and config schema.

<sup>Written for commit fce59728f597650a6d5ff24c731ec46c338be2ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Antigravity as a supported data source.
  * Added daily, monthly, and session usage reports with JSON and formatted output.
  * Added automatic discovery of Antigravity conversation data.
  * Added `ANTIGRAVITY_DATA_DIR` support for custom, comma-separated data locations.
  * Added Antigravity configuration options, pricing support, and model handling.

* **Documentation**
  * Added an Antigravity usage guide and updated supported-source, configuration, and environment-variable documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->