### PR TITLE
feat(adapter-antigravity): add Antigravity CLI, IDE, and Desktop usage adapter

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -77,8 +77,9 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Kimi               | `ccusage kimi daily`     |
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
-| Gemini CLI         | `ccusage gemini daily`   |
-| Grok Build CLI     | `ccusage grok daily`     |
+| Gemini CLI         | `ccusage gemini daily`      |
+| Grok Build CLI     | `ccusage grok daily`        |
+| Antigravity        | `ccusage antigravity daily` |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
 

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -83,6 +83,7 @@ export default defineConfig({
 						{ text: 'Gemini CLI', link: '/guide/gemini/' },
 						{ text: 'Kimi', link: '/guide/kimi/' },
 						{ text: 'OpenClaw', link: '/guide/openclaw/' },
+						{ text: 'Antigravity', link: '/guide/antigravity/' },
 						{ text: 'Grok Build CLI', link: '/guide/grok/' },
 						{ text: 'Source Support Q&A', link: '/guide/source-support-qa' },
 					],

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and Antigravity.
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |
@@ -46,24 +46,25 @@ Unified tables include an **Agent** column so you can compare sources in one vie
 
 ## Supported Sources
 
-| Source         | Namespace  | Example focused view      |
-| -------------- | ---------- | ------------------------- |
-| Claude Code    | `claude`   | `ccusage claude daily`    |
-| Codex          | `codex`    | `ccusage codex daily`     |
-| OpenCode       | `opencode` | `ccusage opencode weekly` |
-| Amp            | `amp`      | `ccusage amp session`     |
-| Droid          | `droid`    | `ccusage droid daily`     |
-| Codebuff       | `codebuff` | `ccusage codebuff daily`  |
-| Hermes Agent   | `hermes`   | `ccusage hermes daily`    |
-| pi-agent       | `pi`       | `ccusage pi monthly`      |
-| Goose          | `goose`    | `ccusage goose daily`     |
-| OpenClaw       | `openclaw` | `ccusage openclaw daily`  |
-| Kilo           | `kilo`     | `ccusage kilo daily`      |
-| Kimi           | `kimi`     | `ccusage kimi daily`      |
-| Qwen           | `qwen`     | `ccusage qwen daily`      |
-| Copilot CLI    | `copilot`  | `ccusage copilot daily`   |
-| Gemini CLI     | `gemini`   | `ccusage gemini daily`    |
-| Grok Build CLI | `grok`     | `ccusage grok daily`      |
+| Source         | Namespace     | Example focused view        |
+| -------------- | ------------- | --------------------------- |
+| Claude Code    | `claude`      | `ccusage claude daily`      |
+| Codex          | `codex`       | `ccusage codex daily`       |
+| OpenCode       | `opencode`    | `ccusage opencode weekly`   |
+| Amp            | `amp`         | `ccusage amp session`       |
+| Droid          | `droid`       | `ccusage droid daily`       |
+| Codebuff       | `codebuff`    | `ccusage codebuff daily`    |
+| Hermes Agent   | `hermes`      | `ccusage hermes daily`      |
+| pi-agent       | `pi`          | `ccusage pi monthly`        |
+| Goose          | `goose`       | `ccusage goose daily`       |
+| OpenClaw       | `openclaw`    | `ccusage openclaw daily`    |
+| Kilo           | `kilo`        | `ccusage kilo daily`        |
+| Kimi           | `kimi`        | `ccusage kimi daily`        |
+| Qwen           | `qwen`        | `ccusage qwen daily`        |
+| Copilot CLI    | `copilot`     | `ccusage copilot daily`     |
+| Gemini CLI     | `gemini`      | `ccusage gemini daily`      |
+| Antigravity    | `antigravity` | `ccusage antigravity daily` |
+| Grok Build CLI | `grok`        | `ccusage grok daily`        |
 
 ## When to Focus a Source
 

--- a/docs/guide/antigravity/index.md
+++ b/docs/guide/antigravity/index.md
@@ -1,0 +1,70 @@
+# Antigravity Data Source (Beta)
+
+> Antigravity support covers Antigravity CLI (`agy`), IDE, and Desktop environments.
+
+ccusage reads per-conversation SQLite databases written by Antigravity as one of its supported local data sources. Antigravity uses the same unified and focused report model as Claude Code, Codex, OpenCode, Amp, pi-agent, and Gemini CLI.
+
+## Focused Views
+
+```bash
+# Daily Antigravity usage
+ccusage antigravity daily
+
+# Monthly Antigravity usage
+ccusage antigravity monthly
+
+# Antigravity sessions
+ccusage antigravity session
+```
+
+Most users can start with unified reports such as `ccusage daily`. Add the `antigravity` namespace only when you want to focus the same report shape on Antigravity usage.
+
+## Data Source
+
+The CLI reads Antigravity conversation SQLite databases located under `ANTIGRAVITY_DATA_DIR` (defaults to `~/.gemini/antigravity`, `~/.gemini/antigravity-cli`, `~/.gemini/antigravity-ide`, `~/.gemini/Antigravity`, and `~/.config/Antigravity`). `ANTIGRAVITY_DATA_DIR` can be one directory or a comma-separated list of directories.
+
+```bash
+ANTIGRAVITY_DATA_DIR="$HOME/.gemini/antigravity,$HOME/.gemini/antigravity-cli" ccusage antigravity daily
+```
+
+```text
+~/.gemini/antigravity/
+├── conversations/
+│   └── <conversation-id>.db
+└── brain/
+    └── <conversation-id>/
+```
+
+## Report Views
+
+| Focused view                  | Description                             | See also                                |
+| ----------------------------- | --------------------------------------- | --------------------------------------- |
+| `ccusage antigravity daily`   | Aggregate usage by date                 | [Daily Usage](/guide/daily-reports)     |
+| `ccusage antigravity monthly` | Aggregate usage by month                | [Monthly Usage](/guide/monthly-reports) |
+| `ccusage antigravity session` | Group usage by conversation identifier  | [Session Usage](/guide/session-reports) |
+
+These views support `--json`, `--compact`, `--last`, `--since`, `--until`, and `--offline`.
+
+## What Gets Calculated
+
+- **Token usage** - Decodes `steps.metadata` (`CortexStepMetadata`) and `gen_metadata.data` (`ChatModelMetadata`) protobuf payloads, tracking input, output, cache creation, cache read, and thinking/reasoning token counts.
+- **Cache tokens** - Cache read tokens and input tokens are tracked and reported separately.
+- **Deduplication** - Repeated retry attempts and shared subagent conversations are deduplicated by server response ID.
+- **Pricing** - Costs are calculated from LiteLLM pricing data across Gemini, Anthropic, OpenAI, and DeepSeek provider models.
+
+## Environment Variables
+
+| Variable               | Description                                                                                  |
+| ---------------------- | -------------------------------------------------------------------------------------------- |
+| `ANTIGRAVITY_DATA_DIR` | Override the root directory, or comma-separated root directories, containing Antigravity data |
+| `LOG_LEVEL`            | Adjust verbosity (0 silent ... 5 trace)                                                      |
+
+## Troubleshooting
+
+::: details No Antigravity usage data found
+Ensure Antigravity has written conversation databases under `~/.gemini/antigravity*/conversations/*.db` or set `ANTIGRAVITY_DATA_DIR` to point to your data directory.
+:::
+
+::: details Costs showing as $0.00
+If a model name is not yet recognized or is reported as an unnamed placeholder (`antigravity-model-<id>`), the cost will be $0.00 and reported as missing pricing. Use `--offline=false` or configure pricing overrides in `ccusage.json`.
+:::

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -23,6 +23,7 @@ ccusage detects supported data source files from conventional locations by defau
 | `QWEN_DATA_DIR`                   | Qwen           | `~/.qwen`                          |
 | `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI    | Explicit `.jsonl` file             |
 | `GEMINI_DATA_DIR`                 | Gemini CLI     | `~/.gemini/tmp`                    |
+| `ANTIGRAVITY_DATA_DIR`            | Antigravity    | `~/.gemini/antigravity`            |
 | `GROK_HOME`                       | Grok Build CLI | `~/.grok`                          |
 
 Example:
@@ -42,6 +43,7 @@ export KIMI_DATA_DIR="/path/to/kimi,/archive/kimi"
 export QWEN_DATA_DIR="/path/to/qwen,/archive/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
 export GEMINI_DATA_DIR="/path/to/gemini/tmp,/archive/gemini/tmp"
+export ANTIGRAVITY_DATA_DIR="/path/to/antigravity,/archive/antigravity"
 export GROK_HOME="/path/to/grok-home"
 ccusage daily
 ```

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -176,6 +176,7 @@ If ccusage shows no data, check:
    - OpenClaw: `${OPENCLAW_DIR:-~/.openclaw}` (also scans `~/.clawdbot`, `~/.moltbot`, `~/.moldbot`)
    - Qwen: `${QWEN_DATA_DIR:-~/.qwen}`
    - GitHub Copilot CLI: `~/.copilot/otel/*.jsonl` or `COPILOT_OTEL_FILE_EXPORTER_PATH`
+   - Antigravity: `${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity}`
    - Grok Build CLI: `${GROK_HOME:-~/.grok}`
 
 ### Custom Data Directory
@@ -197,6 +198,7 @@ export KILO_DATA_DIR="/path/to/kilo"
 export KIMI_DATA_DIR="/path/to/kimi"
 export QWEN_DATA_DIR="/path/to/qwen"
 export COPILOT_OTEL_FILE_EXPORTER_PATH="/path/to/copilot-otel.jsonl"
+export ANTIGRAVITY_DATA_DIR="/path/to/antigravity"
 export GROK_HOME="/path/to/grok-home"
 ```
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and Antigravity.
 
 The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Grok Build CLI, and Antigravity in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed
@@ -87,14 +87,15 @@ ccusage reads from local coding CLI data directories:
 | Kilo           | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`           |
 | Kimi           | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`) |
 | Qwen           | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
-| Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
-| Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
-| Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                           |
+| Copilot CLI    | `copilot`     | `~/.copilot/otel/*.jsonl`                         |
+| Gemini CLI     | `gemini`      | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
+| Antigravity    | `antigravity` | `${ANTIGRAVITY_DATA_DIR:-~/.gemini/antigravity}`  |
+| Grok Build CLI | `grok`        | `${GROK_HOME:-~/.grok}`                           |
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.
 
-Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for the current notes on Antigravity CLI, legacy Grok CLI SQLite data, and Devin CLI.
+Some coding agents have been investigated but are not supported because their local files do not contain reliable token usage. See [Source Support Q&A](/guide/source-support-qa) for notes on investigated tools.
 
 ## Report Shape
 

--- a/docs/guide/source-support-qa.md
+++ b/docs/guide/source-support-qa.md
@@ -19,16 +19,6 @@ Local transcript text alone is not enough. A transcript can be useful for debugg
 
 ## Unsupported Sources Investigated
 
-::: details Why is Antigravity CLI not supported?
-Antigravity CLI is separate from Gemini CLI. The Antigravity CLI binary is exposed as `agy`, and it stores state under `~/.gemini/antigravity-cli/`.
-
-The current local data has conversation files such as `conversations/<conversation-id>.pb`, plus lightweight history and cache JSON files. The `.pb` files are opaque binary payloads and do not expose readable token usage, model usage, or per-turn accounting without Antigravity's private schema and storage semantics.
-
-The CLI log files include operational events such as conversation creation, streaming, prompt length, auth, and model configuration messages. They do not include input, output, cache, or reasoning token counts. Quota-oriented tools can inspect remaining Antigravity quota, but quota snapshots are not the same as historical per-session token usage.
-
-Because the local files do not expose the token accounting needed for ccusage reports, Antigravity CLI is not supported right now.
-:::
-
 ::: details Why is Devin CLI not supported?
 Devin CLI usage information appears to live in Devin's cloud service rather than in a local usage log that ccusage can read. The locally available data did not provide direct access to historical token usage or costs.
 
@@ -36,6 +26,10 @@ ccusage is a local, read-only analyzer. It does not scrape private cloud service
 :::
 
 ## Previously Unsupported, Now Supported
+
+::: details Antigravity (CLI, IDE, Desktop)
+Earlier investigations noted that Antigravity stores `.pb` payloads. Antigravity is now supported: ccusage parses the protobuf wire blobs stored in `steps.metadata` (`CortexStepMetadata`) and `gen_metadata.data` (`ChatModelMetadata`) across SQLite conversation databases under `~/.gemini/antigravity/`, `~/.gemini/antigravity-cli/`, and `~/.config/Antigravity/`. See [Antigravity Data Source](/guide/antigravity/).
+:::
 
 ::: details Grok Build CLI
 Earlier investigations looked at local Grok data that did not expose usable token

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -121,6 +121,7 @@ version = "0.0.0"
 dependencies = [
  "ccusage-adapter-all",
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -153,6 +154,7 @@ name = "ccusage-adapter-all"
 version = "0.0.0"
 dependencies = [
  "ccusage-adapter-amp",
+ "ccusage-adapter-antigravity",
  "ccusage-adapter-claude",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
@@ -187,6 +189,18 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-antigravity"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
+ "serde_json",
+ "sqlite",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -18,6 +18,7 @@ publish = false
 [workspace.dependencies]
 ccusage-adapter-all = { path = "crates/ccusage-adapter-all" }
 ccusage-adapter-amp = { path = "adapters/amp" }
+ccusage-adapter-antigravity = { path = "adapters/antigravity" }
 ccusage-adapter-claude = { path = "adapters/claude" }
 ccusage-adapter-codebuff = { path = "adapters/codebuff" }
 ccusage-adapter-codex = { path = "adapters/codex" }

--- a/rust/adapters/antigravity/Cargo.toml
+++ b/rust/adapters/antigravity/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ccusage-adapter-antigravity"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde_json.workspace = true
+sqlite.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/antigravity/README.md
+++ b/rust/adapters/antigravity/README.md
@@ -1,0 +1,114 @@
+# ccusage-adapter-antigravity
+
+The Antigravity adapter: it turns the per-conversation SQLite databases written by
+Antigravity (CLI, IDE, Desktop) into the usage entries the reports render.
+
+## Commands
+
+```sh
+ccusage antigravity daily
+ccusage antigravity monthly
+ccusage antigravity session
+```
+
+Antigravity also joins `ccusage daily` and the other unified reports whenever
+conversation databases are detected.
+
+The user-facing documentation lives in
+[docs/guide/antigravity](../../../docs/guide/antigravity/index.md), including the
+accuracy notes that explain what these numbers can and cannot tell you. See
+[docs/guide/all-reports](../../../docs/guide/all-reports.md) for the unified
+reports and [docs/guide/cost-modes](../../../docs/guide/cost-modes.md) for how
+`--mode` changes cost reporting.
+
+## Owns
+
+- `loader.rs` — reading the source, dedupe, and date filtering.
+- `parser.rs` — token mapping, model naming, and pricing candidates.
+- `paths.rs` — environment variables, default directories, and file discovery.
+- `proto.rs` — the minimal protobuf wire reader for the stored blobs.
+- `report.rs` — the JSON and table shapes where they differ from the shared ones.
+
+Anything that is not specific to this source belongs in `ccusage-core` or
+`ccusage-adapter-common` instead.
+
+## Data source
+
+- `${ANTIGRAVITY_DATA_DIR}/conversations/**/*.db`, or
+- `~/.gemini/antigravity/conversations/**/*.db`
+- `~/.gemini/antigravity-cli/conversations/**/*.db`
+- `~/.gemini/antigravity-ide/conversations/**/*.db`
+- `~/.gemini/Antigravity/conversations/**/*.db`
+- `~/.config/Antigravity/conversations/**/*.db`
+
+`ANTIGRAVITY_DATA_DIR` accepts comma-separated roots, and each root's
+`conversations/` and `brain/` directories are searched recursively, so nested sub-conversation
+databases are collected too.
+
+Antigravity is a Gemini-family tool, so its CLI/IDE state lives under `.gemini` or `.config`.
+Reads SQLite with the bundled `sqlite` crate, which is why this crate declares it and most adapters do not.
+
+Usage is read from two tables per conversation:
+
+- `steps.metadata` (`CortexStepMetadata`) — one row per invocation, including the
+  background calls no other table records. This is the primary source.
+- `gen_metadata.data` (`ChatModelMetadata`) — the only place a human-readable
+  model name appears, and a backstop for a step that has since been pruned.
+
+## Wire format
+
+Antigravity ships no `.proto` files, so `proto.rs` decodes the blobs by field
+number. The numbers were recovered from the `FileDescriptorProto` blobs embedded
+in the binary rather than guessed from the data.
+
+The fields consumed, from `ModelUsageStats`:
+
+| Field | Name                     | Mapped to                     |
+| ----- | ------------------------ | ----------------------------- |
+| 1     | `model`                  | placeholder name when unnamed |
+| 2     | `input_tokens`           | `inputTokens`                 |
+| 3     | `output_tokens`          | `outputTokens`                |
+| 4     | `cache_write_tokens`     | `cacheCreationTokens`         |
+| 5     | `cache_read_tokens`      | `cacheReadTokens`             |
+| 9     | `thinking_output_tokens` | fallback for field 3          |
+| 10    | `response_output_tokens` | fallback for field 3          |
+| 7     | `message_id`             | dedup identity                |
+| 11    | `response_id`            | dedup identity                |
+| 12    | `provider_assigned_...`  | dedup identity                |
+
+`input_tokens` and `cache_read_tokens` are disjoint, so neither needs adjusting.
+`output_tokens` already contains `thinking_output_tokens`, so the thinking count is only ever used to rebuild a missing total.
+
+## Dedupe
+
+Every collected invocation is deduplicated on `response_id`, falling back to
+`provider_assigned_message_id` then `message_id`. One model call can be recorded
+in more than one place — `retry_infos` repeats the attempt that succeeded
+alongside those that failed, and a sub-conversation may repeat a call its parent
+already recorded — and this is what keeps those from being counted twice while
+still counting the failed attempts.
+
+## Cost
+
+Antigravity leaves `model_cost`, `credit_cost` and `consumed_credits` unset on
+consumer accounts, so there is no precomputed cost to read and `--mode display`
+reports zero. Cost is calculated from LiteLLM rates for the `response_model` name,
+which makes it the equivalent public API cost rather than an amount billed.
+
+Invocations `gen_metadata` never named are reported under
+`antigravity-model-<id>`. The model id is an opaque number; their tokens are still counted and they surface as missing pricing.
+
+## Public surface
+
+- `loader::load_entries`
+- `paths::has_data`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde_json`
+- `sqlite`

--- a/rust/adapters/antigravity/src/lib.rs
+++ b/rust/adapters/antigravity/src/lib.rs
@@ -1,0 +1,49 @@
+use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod proto;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub use paths::has_data;
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, |row| {
+        ccusage_core::summary_period(row)
+    });
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Antigravity Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/antigravity/src/loader.rs
+++ b/rust/adapters/antigravity/src/loader.rs
@@ -1,0 +1,489 @@
+use std::{
+    collections::{HashMap, HashSet},
+    path::Path,
+    sync::Arc,
+};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use crate::{
+    LoadedEntry, PricingMap, Result, cli::CostMode, cli::SharedArgs, debug_log, parse_tz,
+    read_files_parallel,
+};
+
+use super::{
+    parser::{UsageRecord, record_to_entry},
+    paths::antigravity_db_paths,
+    proto::{ModelUsage, parse_generation_metadata, parse_step_metadata},
+};
+
+/// Every conversation step, in the order Antigravity appended them.
+const ANTIGRAVITY_STEP_QUERY: &str = r#"
+SELECT idx, metadata
+FROM steps
+WHERE metadata IS NOT NULL
+ORDER BY idx
+"#;
+
+/// Per-generation metadata, which is the only source of model names.
+const ANTIGRAVITY_GENERATION_QUERY: &str = r#"
+SELECT idx, data
+FROM gen_metadata
+WHERE data IS NOT NULL
+ORDER BY idx
+"#;
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Antigravity"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = parse_tz(shared.timezone.as_deref());
+    let db_paths = antigravity_db_paths()?;
+    let loaded = read_files_parallel(&db_paths, shared.single_thread, |db_path| {
+        collect_records(db_path, shared)
+    });
+    Ok(records_to_entries(
+        loaded,
+        tz.as_ref(),
+        shared.mode,
+        pricing,
+    ))
+}
+
+/// Turn the per-database records into entries, keeping each invocation once.
+///
+/// Groups arrive in the sorted path order path discovery fixed, so which record
+/// survives for a given response id does not depend on how the parallel reads
+/// happened to finish.
+fn records_to_entries(
+    groups: impl IntoIterator<Item = Vec<UsageRecord>>,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Vec<LoadedEntry> {
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for records in groups {
+        for record in records {
+            // A record with no server-assigned identity cannot be matched against
+            // anything, so it is kept rather than guessed at.
+            if let Some(identity) = record.usage.identity()
+                && !seen.insert(identity.to_string())
+            {
+                continue;
+            }
+            if let Some(entry) = record_to_entry(record, tz, mode, pricing) {
+                entries.push(entry);
+            }
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    entries
+}
+
+/// Read every blob column returned by one query.
+fn read_blobs(
+    connection: &sqlite::Connection,
+    db_path: &Path,
+    query: &str,
+    shared: &SharedArgs,
+) -> Vec<Vec<u8>> {
+    // A conversation database created by a different Antigravity version can be
+    // missing a table entirely, which is a prepare-time error rather than a reason
+    // to discard the rest of the conversation.
+    let Ok(mut statement) = connection.prepare(query) else {
+        debug_log(
+            shared,
+            format!(
+                "Failed to query Antigravity conversation {}",
+                db_path.display()
+            ),
+        );
+        return Vec::new();
+    };
+
+    let mut blobs = Vec::new();
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                if let Ok(blob) = statement.read::<Vec<u8>, _>(1) {
+                    blobs.push(blob);
+                }
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => {
+                debug_log(
+                    shared,
+                    format!(
+                        "Failed to read Antigravity conversation {}",
+                        db_path.display()
+                    ),
+                );
+                break;
+            }
+        }
+    }
+    blobs
+}
+
+/// Collect every model invocation recorded by one conversation database.
+///
+/// `steps` is the primary source: it holds one row per invocation, including the
+/// background calls that `gen_metadata` never records. `gen_metadata` is read for
+/// two reasons — it is the only place a model name appears, and it keeps usage
+/// visible for a step that has since been pruned.
+fn collect_records(db_path: &Path, shared: &SharedArgs) -> Vec<UsageRecord> {
+    let conversation_id: Arc<str> = db_path.file_stem().map_or_else(
+        || Arc::from("antigravity"),
+        |stem| Arc::from(stem.to_string_lossy().as_ref()),
+    );
+
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        debug_log(
+            shared,
+            format!(
+                "Failed to open Antigravity conversation {}",
+                db_path.display()
+            ),
+        );
+        return Vec::new();
+    };
+
+    // Names first, so both sources can be attributed in one pass.
+    let generations = read_blobs(&connection, db_path, ANTIGRAVITY_GENERATION_QUERY, shared)
+        .iter()
+        .flat_map(|blob| parse_generation_metadata(blob))
+        .collect::<Vec<_>>();
+    let mut models = HashMap::new();
+    for generation in &generations {
+        let Some(model) = generation.model.as_deref() else {
+            continue;
+        };
+        for usage in &generation.usages {
+            if let Some(identity) = usage.identity() {
+                models.insert(identity.to_string(), model.to_string());
+            }
+        }
+    }
+
+    let name_of = |usage: &ModelUsage| {
+        usage
+            .identity()
+            .and_then(|identity| models.get(identity))
+            .cloned()
+    };
+
+    let mut records = Vec::new();
+    for blob in read_blobs(&connection, db_path, ANTIGRAVITY_STEP_QUERY, shared) {
+        let step = parse_step_metadata(&blob);
+        let Some(timestamp) = step.timestamp else {
+            // A usage row with no timestamp cannot be placed in any reporting
+            // period, so there is nothing useful to do with it.
+            continue;
+        };
+        for usage in step.usages {
+            let model = name_of(&usage);
+            records.push(UsageRecord {
+                conversation_id: Arc::clone(&conversation_id),
+                timestamp,
+                usage,
+                model,
+            });
+        }
+    }
+
+    for generation in generations {
+        let Some(timestamp) = generation.timestamp else {
+            continue;
+        };
+        for usage in generation.usages {
+            // Only identifiable rows are taken from `gen_metadata`. Without an
+            // identity there is no way to tell a pruned step's usage apart from a
+            // row already collected above, and counting it twice is worse than
+            // missing it.
+            if usage.identity().is_none() {
+                continue;
+            }
+            let model = name_of(&usage);
+            records.push(UsageRecord {
+                conversation_id: Arc::clone(&conversation_id),
+                timestamp,
+                usage,
+                model,
+            });
+        }
+    }
+    records
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::proto::encode::{field_bytes, field_varint, timestamp_bytes, usage_bytes};
+    use ccusage_test_support::fs_fixture;
+
+    /// Build a `CortexStepMetadata` blob carrying one invocation.
+    fn step_blob(seconds: i64, usage: &[u8]) -> Vec<u8> {
+        let mut blob = field_bytes(1, &timestamp_bytes(seconds, 0));
+        blob.extend(field_bytes(9, usage));
+        blob
+    }
+
+    /// Build a `gen_metadata` blob naming one invocation.
+    fn generation_blob(seconds: i64, model: &str, usage: &[u8]) -> Vec<u8> {
+        let mut chat = field_bytes(4, usage);
+        chat.extend(field_bytes(
+            9,
+            &field_bytes(4, &timestamp_bytes(seconds, 0)),
+        ));
+        chat.extend(field_bytes(19, model.as_bytes()));
+        field_bytes(1, &chat)
+    }
+
+    fn create_conversation_db(path: &Path) {
+        let db = sqlite::open(path).unwrap();
+        db.execute(
+            r#"
+CREATE TABLE steps (idx INTEGER PRIMARY KEY, metadata BLOB);
+CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);
+"#,
+        )
+        .unwrap();
+    }
+
+    fn insert_blob(path: &Path, table: &str, idx: i64, blob: &[u8]) {
+        let db = sqlite::open(path).unwrap();
+        let column = if table == "steps" { "metadata" } else { "data" };
+        let mut statement = db
+            .prepare(format!(
+                "INSERT INTO {table} (idx, {column}) VALUES (?1, ?2)"
+            ))
+            .unwrap();
+        statement.bind((1, idx)).unwrap();
+        statement.bind((2, blob)).unwrap();
+        statement.next().unwrap();
+    }
+
+    /// A conversation with one named invocation that used a cache read.
+    fn seed_conversation(path: &Path) {
+        create_conversation_db(path);
+        let usage = usage_bytes(1071, 4050, 375, 16275, "response-a");
+        insert_blob(path, "steps", 0, &step_blob(1_785_328_986, &usage));
+        insert_blob(
+            path,
+            "gen_metadata",
+            0,
+            &generation_blob(1_785_328_986, "gemini-3.6-flash", &usage),
+        );
+    }
+
+    fn load(db_paths: &[PathBuf]) -> Vec<LoadedEntry> {
+        let shared = SharedArgs::default();
+        let pricing = PricingMap::load_embedded();
+        let groups = db_paths
+            .iter()
+            .map(|db_path| collect_records(db_path, &shared))
+            .collect::<Vec<_>>();
+        records_to_entries(
+            groups,
+            Some(&jiff::tz::TimeZone::UTC),
+            shared.mode,
+            &pricing,
+        )
+    }
+
+    #[test]
+    fn names_a_step_invocation_from_its_generation_row() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        seed_conversation(&db_path);
+
+        let entries = load(&[db_path]);
+
+        // The same invocation is recorded by both tables and must land once.
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("gemini-3.6-flash"));
+        assert_eq!(entries[0].session_id.as_ref(), "adf2fd49");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 4050);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 16275);
+    }
+
+    #[test]
+    fn prices_an_invocation_its_generation_row_named() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        // Anthropic rates are embedded, so this exercises the cost path offline.
+        let usage = usage_bytes(1071, 4050, 375, 0, "response-a");
+        insert_blob(&db_path, "steps", 0, &step_blob(1_785_328_986, &usage));
+        insert_blob(
+            &db_path,
+            "gen_metadata",
+            0,
+            &generation_blob(1_785_328_986, "claude-sonnet-4-5", &usage),
+        );
+
+        let entries = load(&[db_path]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("claude-sonnet-4-5"));
+        assert!(entries[0].cost > 0.0);
+        assert_eq!(entries[0].missing_pricing_model, None);
+    }
+
+    #[test]
+    fn counts_a_retry_attempt_without_recounting_the_successful_one() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        let succeeded = usage_bytes(1071, 4050, 375, 0, "response-ok");
+        // `retry_infos` repeats the successful attempt alongside the failed one,
+        // so both shapes have to survive without inflating the total.
+        let mut blob = step_blob(1_785_328_986, &succeeded);
+        blob.extend(field_bytes(28, &field_bytes(2, &succeeded)));
+        blob.extend(field_bytes(
+            28,
+            &field_bytes(2, &usage_bytes(1071, 4000, 0, 0, "response-failed")),
+        ));
+        insert_blob(&db_path, "steps", 0, &blob);
+
+        let entries = load(&[db_path]);
+
+        assert_eq!(entries.len(), 2);
+        let input = entries
+            .iter()
+            .map(|entry| entry.data.message.usage.input_tokens)
+            .sum::<u64>();
+        assert_eq!(input, 8050);
+    }
+
+    #[test]
+    fn counts_a_sub_conversation_once_when_its_parent_repeats_it() {
+        let fixture = fs_fixture!({});
+        let parent = fixture.path("parent.db");
+        let child = fixture.path("child.db");
+        seed_conversation(&parent);
+        seed_conversation(&child);
+
+        let entries = load(&[parent, child]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "parent");
+    }
+
+    #[test]
+    fn keeps_usage_from_a_generation_whose_step_was_pruned() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        insert_blob(
+            &db_path,
+            "gen_metadata",
+            0,
+            &generation_blob(
+                1_785_328_986,
+                "gemini-3.6-flash",
+                &usage_bytes(1071, 20110, 33, 0, "response-a"),
+            ),
+        );
+
+        let entries = load(&[db_path]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 20110);
+    }
+
+    #[test]
+    fn keeps_a_background_call_that_no_generation_row_names() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        insert_blob(
+            &db_path,
+            "steps",
+            0,
+            &step_blob(1_785_328_981, &usage_bytes(1050, 93, 3, 0, "response-b")),
+        );
+
+        let entries = load(&[db_path]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].model.as_deref(), Some("antigravity-model-1050"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 93);
+        assert_eq!(
+            entries[0].missing_pricing_model.as_deref(),
+            Some("antigravity-model-1050")
+        );
+    }
+
+    #[test]
+    fn skips_a_step_that_records_no_timestamp() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        insert_blob(
+            &db_path,
+            "steps",
+            0,
+            &field_bytes(9, &usage_bytes(1071, 4050, 375, 0, "response-a")),
+        );
+
+        assert!(load(&[db_path]).is_empty());
+    }
+
+    #[test]
+    fn tolerates_a_conversation_database_without_the_expected_tables() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        sqlite::open(&db_path)
+            .unwrap()
+            .execute("CREATE TABLE unrelated (idx INTEGER PRIMARY KEY)")
+            .unwrap();
+
+        assert!(load(&[db_path]).is_empty());
+    }
+
+    #[test]
+    fn ignores_a_step_holding_an_undecodable_blob() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        insert_blob(&db_path, "steps", 0, &[0xff, 0xff, 0xff, 0xff]);
+        insert_blob(
+            &db_path,
+            "steps",
+            1,
+            &step_blob(
+                1_785_328_986,
+                &usage_bytes(1071, 4050, 375, 0, "response-a"),
+            ),
+        );
+
+        // One corrupt row must not cost the rest of the conversation.
+        let entries = load(&[db_path]);
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.input_tokens, 4050);
+    }
+
+    #[test]
+    fn ignores_a_step_whose_usage_carries_no_tokens() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("adf2fd49.db");
+        create_conversation_db(&db_path);
+        let mut usage = field_varint(1, 1071);
+        usage.extend(field_bytes(11, b"response-a"));
+        insert_blob(&db_path, "steps", 0, &step_blob(1_785_328_986, &usage));
+
+        assert!(load(&[db_path]).is_empty());
+    }
+}

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -1,0 +1,321 @@
+use std::sync::Arc;
+
+use jiff::tz::TimeZone as JiffTimeZone;
+
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz,
+    missing_pricing_model_for_candidates,
+};
+
+use super::proto::ModelUsage;
+
+/// A collected model invocation before it is mapped to a report row.
+#[derive(Debug, Clone)]
+pub(super) struct UsageRecord {
+    pub(super) conversation_id: Arc<str>,
+    pub(super) timestamp: TimestampMs,
+    pub(super) usage: ModelUsage,
+    pub(super) model: Option<String>,
+}
+
+/// Fallback model name for a background call `gen_metadata` never recorded.
+fn placeholder_model(model_id: u64) -> String {
+    format!("antigravity-model-{model_id}")
+}
+
+/// Provider-qualified pricing keys to try for a model name.
+///
+/// Antigravity records bare model names like `gemini-3.6-flash` or
+/// `claude-sonnet-4-5`, while pricing snapshots index them under provider
+/// namespaces such as `anthropic/` or `openrouter/google/`.
+pub(super) fn model_candidates(model: &str) -> Vec<String> {
+    let mut candidates = Vec::new();
+    candidates.push(model.to_string());
+    if model.starts_with("gemini") || model.contains("gemini") {
+        candidates.push(format!("gemini/{model}"));
+        candidates.push(format!("vertex_ai/{model}"));
+        candidates.push(format!("google/{model}"));
+        candidates.push(format!("openrouter/google/{model}"));
+    } else if model.starts_with("claude") {
+        candidates.push(format!("anthropic/{model}"));
+        candidates.push(format!("vertex_ai/{model}"));
+        candidates.push(format!("bedrock/{model}"));
+        candidates.push(format!("openrouter/anthropic/{model}"));
+    } else if model.starts_with("gpt")
+        || model.starts_with("o1")
+        || model.starts_with("o3")
+        || model.starts_with("o4")
+    {
+        candidates.push(format!("openai/{model}"));
+        candidates.push(format!("azure/{model}"));
+        candidates.push(format!("openrouter/openai/{model}"));
+    } else if model.starts_with("deepseek") {
+        candidates.push(format!("deepseek/{model}"));
+        candidates.push(format!("openrouter/deepseek/{model}"));
+    } else if model.starts_with("qwen") {
+        candidates.push(format!("qwen/{model}"));
+        candidates.push(format!("openrouter/qwen/{model}"));
+    }
+    candidates
+}
+
+/// Map protobuf model usage to ccusage's internal raw token usage.
+fn token_usage(usage: &ModelUsage) -> TokenUsageRaw {
+    TokenUsageRaw {
+        input_tokens: usage.input_tokens,
+        output_tokens: usage.total_output_tokens(),
+        cache_creation_input_tokens: usage.cache_write_tokens,
+        cache_read_input_tokens: usage.cache_read_tokens,
+        speed: None,
+        cache_creation: None,
+    }
+}
+
+/// Turn a collected invocation into a report entry.
+pub(super) fn record_to_entry(
+    record: UsageRecord,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: &PricingMap,
+) -> Option<LoadedEntry> {
+    if !record.usage.has_tokens() {
+        return None;
+    }
+    let named = record.model.is_some();
+    let model = record
+        .model
+        .unwrap_or_else(|| placeholder_model(record.usage.model_id));
+    let usage = token_usage(&record.usage);
+    let candidates = model_candidates(&model);
+
+    let cost = match mode {
+        // Antigravity leaves `model_cost`, `credit_cost` and `consumed_credits`
+        // unset, so there is no precomputed cost to display.
+        CostMode::Display => 0.0,
+        CostMode::Auto | CostMode::Calculate => candidates
+            .iter()
+            .find(|candidate| pricing.find(candidate).is_some())
+            .map_or(0.0, |candidate| {
+                calculate_cost_for_usage(
+                    Some(candidate),
+                    usage,
+                    None,
+                    CostMode::Calculate,
+                    Some(pricing),
+                )
+            }),
+    };
+    let missing_pricing_model = if mode == CostMode::Display {
+        None
+    } else if named {
+        missing_pricing_model_for_candidates(
+            &model,
+            candidates,
+            crate::total_usage_tokens(usage),
+            Some(pricing),
+        )
+    } else {
+        // A placeholder name can never match a pricing entry, so report it
+        // directly instead of paying for the lookup.
+        Some(model.clone())
+    };
+
+    let data = UsageEntry {
+        session_id: Some(record.conversation_id.to_string()),
+        timestamp: crate::format_rfc3339_millis(record.timestamp),
+        version: None,
+        message: UsageMessage {
+            usage,
+            model: Some(model.clone()),
+            id: record.usage.response_id.clone(),
+        },
+        cost_usd: None,
+        request_id: record.usage.response_id.clone(),
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+
+    Some(LoadedEntry {
+        date: format_date_tz(record.timestamp, tz),
+        timestamp: record.timestamp,
+        project: Arc::from("antigravity"),
+        session_id: record.conversation_id,
+        project_path: Arc::from("Antigravity"),
+        cost,
+        credits: None,
+        model: Some(model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        extra_total_tokens: 0,
+        message_count: None,
+        data,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn usage(input: u64, output: u64, cache_read: u64) -> ModelUsage {
+        ModelUsage {
+            model_id: 1071,
+            input_tokens: input,
+            output_tokens: output,
+            cache_read_tokens: cache_read,
+            response_id: Some("response-a".to_string()),
+            ..ModelUsage::default()
+        }
+    }
+
+    fn record(model: Option<&str>, usage: ModelUsage) -> UsageRecord {
+        UsageRecord {
+            conversation_id: Arc::from("conversation-a"),
+            timestamp: TimestampMs::from_millis(1_785_328_986_355),
+            usage,
+            model: model.map(str::to_string),
+        }
+    }
+
+    #[test]
+    fn maps_cache_reads_to_their_own_bucket_rather_than_input() {
+        let pricing = PricingMap::load_embedded();
+        let entry = record_to_entry(
+            record(Some("gemini-3.6-flash"), usage(4050, 375, 16275)),
+            Some(&jiff::tz::TimeZone::UTC),
+            CostMode::Auto,
+            &pricing,
+        )
+        .unwrap();
+
+        assert_eq!(entry.data.message.usage.input_tokens, 4050);
+        assert_eq!(entry.data.message.usage.cache_read_input_tokens, 16275);
+        assert_eq!(entry.data.message.usage.output_tokens, 375);
+        assert_eq!(entry.date, "2026-07-29");
+        assert_eq!(entry.session_id.as_ref(), "conversation-a");
+    }
+
+    #[test]
+    fn prices_a_cache_read_below_the_input_rate() {
+        let pricing = PricingMap::load_embedded();
+        let tz = jiff::tz::TimeZone::UTC;
+        let cached = record_to_entry(
+            record(Some("claude-sonnet-4-5"), usage(4050, 375, 16275)),
+            Some(&tz),
+            CostMode::Auto,
+            &pricing,
+        )
+        .unwrap();
+        let uncached = record_to_entry(
+            record(Some("claude-sonnet-4-5"), usage(4050 + 16275, 375, 0)),
+            Some(&tz),
+            CostMode::Auto,
+            &pricing,
+        )
+        .unwrap();
+
+        assert!(cached.cost > 0.0);
+        assert!(
+            cached.cost < uncached.cost,
+            "cached {} should undercut uncached {}",
+            cached.cost,
+            uncached.cost
+        );
+    }
+
+    #[test]
+    fn reports_an_unnamed_model_as_missing_pricing_instead_of_dropping_it() {
+        let pricing = PricingMap::load_embedded();
+        let entry = record_to_entry(
+            record(
+                None,
+                ModelUsage {
+                    model_id: 1050,
+                    input_tokens: 93,
+                    output_tokens: 3,
+                    response_id: Some("response-b".to_string()),
+                    ..ModelUsage::default()
+                },
+            ),
+            Some(&jiff::tz::TimeZone::UTC),
+            CostMode::Auto,
+            &pricing,
+        )
+        .unwrap();
+
+        assert_eq!(entry.model.as_deref(), Some("antigravity-model-1050"));
+        assert_eq!(entry.data.message.usage.input_tokens, 93);
+        assert_eq!(
+            entry.missing_pricing_model.as_deref(),
+            Some("antigravity-model-1050")
+        );
+        assert_eq!(entry.cost, 0.0);
+    }
+
+    #[test]
+    fn reports_no_cost_in_display_mode_because_the_source_records_none() {
+        let pricing = PricingMap::load_embedded();
+        let entry = record_to_entry(
+            record(Some("gemini-3.6-flash"), usage(4050, 375, 16275)),
+            Some(&jiff::tz::TimeZone::UTC),
+            CostMode::Display,
+            &pricing,
+        )
+        .unwrap();
+
+        assert_eq!(entry.cost, 0.0);
+        assert_eq!(entry.missing_pricing_model, None);
+    }
+
+    #[test]
+    fn skips_a_record_with_no_tokens() {
+        let pricing = PricingMap::load_embedded();
+
+        assert!(
+            record_to_entry(
+                record(Some("gemini-3.6-flash"), usage(0, 0, 0)),
+                Some(&jiff::tz::TimeZone::UTC),
+                CostMode::Auto,
+                &pricing,
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
+    fn narrows_pricing_candidates_by_model_family() {
+        assert_eq!(
+            model_candidates("gemini-3.6-flash"),
+            vec![
+                "gemini-3.6-flash",
+                "gemini/gemini-3.6-flash",
+                "vertex_ai/gemini-3.6-flash",
+                "google/gemini-3.6-flash",
+                "openrouter/google/gemini-3.6-flash",
+            ]
+        );
+        assert_eq!(
+            model_candidates("claude-sonnet-4-5"),
+            vec![
+                "claude-sonnet-4-5",
+                "anthropic/claude-sonnet-4-5",
+                "vertex_ai/claude-sonnet-4-5",
+                "bedrock/claude-sonnet-4-5",
+                "openrouter/anthropic/claude-sonnet-4-5",
+            ]
+        );
+        assert_eq!(model_candidates("mystery-model"), vec!["mystery-model"]);
+    }
+
+    #[test]
+    fn resolves_embedded_pricing_through_a_provider_qualified_candidate() {
+        let pricing = PricingMap::load_embedded();
+
+        assert!(
+            model_candidates("claude-sonnet-4-5")
+                .iter()
+                .any(|candidate| pricing.find(candidate).is_some()),
+            "no embedded pricing for claude-sonnet-4-5"
+        );
+    }
+}

--- a/rust/adapters/antigravity/src/paths.rs
+++ b/rust/adapters/antigravity/src/paths.rs
@@ -1,0 +1,210 @@
+use std::{collections::HashSet, env, path::PathBuf};
+
+use ccusage_adapter_common::collect_files_with_extension;
+
+use crate::Result;
+
+const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
+const ANTIGRAVITY_CONVERSATIONS_DIR_NAME: &str = "conversations";
+const ANTIGRAVITY_BRAIN_DIR_NAME: &str = "brain";
+
+const EXCLUDED_DB_FILENAMES: &[&str] = &[
+    "conversation_summaries.db",
+    "heavy_ad_intervention_opt_out.db",
+    "state.vscdb",
+    "state.vscdb.backup",
+];
+
+/// Roots to search for Antigravity CLI / IDE / Desktop data, honoring `ANTIGRAVITY_DATA_DIR`.
+///
+/// The override accepts comma-separated directories, like every other
+/// source-specific path variable, so a current profile and an archive can be
+/// reported together.
+fn antigravity_roots() -> Result<Vec<PathBuf>> {
+    if let Ok(env_roots) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
+        let roots = env_roots
+            .split(',')
+            .map(str::trim)
+            .filter(|root| !root.is_empty())
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+        if !roots.is_empty() {
+            return Ok(roots);
+        }
+    }
+    let home = ccusage_core::home::home_dir()
+        .ok_or_else(|| crate::cli_error("home directory is not set"))?;
+
+    #[allow(unused_mut)]
+    let mut default_roots = vec![
+        home.join(".gemini").join("antigravity"),
+        home.join(".gemini").join("antigravity-cli"),
+        home.join(".gemini").join("antigravity-ide"),
+        home.join(".gemini").join("Antigravity"),
+        home.join(".gemini").join("antigravity-backup"),
+        home.join(".config").join("Antigravity"),
+        home.join(".config").join("Antigravity IDE"),
+    ];
+
+    #[cfg(target_os = "macos")]
+    {
+        default_roots.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("Antigravity"),
+        );
+        default_roots.push(
+            home.join("Library")
+                .join("Application Support")
+                .join("Antigravity IDE"),
+        );
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = env::var("APPDATA") {
+            let appdata_path = PathBuf::from(appdata);
+            default_roots.push(appdata_path.join("Antigravity"));
+            default_roots.push(appdata_path.join("Antigravity IDE"));
+        }
+    }
+
+    Ok(default_roots)
+}
+
+fn is_excluded_db(path: &std::path::Path) -> bool {
+    let Some(file_name) = path.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    EXCLUDED_DB_FILENAMES.iter().any(|&excluded| file_name.eq_ignore_ascii_case(excluded))
+}
+
+/// Check whether any Antigravity conversation database exists.
+pub fn has_data() -> bool {
+    antigravity_db_paths().map_or(false, |paths| !paths.is_empty())
+}
+
+/// Every per-conversation SQLite database Antigravity has written.
+///
+/// Antigravity stores conversation databases under `conversations/`, `brain/`, or
+/// nested subagent directories. Sub-conversations (subagents, and the arms of a model
+/// comparison) get their own database. Collecting all of them makes those calls
+/// visible; the loader's dedup by response id prevents duplicate counting.
+pub(super) fn antigravity_db_paths() -> Result<Vec<PathBuf>> {
+    let mut paths = Vec::new();
+    let mut seen = HashSet::new();
+
+    for root in antigravity_roots()? {
+        if !root.exists() {
+            continue;
+        }
+
+        let mut found = Vec::new();
+
+        // 1. Search `conversations/` directory
+        let conv_dir = root.join(ANTIGRAVITY_CONVERSATIONS_DIR_NAME);
+        if conv_dir.exists() {
+            collect_files_with_extension(&conv_dir, "db", &mut found);
+        }
+
+        // 2. Search `brain/` directory
+        let brain_dir = root.join(ANTIGRAVITY_BRAIN_DIR_NAME);
+        if brain_dir.exists() {
+            collect_files_with_extension(&brain_dir, "db", &mut found);
+        }
+
+        // 3. If root itself contains databases (or other subdirectories), collect them too
+        collect_files_with_extension(&root, "db", &mut found);
+
+        // Read order decides which duplicate survives, so keep it stable across
+        // runs rather than inheriting the filesystem's directory order.
+        found.sort();
+        for path in found {
+            if is_excluded_db(&path) {
+                continue;
+            }
+            let path = path.canonicalize().unwrap_or(path);
+            if seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+    }
+    Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, EnvVarsGuard, fs_fixture};
+
+    #[test]
+    fn discovers_conversation_databases_under_the_data_dir() {
+        let fixture = fs_fixture!({
+            "conversations/adf2fd49.db": "",
+            "conversations/f672f900.db": "",
+            "conversation_summaries.db": "",
+            "conversations/notes.txt": "",
+        });
+        let _cleanup = EnvVarGuard::set(ANTIGRAVITY_DATA_DIR_ENV, fixture.root());
+
+        let paths = antigravity_db_paths().unwrap();
+
+        let names = paths
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        // The summaries database sits outside `conversations/` and is in EXCLUDED_DB_FILENAMES.
+        assert_eq!(names, vec!["adf2fd49.db", "f672f900.db"]);
+    }
+
+    #[test]
+    fn discovers_databases_in_brain_and_custom_subdirectories() {
+        let fixture = fs_fixture!({
+            "brain/sess-1/conversation.db": "",
+            "conversations/subagent/sess-2.db": "",
+            "state.vscdb": "",
+        });
+        let _cleanup = EnvVarGuard::set(ANTIGRAVITY_DATA_DIR_ENV, fixture.root());
+
+        let paths = antigravity_db_paths().unwrap();
+        let names = paths
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        assert_eq!(names, vec!["conversation.db", "sess-2.db"]);
+    }
+
+    #[test]
+    fn reads_comma_separated_data_dirs() {
+        let current = fs_fixture!({ "conversations/current.db": "" });
+        let archive = fs_fixture!({ "conversations/archive.db": "" });
+        let _cleanup = EnvVarGuard::set(
+            ANTIGRAVITY_DATA_DIR_ENV,
+            format!("{}, {}", current.root().display(), archive.root().display()),
+        );
+
+        let names = antigravity_db_paths()
+            .unwrap()
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+
+        assert_eq!(names, vec!["current.db", "archive.db"]);
+    }
+
+    #[test]
+    fn ignores_a_blank_data_dir_override() {
+        let fixture = fs_fixture!({});
+        // Pin `HOME` alongside the override so the fallback root is the fixture
+        // rather than whatever home directory the test process inherits.
+        let _cleanup = EnvVarsGuard::set_many([
+            (ANTIGRAVITY_DATA_DIR_ENV, Some(OsString::from("   "))),
+            ("HOME", Some(fixture.root().as_os_str().to_owned())),
+        ]);
+
+        // Falls back to the default root, which holds no databases under test.
+        assert!(antigravity_db_paths().unwrap().is_empty());
+    }
+}

--- a/rust/adapters/antigravity/src/proto.rs
+++ b/rust/adapters/antigravity/src/proto.rs
@@ -1,0 +1,545 @@
+//! Minimal protobuf wire-format reader for the blobs Antigravity stores in its
+//! conversation SQLite databases.
+//!
+//! Antigravity persists `CortexStepMetadata` and `ChatModelMetadata` as raw
+//! protobuf, and ships no `.proto` files. The field numbers below were recovered
+//! from the `FileDescriptorProto` blobs embedded in the `agy` binary, so they are
+//! the upstream numbers rather than guesses. Antigravity has to read these same
+//! blobs back after an upgrade, which means it cannot renumber fields without
+//! breaking its own persistence — that is what makes decoding by number safe.
+//!
+//! Only the handful of fields ccusage needs are decoded; everything else is
+//! skipped. A hand-rolled reader keeps `prost` (and its build-time codegen and
+//! binary-size cost) out of the dependency graph.
+
+use ccusage_core::TimestampMs;
+
+/// The upper bound `google.protobuf.Timestamp` puts on its nanos field.
+const NANOS_PER_SECOND: u32 = 1_000_000_000;
+
+/// One protobuf field value, limited to the wire types Antigravity actually uses.
+enum Value<'a> {
+    Varint(u64),
+    Bytes(&'a [u8]),
+    Fixed64,
+    Fixed32,
+}
+
+/// Cursor over a protobuf message body.
+struct Reader<'a> {
+    buf: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Reader<'a> {
+    fn new(buf: &'a [u8]) -> Self {
+        Self { buf, pos: 0 }
+    }
+
+    /// Decode a base-128 varint, advancing the cursor.
+    ///
+    /// Returns `None` on truncated input or on a varint longer than the 10 bytes
+    /// a 64-bit value can occupy, which keeps malformed blobs from looping.
+    fn varint(&mut self) -> Option<u64> {
+        let mut value: u64 = 0;
+        for index in 0..10 {
+            let byte = *self.buf.get(self.pos)?;
+            self.pos += 1;
+            // Each byte contributes 7 bits; bit 8 marks "more bytes follow".
+            value |= u64::from(byte & 0x7f) << (index * 7);
+            if byte & 0x80 == 0 {
+                return Some(value);
+            }
+        }
+        None
+    }
+
+    /// Read the next `(field_number, value)` pair, or `None` at end of message.
+    ///
+    /// A malformed tag also yields `None`, which makes callers treat the rest of
+    /// the message as absent instead of erroring out. Partial data is preferable
+    /// to discarding a whole conversation.
+    fn next_field(&mut self) -> Option<(u32, Value<'a>)> {
+        if self.pos >= self.buf.len() {
+            return None;
+        }
+        let tag = self.varint()?;
+        // Low 3 bits are the wire type, the rest is the field number.
+        let field = u32::try_from(tag >> 3).ok()?;
+        if field == 0 {
+            return None;
+        }
+        let value = match tag & 0x7 {
+            0 => Value::Varint(self.varint()?),
+            1 => {
+                self.pos = self.pos.checked_add(8)?;
+                Value::Fixed64
+            }
+            2 => {
+                let len = usize::try_from(self.varint()?).ok()?;
+                let start = self.pos;
+                let end = start.checked_add(len)?;
+                let slice = self.buf.get(start..end)?;
+                self.pos = end;
+                Value::Bytes(slice)
+            }
+            5 => {
+                self.pos = self.pos.checked_add(4)?;
+                Value::Fixed32
+            }
+            // Wire types 3 and 4 are deprecated groups, and 6/7 are invalid.
+            // Neither appears in Antigravity's schema, so stop rather than guess
+            // at a length and misread the remainder.
+            _ => return None,
+        };
+        Some((field, value))
+    }
+}
+
+/// Read a `google.protobuf.Timestamp` (field 1 seconds, field 2 nanos).
+fn timestamp(bytes: &[u8]) -> Option<TimestampMs> {
+    let mut seconds: Option<i64> = None;
+    let mut nanos: u32 = 0;
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field() {
+        match (field, value) {
+            (1, Value::Varint(raw)) => seconds = Some(raw as i64),
+            // `google.protobuf.Timestamp` constrains nanos to a single second, so
+            // discard anything outside that range rather than carrying it into the
+            // millisecond total: normalizing it would report the invocation up to
+            // four seconds late and could push it over a day boundary.
+            (2, Value::Varint(raw)) => {
+                nanos = u32::try_from(raw)
+                    .ok()
+                    .filter(|nanos| *nanos < NANOS_PER_SECOND)
+                    .unwrap_or(0);
+            }
+            _ => {}
+        }
+    }
+    let seconds = seconds?;
+    // Antigravity only ever writes wall-clock timestamps, so reject the zero and
+    // negative range instead of producing 1970 dates from an unset field.
+    if seconds <= 0 {
+        return None;
+    }
+    let millis = seconds
+        .checked_mul(1_000)?
+        .checked_add(i64::from(nanos / 1_000_000))?;
+    Some(TimestampMs::from_millis(millis))
+}
+
+/// Interpret a length-delimited field as UTF-8, discarding empty or binary values.
+fn text(bytes: &[u8]) -> Option<String> {
+    let value = std::str::from_utf8(bytes).ok()?.trim();
+    (!value.is_empty()).then(|| value.to_string())
+}
+
+/// Token counts and identifiers for a single model invocation.
+///
+/// Mirrors Antigravity's `ModelUsageStats`. `output_tokens` already includes
+/// `thinking_output_tokens`, so the thinking count must never be added on top.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub(crate) struct ModelUsage {
+    /// `model` — an opaque numeric model id. The shipped descriptor only names
+    /// these as `MODEL_PLACEHOLDER_M<n>`, so it cannot be turned into a price.
+    pub(crate) model_id: u64,
+    /// `input_tokens` — excludes `cache_read_tokens`. A record with
+    /// `input_tokens` below `cache_read_tokens` proves the two are disjoint.
+    pub(crate) input_tokens: u64,
+    /// `output_tokens` — thinking plus visible response tokens.
+    pub(crate) output_tokens: u64,
+    /// `cache_write_tokens`.
+    pub(crate) cache_write_tokens: u64,
+    /// `cache_read_tokens`.
+    pub(crate) cache_read_tokens: u64,
+    /// `thinking_output_tokens`, kept only to reconstruct `output_tokens` when
+    /// the total is absent.
+    pub(crate) thinking_output_tokens: u64,
+    /// `response_output_tokens`, used for the same fallback.
+    pub(crate) response_output_tokens: u64,
+    /// `response_id` — server-assigned, and the primary dedup key.
+    pub(crate) response_id: Option<String>,
+    /// `message_id` — dedup fallback when `response_id` is absent.
+    pub(crate) message_id: Option<String>,
+    /// `provider_assigned_message_id` — second dedup fallback.
+    pub(crate) provider_message_id: Option<String>,
+}
+
+impl ModelUsage {
+    /// Total output tokens, reconstructed from the thinking and response split
+    /// when the precomputed total is missing.
+    pub(crate) fn total_output_tokens(&self) -> u64 {
+        if self.output_tokens > 0 {
+            return self.output_tokens;
+        }
+        self.thinking_output_tokens
+            .saturating_add(self.response_output_tokens)
+    }
+
+    /// Whether the record carries any billable token count.
+    pub(crate) fn has_tokens(&self) -> bool {
+        self.input_tokens > 0
+            || self.cache_read_tokens > 0
+            || self.cache_write_tokens > 0
+            || self.total_output_tokens() > 0
+    }
+
+    /// Stable identity for this invocation, preferring server-assigned ids.
+    ///
+    /// Deduplicating on this is what keeps a single model call from being counted
+    /// twice when it shows up in more than one place — `retry_infos` repeats the
+    /// successful attempt alongside the failed ones, and a sub-conversation may
+    /// repeat a call already recorded by its parent.
+    pub(crate) fn identity(&self) -> Option<&str> {
+        self.response_id
+            .as_deref()
+            .or(self.provider_message_id.as_deref())
+            .or(self.message_id.as_deref())
+    }
+}
+
+/// Decode a `ModelUsageStats` message.
+fn model_usage(bytes: &[u8]) -> ModelUsage {
+    let mut usage = ModelUsage::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field() {
+        match (field, value) {
+            (1, Value::Varint(raw)) => usage.model_id = raw,
+            (2, Value::Varint(raw)) => usage.input_tokens = raw,
+            (3, Value::Varint(raw)) => usage.output_tokens = raw,
+            (4, Value::Varint(raw)) => usage.cache_write_tokens = raw,
+            (5, Value::Varint(raw)) => usage.cache_read_tokens = raw,
+            (9, Value::Varint(raw)) => usage.thinking_output_tokens = raw,
+            (10, Value::Varint(raw)) => usage.response_output_tokens = raw,
+            (7, Value::Bytes(raw)) => usage.message_id = text(raw),
+            (11, Value::Bytes(raw)) => usage.response_id = text(raw),
+            (12, Value::Bytes(raw)) => usage.provider_message_id = text(raw),
+            _ => {}
+        }
+    }
+    usage
+}
+
+/// Pull the `usage` (field 2) out of a `RetryInfo` message.
+fn retry_usage(bytes: &[u8]) -> Option<ModelUsage> {
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field() {
+        if let (2, Value::Bytes(raw)) = (field, value) {
+            return Some(model_usage(raw));
+        }
+    }
+    None
+}
+
+/// Every model invocation recorded by one conversation step.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct StepUsage {
+    /// `created_at`, falling back to `started_at`.
+    pub(crate) timestamp: Option<TimestampMs>,
+    /// The successful invocation plus every retry attempt.
+    pub(crate) usages: Vec<ModelUsage>,
+}
+
+/// Decode the `CortexStepMetadata` blob stored in `steps.metadata`.
+///
+/// Both `model_usage` (field 9) and each `retry_infos` entry (field 28) are
+/// collected. Attempts that failed still consumed input tokens, and the caller
+/// deduplicates by [`ModelUsage::identity`], so gathering both cannot
+/// double-count the attempt that succeeded.
+pub(crate) fn parse_step_metadata(bytes: &[u8]) -> StepUsage {
+    let mut step = StepUsage::default();
+    let mut started_at = None;
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field() {
+        match (field, value) {
+            (1, Value::Bytes(raw)) => step.timestamp = timestamp(raw),
+            (32, Value::Bytes(raw)) => started_at = timestamp(raw),
+            (9, Value::Bytes(raw)) => step.usages.push(model_usage(raw)),
+            (28, Value::Bytes(raw)) => step.usages.extend(retry_usage(raw)),
+            _ => {}
+        }
+    }
+    step.timestamp = step.timestamp.or(started_at);
+    step
+}
+
+/// A model invocation recorded by `gen_metadata`, including its model name.
+#[derive(Debug, Default, Clone)]
+pub(crate) struct GenerationUsage {
+    /// `response_model`, e.g. `gemini-3.6-flash`. This is the only place a
+    /// human-readable model name appears, which is why `gen_metadata` is read at
+    /// all rather than relying on `steps` alone.
+    pub(crate) model: Option<String>,
+    /// `chat_start_metadata.created_at`.
+    pub(crate) timestamp: Option<TimestampMs>,
+    /// The successful invocation plus every retry attempt.
+    pub(crate) usages: Vec<ModelUsage>,
+}
+
+impl GenerationUsage {
+    /// Whether this record can name the model behind a usage row.
+    fn names_a_model(&self) -> bool {
+        self.model.is_some() && self.usages.iter().any(|usage| usage.identity().is_some())
+    }
+}
+
+/// Decode a `ChatModelMetadata` message.
+fn chat_model_metadata(bytes: &[u8]) -> GenerationUsage {
+    let mut generation = GenerationUsage::default();
+    let mut reader = Reader::new(bytes);
+    while let Some((field, value)) = reader.next_field() {
+        match (field, value) {
+            (4, Value::Bytes(raw)) => generation.usages.push(model_usage(raw)),
+            (17, Value::Bytes(raw)) => generation.usages.extend(retry_usage(raw)),
+            (19, Value::Bytes(raw)) => generation.model = text(raw),
+            // `chat_start_metadata.created_at` is the request time; the step rows
+            // carry their own timestamp, so this only matters for usage that
+            // appears in `gen_metadata` alone.
+            (9, Value::Bytes(raw)) => {
+                let mut start = Reader::new(raw);
+                while let Some((inner, inner_value)) = start.next_field() {
+                    if let (4, Value::Bytes(stamp)) = (inner, inner_value) {
+                        generation.timestamp = timestamp(stamp);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    generation
+}
+
+/// Decode the blob stored in `gen_metadata.data`.
+///
+/// The `ChatModelMetadata` sits inside a wrapper message. Rather than hard-coding
+/// the wrapper's field number, every length-delimited field is tried and only
+/// those yielding both a model name and an identifiable usage row are kept. The
+/// sibling field holding the outbound request has neither, so it is rejected
+/// without needing to know the wrapper's shape.
+pub(crate) fn parse_generation_metadata(bytes: &[u8]) -> Vec<GenerationUsage> {
+    let mut found = Vec::new();
+    let mut reader = Reader::new(bytes);
+    while let Some((_, value)) = reader.next_field() {
+        if let Value::Bytes(raw) = value {
+            let generation = chat_model_metadata(raw);
+            if generation.names_a_model() {
+                found.push(generation);
+            }
+        }
+    }
+    found
+}
+
+/// Protobuf encoders for building fixture blobs.
+///
+/// Antigravity's real conversation databases embed absolute paths, user prompts and
+/// Antigravity's own system prompt, none of which belong in this repository, so
+/// tests synthesize the blobs they need instead of shipping a captured database.
+#[cfg(test)]
+pub(crate) mod encode {
+    /// Encode a base-128 varint.
+    fn varint(mut value: u64) -> Vec<u8> {
+        let mut out = Vec::new();
+        loop {
+            let byte = (value & 0x7f) as u8;
+            value >>= 7;
+            if value == 0 {
+                out.push(byte);
+                return out;
+            }
+            out.push(byte | 0x80);
+        }
+    }
+
+    /// Encode a varint field.
+    pub(crate) fn field_varint(number: u32, value: u64) -> Vec<u8> {
+        let mut out = varint(u64::from(number) << 3);
+        out.extend(varint(value));
+        out
+    }
+
+    /// Encode a length-delimited field.
+    pub(crate) fn field_bytes(number: u32, value: &[u8]) -> Vec<u8> {
+        let mut out = varint((u64::from(number) << 3) | 2);
+        out.extend(varint(value.len() as u64));
+        out.extend_from_slice(value);
+        out
+    }
+
+    /// Build a `google.protobuf.Timestamp`.
+    pub(crate) fn timestamp_bytes(seconds: i64, nanos: u32) -> Vec<u8> {
+        let mut out = field_varint(1, seconds as u64);
+        out.extend(field_varint(2, u64::from(nanos)));
+        out
+    }
+
+    /// Build a `ModelUsageStats` with the token fields ccusage reads.
+    pub(crate) fn usage_bytes(
+        model_id: u64,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        response_id: &str,
+    ) -> Vec<u8> {
+        let mut out = field_varint(1, model_id);
+        out.extend(field_varint(2, input));
+        out.extend(field_varint(3, output));
+        out.extend(field_varint(5, cache_read));
+        out.extend(field_bytes(11, response_id.as_bytes()));
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode::*, *};
+
+    #[test]
+    fn decodes_the_token_fields_of_a_model_usage_record() {
+        let usage = model_usage(&usage_bytes(1071, 4050, 375, 16275, "response-a"));
+
+        assert_eq!(usage.model_id, 1071);
+        assert_eq!(usage.input_tokens, 4050);
+        assert_eq!(usage.output_tokens, 375);
+        assert_eq!(usage.cache_read_tokens, 16275);
+        assert_eq!(usage.response_id.as_deref(), Some("response-a"));
+    }
+
+    #[test]
+    fn reconstructs_output_tokens_from_the_thinking_and_response_split() {
+        let mut bytes = field_varint(9, 351);
+        bytes.extend(field_varint(10, 24));
+        let usage = model_usage(&bytes);
+
+        assert_eq!(usage.output_tokens, 0);
+        assert_eq!(usage.total_output_tokens(), 375);
+    }
+
+    #[test]
+    fn prefers_the_recorded_output_total_over_the_split() {
+        let mut bytes = field_varint(3, 375);
+        bytes.extend(field_varint(9, 351));
+        bytes.extend(field_varint(10, 24));
+
+        assert_eq!(model_usage(&bytes).total_output_tokens(), 375);
+    }
+
+    #[test]
+    fn falls_back_through_the_identity_fields() {
+        let mut bytes = field_bytes(7, b"message-a");
+        bytes.extend(field_bytes(12, b"provider-a"));
+        let usage = model_usage(&bytes);
+
+        assert_eq!(usage.identity(), Some("provider-a"));
+        assert_eq!(
+            model_usage(&field_bytes(7, b"message-a")).identity(),
+            Some("message-a")
+        );
+        assert_eq!(model_usage(&[]).identity(), None);
+    }
+
+    #[test]
+    fn reads_step_usage_with_retry_attempts() {
+        let mut bytes = field_bytes(1, &timestamp_bytes(1_785_328_986, 355_887_000));
+        bytes.extend(field_bytes(
+            9,
+            &usage_bytes(1071, 4050, 375, 16275, "response-ok"),
+        ));
+        bytes.extend(field_bytes(
+            28,
+            &field_bytes(2, &usage_bytes(1071, 4000, 0, 0, "response-failed")),
+        ));
+        let step = parse_step_metadata(&bytes);
+
+        assert_eq!(step.usages.len(), 2);
+        assert_eq!(step.usages[0].response_id.as_deref(), Some("response-ok"));
+        assert_eq!(
+            step.usages[1].response_id.as_deref(),
+            Some("response-failed")
+        );
+        assert_eq!(
+            step.timestamp,
+            Some(TimestampMs::from_millis(1_785_328_986_355))
+        );
+    }
+
+    #[test]
+    fn falls_back_to_started_at_when_created_at_is_absent() {
+        let bytes = field_bytes(32, &timestamp_bytes(1_785_328_980, 0));
+
+        assert_eq!(
+            parse_step_metadata(&bytes).timestamp,
+            Some(TimestampMs::from_millis(1_785_328_980_000))
+        );
+    }
+
+    #[test]
+    fn rejects_an_unset_timestamp_instead_of_dating_it_to_1970() {
+        assert_eq!(parse_step_metadata(&field_bytes(1, &[])).timestamp, None);
+        assert_eq!(timestamp(&field_varint(1, 0)), None);
+    }
+
+    #[test]
+    fn discards_nanos_beyond_the_second_they_may_describe() {
+        // Normalizing an out-of-range nanos count would report the invocation
+        // seconds later than it happened, which near midnight moves it to the
+        // next day. The seconds field is still trusted.
+        let corrupt = timestamp_bytes(1_785_328_986, NANOS_PER_SECOND + 355_887_000);
+
+        assert_eq!(
+            timestamp(&corrupt),
+            Some(TimestampMs::from_millis(1_785_328_986_000))
+        );
+    }
+
+    #[test]
+    fn finds_the_named_generation_inside_its_wrapper() {
+        let mut chat = field_bytes(4, &usage_bytes(1071, 20110, 33, 0, "response-a"));
+        chat.extend(field_bytes(
+            9,
+            &field_bytes(4, &timestamp_bytes(1_785_328_980, 0)),
+        ));
+        chat.extend(field_bytes(19, b"gemini-3.6-flash"));
+        chat.extend(field_bytes(21, b"Gemini 3.6 Flash (High)"));
+
+        // Wrapper: an unrelated request-shaped sibling plus the real payload.
+        let mut wrapper = field_bytes(3, &field_bytes(28, b"gemini-3.6-flash-high"));
+        wrapper.extend(field_bytes(1, &chat));
+        let found = parse_generation_metadata(&wrapper);
+
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].model.as_deref(), Some("gemini-3.6-flash"));
+        assert_eq!(
+            found[0].usages[0].response_id.as_deref(),
+            Some("response-a")
+        );
+        assert_eq!(
+            found[0].timestamp,
+            Some(TimestampMs::from_millis(1_785_328_980_000))
+        );
+    }
+
+    #[test]
+    fn ignores_a_generation_that_cannot_name_a_model() {
+        // A model name with no identifiable usage row cannot be attributed.
+        let bytes = field_bytes(1, &field_bytes(19, b"gemini-3.6-flash"));
+
+        assert!(parse_generation_metadata(&bytes).is_empty());
+    }
+
+    #[test]
+    fn stops_at_malformed_input_without_panicking() {
+        // Truncated length prefix, unterminated varint, and a group wire type.
+        assert!(parse_step_metadata(&[0x0a, 0x7f]).usages.is_empty());
+        assert!(parse_step_metadata(&[0x08, 0xff, 0xff]).usages.is_empty());
+        assert!(parse_step_metadata(&[0x0b, 0x00]).usages.is_empty());
+        assert!(parse_generation_metadata(&[0xff, 0xff, 0xff]).is_empty());
+    }
+
+    #[test]
+    fn treats_a_record_without_tokens_as_empty() {
+        assert!(!model_usage(&field_bytes(11, b"response-a")).has_tokens());
+        assert!(model_usage(&field_varint(5, 16275)).has_tokens());
+    }
+}

--- a/rust/adapters/antigravity/src/report.rs
+++ b/rust/adapters/antigravity/src/report.rs
@@ -1,0 +1,150 @@
+use std::collections::BTreeMap;
+
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, SessionAccumulator,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, kind == AgentReportKind::Session))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<crate::UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        // Antigravity keeps one database per conversation, so a session is a
+        // conversation. Accumulating rather than grouping by key is what carries
+        // the activity range and project path onto the row, which the session
+        // table and JSON both report.
+        AgentReportKind::Session => {
+            let mut groups = BTreeMap::<String, SessionAccumulator>::new();
+            for entry in entries {
+                groups
+                    .entry(entry.session_id.to_string())
+                    .or_default()
+                    .add_entry(entry);
+            }
+            groups
+                .into_values()
+                .map(SessionAccumulator::into_summary)
+                .collect()
+        }
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::{TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage};
+
+    fn entry(date: &str, cache_read: u64) -> LoadedEntry {
+        let usage = TokenUsageRaw {
+            input_tokens: 4050,
+            output_tokens: 375,
+            cache_creation_input_tokens: 0,
+            cache_read_input_tokens: cache_read,
+            speed: None,
+            cache_creation: None,
+        };
+        LoadedEntry {
+            data: UsageEntry {
+                session_id: Some("conversation-a".to_string()),
+                timestamp: format!("{date}T01:02:03.000Z"),
+                version: None,
+                message: UsageMessage {
+                    usage,
+                    model: Some("gemini-3.6-flash".to_string()),
+                    id: Some("response-a".to_string()),
+                },
+                cost_usd: None,
+                request_id: Some("response-a".to_string()),
+                is_api_error_message: None,
+                is_sidechain: None,
+            },
+            timestamp: TimestampMs::from_millis(1_785_328_986_355),
+            date: date.to_string(),
+            project: Arc::from("antigravity"),
+            session_id: Arc::from("conversation-a"),
+            project_path: Arc::from("Antigravity"),
+            cost: 0.0113,
+            credits: None,
+            model: Some("gemini-3.6-flash".to_string()),
+            usage_limit_reset_time: None,
+            missing_pricing_model: None,
+            extra_total_tokens: 0,
+            message_count: None,
+        }
+    }
+
+    #[test]
+    fn reports_cache_reads_separately_from_input_tokens() {
+        let rows =
+            summarize_entries(&[entry("2026-07-29", 16275)], AgentReportKind::Daily).unwrap();
+        let report = report_from_rows(&rows, AgentReportKind::Daily);
+
+        assert_eq!(report["daily"][0]["inputTokens"], 4050);
+        assert_eq!(report["daily"][0]["outputTokens"], 375);
+        assert_eq!(report["daily"][0]["cacheReadTokens"], 16275);
+        assert_eq!(report["daily"][0]["totalTokens"], 20700);
+    }
+
+    #[test]
+    fn groups_conversations_under_the_session_report() {
+        let rows = summarize_entries(&[entry("2026-07-29", 0)], AgentReportKind::Session).unwrap();
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].session_id.as_deref(), Some("conversation-a"));
+        assert_eq!(rows[0].project_path.as_deref(), Some("Antigravity"));
+        // The activity range is what the session table's Last Activity column and
+        // the session JSON report.
+        assert_eq!(
+            rows[0].last_activity.as_deref(),
+            Some("2026-07-29T12:43:06.355Z")
+        );
+        assert_eq!(rows[0].first_activity, rows[0].last_activity);
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -6,6 +6,7 @@ publish.workspace = true
 
 [dependencies]
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -10,6 +10,7 @@ use ccusage_core::*;
 
 mod adapter {
     pub use ccusage_adapter_amp as amp;
+    pub use ccusage_adapter_antigravity as antigravity;
     pub use ccusage_adapter_claude as claude;
     pub use ccusage_adapter_codebuff as codebuff;
     pub use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -11,8 +11,8 @@ use crate::{
     BUILT_IN_AGENT_NAMES, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result,
     SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        amp, antigravity, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes,
+        kilo, kimi, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -322,6 +322,22 @@ fn load_base_rows(
                     grok::summarize_entries,
                 )?;
                 rows.detected = rows.detected || grok::has_data();
+                Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("Antigravity"),
+            load: Box::new(|| {
+                let mut rows = load_summary_agent_rows(
+                    "antigravity",
+                    load_kind,
+                    &loader_shared,
+                    || antigravity::load_entries(&loader_shared, pricing),
+                    antigravity::summarize_entries,
+                )?;
+                rows.detected = rows.detected || antigravity::has_data();
                 Ok(rows)
             }),
         },

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -560,6 +560,10 @@ fn isolated_agent_env(
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
         "GROK_HOME",
+        "ANTIGRAVITY_DATA_DIR",
+        "CLINE_DATA_DIR",
+        "MUSE_DATA_DIR",
+        "ZCODE_DATA_DIR",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -561,9 +561,6 @@ fn isolated_agent_env(
         "QWEN_DATA_DIR",
         "GROK_HOME",
         "ANTIGRAVITY_DATA_DIR",
-        "CLINE_DATA_DIR",
-        "MUSE_DATA_DIR",
-        "ZCODE_DATA_DIR",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -104,6 +104,10 @@
 			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
+			},
+			{
+				"name": "antigravity",
+				"description": "Show Antigravity usage commands"
 			}
 		]
 	},
@@ -774,6 +778,43 @@
 			"path": ["grok", "session"],
 			"description": "Show Grok Build CLI usage grouped by session",
 			"usage": "ccusage grok session <OPTIONS>",
+			"options": "agent_options"
+		},
+		{
+			"path": ["antigravity"],
+			"description": "Usage reports for antigravity.",
+			"usage": "ccusage antigravity <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Antigravity usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Antigravity usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Antigravity usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["antigravity", "daily"],
+			"description": "Show Antigravity usage grouped by date",
+			"usage": "ccusage antigravity daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "monthly"],
+			"description": "Show Antigravity usage grouped by month",
+			"usage": "ccusage antigravity monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["antigravity", "session"],
+			"description": "Show Antigravity usage grouped by session",
+			"usage": "ccusage antigravity session <OPTIONS>",
 			"options": "agent_options"
 		}
 	]

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -318,6 +318,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Gemini,
         ),
