### PR TITLE
docs: link the ccusage origin story

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -192,6 +192,8 @@ bunx ccusage monthly --compact  # Compact monthly report
 
 Full documentation is available at **[ccusage.com](https://ccusage.com/)**
 
+Further reading (Japanese): [how ccusage began](https://ryoppippi.com/blog/2025-05-29-zenn-6c9a8fe6629cd6-ja/)
+
 ## Development
 
 <details>

--- a/docs/index.md
+++ b/docs/index.md
@@ -52,6 +52,8 @@ features:
     details: Use pre-cached pricing data without network connectivity
 ---
 
+Project history (Japanese): [how ccusage began](https://ryoppippi.com/blog/2025-05-29-zenn-6c9a8fe6629cd6-ja/)
+
 <div style="text-align: center; margin: 2rem 0;">
   <h2 style="margin-bottom: 1rem;">Support ccusage</h2>
   <p style="margin-bottom: 1rem;">Sponsored by</p>


### PR DESCRIPTION
Adds a compact link to the original Japanese ccusage launch article in the README and documentation homepage. This gives readers project history without adding a large standalone README section.

Validated with `just fmt` and `just docs::build`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a compact link to the Japanese project history article (“how ccusage began”) in the README and docs homepage to give readers context without expanding the docs.

Docs-only; no runtime or build changes. Verified with `just fmt` and `just docs::build`.

<sup>Written for commit ca269e1c7cf98d21288fa03313ea281a3efe6aec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Japanese-language article about the project’s origins to the ccusage documentation.
  * Added a link to the project history from the documentation homepage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->