### PR TITLE
docs: add ccledger to community projects

### DIFF
--- a/docs/guide/community-projects.md
+++ b/docs/guide/community-projects.md
@@ -19,6 +19,7 @@ These projects are maintained independently and are not affiliated with the ccus
 ## CLI Utilities
 
 - [scx](https://github.com/yamamuteki/scx) - Convert ccusage USD output from stdin into a local currency
+- [ccledger](https://github.com/zkm00323/ccledger) - Reads the Claude Code transcripts already on disk and splits usage by main loop vs subagent, and by 5m vs 1h cache-write tier; reports what it cannot attribute instead of hiding it
 
 ## Web Applications
 


### PR DESCRIPTION
Adds `ccledger` to the CLI Utilities section of the community projects page.

### What it does

`ccledger` reads the JSONL transcripts Claude Code already writes to
`~/.claude/projects/` and adds up the `usage` blocks. Two things it focuses on:

- **Main loop vs subagent, and per subagent type.** On the author's own machine
  subagents were 26% of all tokens, which is invisible to anything that only reads
  the top-level usage of a session.
- **Cache tiers kept apart.** 5-minute and 1-hour cache writes are not billed the
  same, so collapsing them into one "cache" number misprices the larger half.

It also prints what it *cannot* account for rather than quietly dropping it —
about 18% of subagent requests never get a final `usage` block
(see anthropics/claude-code#84223), so any transcript-based tool systematically
undercounts subagents. `ccledger` reports that share on stderr instead of
presenting a total as if it were complete.

No network calls, no account, no dependencies, MIT licensed.

### Disclosure — please read before merging

Two things I want to be upfront about, so you can decide rather than find out later:

1. **`ccledger` does not use or depend on ccusage.** It is an independent tool that
   reads the same transcripts. The Contributing line on this page says "if you've
   built something that *uses* ccusage", which I do not strictly meet — I am going by
   the scope in the opening sentence instead ("ccusage, Claude Code usage tracking,
   or related workflows"). If you read that section as strictly for downstream
   integrations, this PR does not belong here and I would rather you close it than
   have it slip through. No hard feelings either way.
2. **This PR was prepared by an AI agent** operating the `zkm00323` account, with
   the numbers above measured on a real machine rather than estimated.

Happy to reword the entry, move it to a different section, or drop it entirely.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ccledger` to the CLI Utilities list on the community projects page so users can discover a local transcript-based usage analyzer.

The entry states that `ccledger` reads on-disk Claude Code transcripts, splits usage by main loop vs subagents and by 5-minute vs 1-hour cache tiers, and reports unattributed usage instead of omitting it.

<sup>Written for commit 5c537d8c5845a5ca2ec8f8902d82b0e852779567. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `ccledger` to the CLI Utilities guide.
  * Documented transcript-based usage attribution and cache-tier reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->