+        "antigravity" => parse_basic_agent_command(
+            parser,
+            shared,
+            "antigravity",
+            STANDARD_AGENT_REPORTS,
+            Command::Antigravity,
+        ),
         "kimi" => parse_basic_agent_command(
             parser,
             shared,
@@ -770,6 +777,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "antigravity"
             | "grok"
     )
 }
@@ -943,7 +951,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "antigravity" | "grok" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -965,6 +973,8 @@ fn agent_display_name(agent: &str) -> &'static str {
         "copilot" => "GitHub Copilot CLI",
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
+        "antigravity" => "Antigravity",
+
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
@@ -1048,6 +1058,8 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Antigravity(args)
+
             | Command::Grok(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -1,5 +1,5 @@
 ---
-source: crates/ccusage-cli/src/tests.rs
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: help_text()
 ---
 USAGE:
@@ -29,6 +29,7 @@ COMMANDS:
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
   grok                       Show Grok Build CLI usage commands
+  antigravity                Show Antigravity usage commands
 
 For more info, run any command with the `--help` flag:
   ccusage daily --help
@@ -53,6 +54,7 @@ For more info, run any command with the `--help` flag:
   ccusage qwen --help
   ccusage openclaw --help
   ccusage grok --help
+  ccusage antigravity --help
 
 OPTIONS:
   -j, --json                           Output in JSON format (default: false)

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -204,6 +204,8 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Antigravity(args)) => agent_command_snapshot("antigravity", args),
+
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
     }
 }
@@ -647,7 +649,8 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok", "antigravity",
+
     ];
 
     for agent in agents {

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,8 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    Antigravity(AgentCommandArgs),
+
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok", "antigravity",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -17,6 +17,7 @@ fetch-litellm-pricing = ["ccusage-core/fetch-litellm-pricing"]
 [dependencies]
 ccusage-adapter-all.workspace = true
 ccusage-adapter-amp.workspace = true
+ccusage-adapter-antigravity.workspace = true
 ccusage-adapter-claude.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,5 +1,6 @@
 pub(crate) use ccusage_adapter_all as all;
 pub(crate) use ccusage_adapter_amp as amp;
+pub(crate) use ccusage_adapter_antigravity as antigravity;
 pub(crate) use ccusage_adapter_claude as claude;
 pub(crate) use ccusage_adapter_codebuff as codebuff;
 pub(crate) use ccusage_adapter_codex as codex;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,6 +49,8 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Antigravity(args)
+
             | Command::Grok(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,8 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::Antigravity(args)) => adapter::antigravity::run(args),
+
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,8 +88,10 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
+            ccusage_adapter_antigravity::run,
+
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
             ccusage_adapter_copilot::run,
@@ -104,7 +108,9 @@ mod tests {
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
+
+
     }
 
     #[test]


### PR DESCRIPTION
## What this adds

A new `antigravity` agent adapter exposing the standard report modes (`ccusage antigravity daily`, `weekly`, `monthly`, `session`, plus JSON output and last-window/statusline integration through the unified loader).

## What it reads

Antigravity (CLI, IDE, and Desktop) stores usage in per-conversation SQLite databases written under `conversations/`, `brain/`, and nested subagent directories. Sub-conversations (subagents and the arms of a model comparison) get their own database, so the loader collects every `.db` file under the data roots and deduplicates by response id to prevent double counting. Known non-usage databases (`conversation_summaries.db`, `heavy_ad_intervention_opt_out.db`, `state.vscdb`) are excluded. Databases are opened read-only so a live session is never locked.

## Path discovery

- **Linux**: `~/.gemini/antigravity*` (including `antigravity-cli`, `antigravity-ide`, `antigravity-backup`) and `~/.config/Antigravity{," IDE"}`
- **macOS**: the dotfile/`.config` roots above plus `~/Library/Application Support/Antigravity{," IDE"}`
- **Windows**: the dotfile/`.config` roots above plus `%APPDATA%\\Antigravity{," IDE"}`
- **Override**: `ANTIGRAVITY_DATA_DIR` accepts comma-separated directories (e.g. a current profile plus an archive), matching the other source-specific path variables.

## Validation

```
cd rust
CCUSAGE_PRICING_JSON_PATH=<model_prices_and_context_window.json> \\
  cargo test -p ccusage-adapter-antigravity -p ccusage-cli-parser -p ccusage --quiet
CCUSAGE_PRICING_JSON_PATH=<...> cargo check --workspace
```

All green: 50 + 35 + 77 tests pass, workspace check clean, and the `root_help` snapshot includes the new `antigravity` command.

Fixes # (tracks the Antigravity support request)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Antigravity adapter that reads per-conversation SQLite databases and exposes daily, monthly, and session reports. Previously Antigravity usage was not detected; now it’s included in unified views and available via `ccusage antigravity ...`, with costs calculated from pricing data when available.

- Review notes:
  - Path discovery and DB collection: scans `conversations/`, `brain/`, and nested subagent dirs under default roots on Linux/macOS/Windows; opens SQLite read-only; skips known non-usage DBs; deduplicates invocations by server response ID to avoid double counting across retries and sub-conversations.
  - Wire decoding: `proto.rs` implements a minimal protobuf reader for `steps.metadata` and `gen_metadata.data`; parses token fields (input, output, cache read/write, thinking) and identifiers; tolerates missing/partial rows without aborting the conversation.
  - Cost behavior: Antigravity records no precomputed cost, so Display mode shows $0. Auto/Calculate matches provider-qualified candidates (e.g., `anthropic/`, `gemini/`) to LiteLLM pricing; unnamed models surface as `antigravity-model-<id>` with missing pricing.
  - Integration: new `ccusage-adapter-antigravity` crate; registered in `ccusage-adapter-all`, CLI parser/commands, and unified loader; docs and help updated; tests cover parsing, dedupe, pricing, and path discovery.

- Rollout:
  - No migration required. If data is outside defaults, set `ANTIGRAVITY_DATA_DIR` to one or more roots (comma-separated). If costs show as $0 or missing pricing, run with `--offline=false` or add pricing overrides.

<sup>Written for commit 34256db9d7d36657f1a46402fe0b1f312aadca95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added beta support for Antigravity usage data from CLI, IDE, and Desktop environments.
  - Added daily, monthly, and session Antigravity reports with token usage and pricing details.
  - Added automatic data discovery, custom `ANTIGRAVITY_DATA_DIR` configuration, and support for `--last`.
  - Added unified reporting integration and Antigravity command-line help.

- **Documentation**
  - Added Antigravity setup, configuration, report, pricing, and troubleshooting guidance.
  - Updated supported-source listings and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->