### PR TITLE
feat(adapter-muse): add Muse Code usage adapter with cross-platform discovery

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -78,6 +78,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
+| Muse Code          | `ccusage muse daily`     |
 | Grok Build CLI     | `ccusage grok daily`     |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
@@ -166,7 +167,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Muse Code, and Grok Build CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Muse Code, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Muse Code, and Grok Build CLI.
 
 The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Muse Code, and Grok Build CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "ccusage-adapter-hermes",
  "ccusage-adapter-kilo",
  "ccusage-adapter-kimi",
+ "ccusage-adapter-muse",
  "ccusage-adapter-openclaw",
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
@@ -165,6 +166,7 @@ dependencies = [
  "ccusage-adapter-hermes",
  "ccusage-adapter-kilo",
  "ccusage-adapter-kimi",
+ "ccusage-adapter-muse",
  "ccusage-adapter-openclaw",
  "ccusage-adapter-opencode",
  "ccusage-adapter-pi",
@@ -334,6 +336,17 @@ dependencies = [
  "ccusage-test-support",
  "jiff",
  "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-muse"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
  "serde_json",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,6 +30,7 @@ ccusage-adapter-grok = { path = "adapters/grok" }
 ccusage-adapter-hermes = { path = "adapters/hermes" }
 ccusage-adapter-kilo = { path = "adapters/kilo" }
 ccusage-adapter-kimi = { path = "adapters/kimi" }
+ccusage-adapter-muse = { path = "adapters/muse" }
 ccusage-adapter-openclaw = { path = "adapters/openclaw" }
 ccusage-adapter-opencode = { path = "adapters/opencode" }
 ccusage-adapter-pi = { path = "adapters/pi" }

--- a/rust/adapters/muse/Cargo.toml
+++ b/rust/adapters/muse/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccusage-adapter-muse"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/muse/README.md
+++ b/rust/adapters/muse/README.md
@@ -1,0 +1,56 @@
+# ccusage-adapter-muse
+
+The Muse Code adapter: it turns Muse Code's event-sourced session logs
+into the usage entries the reports render.
+
+## Owns
+
+- `paths.rs` — XDG data directories and session log discovery.
+- `parser.rs` — raw record parsing, token mapping, and model naming.
+- `loader.rs` — file walking, dedupe, and date filtering entry points.
+- `report.rs` — the JSON and table shapes where they differ from the shared ones.
+
+## Data source
+
+- `$XDG_DATA_HOME/muse/sessions/YYYY/MM/DD/<session-uuid>/session.jsonl`
+
+Set `XDG_DATA_HOME` to relocate or fixture the discovery root. An empty
+`XDG_DATA_HOME` disables Muse discovery.
+
+| OS      | Discovery roots (scanned in order)                        |
+| ------- | --------------------------------------------------------- |
+| Linux   | `$XDG_DATA_HOME` (default `~/.local/share`)               |
+| macOS   | `$XDG_DATA_HOME` (default `~/.local/share`), `~/Library/Application Support` |
+| Windows | `$XDG_DATA_HOME` (default `~/.local/share`), `%APPDATA%`  |
+
+Muse Code currently ships Linux and macOS builds only; the macOS
+`~/Library/Application Support` and Windows `%APPDATA%` candidates are scanned
+defensively so discovery keeps working if Muse later writes there. All roots
+are scanned and results are sorted and deduped, so overlapping roots never
+double-count a log.
+
+Each session directory holds one append-only event-sourced log. Assistant
+model calls appear as `runtime.session` records whose `event.kind` is
+`model_completed`, carrying the model and the token usage. Child agents log
+under `subagent/<child-uuid>/session.jsonl` with their own records; they are
+read too, because the parent log does not record their tokens.
+
+Muse logs no cost, so every entry is priced from the shared pricing map by
+model name; models without a published rate card surface the usual
+missing-pricing warning.
+
+## Public surface
+
+- `loader::load_entries`
+- `report::report_from_rows`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde_json`
+
+See `src/README.md` for the record shapes and token rules.

--- a/rust/adapters/muse/src/README.md
+++ b/rust/adapters/muse/src/README.md
@@ -1,0 +1,56 @@
+# Muse Code record shapes
+
+Muse Code stores one append-only, event-sourced `session.jsonl` per session
+under `sessions/YYYY/MM/DD/<session-uuid>/`, with child-agent logs under
+`subagent/<child-uuid>/`. There is no committed schema from Meta; the wire
+format below is what the adapter parses.
+
+## Discovery
+
+Logs are found under `$XDG_DATA_HOME/muse/sessions/` (default
+`~/.local/share/muse/sessions/`) on every OS; macOS additionally scans
+`~/Library/Application Support/muse/sessions/` and Windows `%APPDATA%\muse\sessions\`
+as defensive candidates. Muse Code currently ships Linux and macOS builds
+only. See `paths.rs` for the root list.
+
+## Envelope
+
+Every line is one envelope:
+
+```json
+{"schema_version":1,"id":"<record-uuid>","stream":{"kind":"session","id":"<session-uuid>"},
+ "sequence":89,"recorded_at":1785962540739784,"record_type":"event",
+ "durability":"durable","causation_id":null,
+ "payload_type":"runtime.session","payload_schema_version":1,"payload":{…}}
+```
+
+- `recorded_at` is **microseconds** since the Unix epoch; the adapter divides
+  by 1000 to get the millisecond timestamps reports use.
+- `sequence` restarts per turn and record `id`s repeat across sessions, so the
+  dedupe identity is the `(stream.id, id)` pair.
+- Rare tombstone lines carry no `payload_type` and are skipped.
+
+## Records the adapter reads
+
+| payload_type | payload | used for |
+|---|---|---|
+| `runtime.session.metadata` | `record.workspace_root` | project name (basename) |
+| `runtime.session` (`event.kind == "model_completed"`) | `event.model`, `event.usage` | one usage entry per model call |
+
+## Token semantics
+
+`model_completed.usage` has exactly six fields:
+
+- `input_tokens` — **gross, includes `cache_read_tokens`** (netted before storing)
+- `cache_read_tokens` — cached prefix replayed this turn (`cached_tokens` is a
+  duplicate fallback)
+- `cache_write_tokens` — cache-creation tokens
+- `output_tokens` — gross; `reasoning_tokens` is a subset of it and is priced at
+  the output rate like every other adapter
+
+## Cost
+
+Muse logs no cost and Meta publishes no per-token rate card, so entries are
+priced from the shared pricing map by model name. Unknown models report $0 and
+the standard missing-pricing warning; users can add pricing overrides in
+ccusage config.

--- a/rust/adapters/muse/src/lib.rs
+++ b/rust/adapters/muse/src/lib.rs
@@ -1,0 +1,45 @@
+use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, ccusage_core::summary_period);
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Muse Code Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/muse/src/loader.rs
+++ b/rust/adapters/muse/src/loader.rs
@@ -1,0 +1,142 @@
+use std::{collections::HashSet, path::Path};
+
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, read_files_parallel};
+
+use super::{
+    parser::{MuseEntry, MuseSession, parse_session_file, to_loaded_entry},
+    paths::muse_session_files,
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Muse Code"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = crate::parse_tz(shared.timezone.as_deref());
+    let files = muse_session_files()?;
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        load_session_file(file, shared)
+    });
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for (file_entries, workspace_root) in loaded {
+        for entry in file_entries {
+            // Record ids repeat across sessions, so the (session, id) pair is
+            // the stable identity a re-read of the same log must dedupe on.
+            let key = (entry.session_id.clone(), entry.record_id.clone());
+            if !seen.insert(key) {
+                continue;
+            }
+            entries.push(to_loaded_entry(
+                entry,
+                tz.as_ref(),
+                pricing,
+                workspace_root.as_deref(),
+            ));
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_session_file(file_path: &Path, shared: &SharedArgs) -> (Vec<MuseEntry>, Option<String>) {
+    let Ok(contents) = std::fs::read_to_string(file_path) else {
+        crate::debug_log(
+            shared,
+            format!(
+                "Failed to read Muse Code session log: {}",
+                file_path.display()
+            ),
+        );
+        return (Vec::new(), None);
+    };
+    let session: MuseSession = parse_session_file(&contents);
+    (session.entries, session.workspace_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
+
+    fn envelope(
+        payload_type: &str,
+        id: &str,
+        stream_id: &str,
+        recorded_at_us: u64,
+        event: &str,
+    ) -> String {
+        format!(
+            r#"{{"schema_version":1,"id":"{id}","stream":{{"kind":"session","id":"{stream_id}"}},"sequence":1,"recorded_at":{recorded_at_us},"record_type":"event","durability":"durable","causation_id":null,"payload_type":"{payload_type}","payload_schema_version":1,"payload":{event}}}"#
+        )
+    }
+
+    fn model_completed(id: &str, stream_id: &str, recorded_at_us: u64, model: &str) -> String {
+        envelope(
+            "runtime.session",
+            id,
+            stream_id,
+            recorded_at_us,
+            &format!(
+                r#"{{"event":{{"kind":"model_completed","model":"{model}","usage":{{"input_tokens":100,"output_tokens":10}}}},"kind":"run"}}"#
+            ),
+        )
+    }
+
+    #[test]
+    fn loads_entries_from_session_and_subagent_logs() {
+        let fixture = fs_fixture!({
+            "muse/sessions/2026/08/01/sess-parent/session.jsonl": [
+                envelope(
+                    "runtime.session.metadata",
+                    "meta-1",
+                    "sess-parent",
+                    1_785_962_827_173_826,
+                    r#"{"record":{"workspace_root":"/home/user/projects/ccusage"}}"#,
+                ),
+                model_completed("rec-1", "sess-parent", 1_785_962_827_173_826, "muse-spark-1.2"),
+                model_completed("rec-2", "sess-parent", 1_785_962_828_000_000, "muse-spark-1.2"),
+            ]
+            .join("\n"),
+            "muse/sessions/2026/08/01/sess-parent/subagent/sess-child/session.jsonl":
+                model_completed("rec-3", "sess-child", 1_785_962_830_000_000, "muse-spark-1.2-contributor"),
+        });
+        let _xdg = EnvVarGuard::set("XDG_DATA_HOME", fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            mode: crate::cli::CostMode::Display,
+            ..SharedArgs::default()
+        };
+
+        let entries = load_entries(&shared, &PricingMap::default()).unwrap();
+
+        assert_eq!(entries.len(), 3);
+        assert_eq!(entries[0].session_id.as_ref(), "sess-parent");
+        assert_eq!(entries[0].project.as_ref(), "ccusage");
+        assert_eq!(entries[2].session_id.as_ref(), "sess-child");
+        // The child log has no metadata record of its own, so it falls back to
+        // the source name.
+        assert_eq!(entries[2].project.as_ref(), "muse");
+    }
+
+    #[test]
+    fn dedupes_records_on_reread() {
+        let fixture = fs_fixture!({
+            "muse/sessions/2026/08/01/sess-parent/session.jsonl": [
+                model_completed("rec-1", "sess-parent", 1_785_962_827_173_826, "muse-spark-1.2"),
+                model_completed("rec-1", "sess-parent", 1_785_962_827_173_826, "muse-spark-1.2"),
+            ]
+            .join("\n"),
+        });
+        let _xdg = EnvVarGuard::set("XDG_DATA_HOME", fixture.root());
+        let shared = SharedArgs::default();
+
+        let entries = load_entries(&shared, &PricingMap::default()).unwrap();
+
+        assert_eq!(entries.len(), 1);
+    }
+}

--- a/rust/adapters/muse/src/parser.rs
+++ b/rust/adapters/muse/src/parser.rs
@@ -1,0 +1,362 @@
+use std::{path::Path, sync::Arc};
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde_json::Value;
+
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
+    missing_pricing_model_for_candidates,
+};
+
+/// One parsed session log: the model-completed records plus the project root
+/// the session announced in its metadata record.
+pub(super) struct MuseSession {
+    pub(super) entries: Vec<MuseEntry>,
+    pub(super) workspace_root: Option<String>,
+}
+
+pub(super) struct MuseEntry {
+    pub(super) timestamp: TimestampMs,
+    timestamp_text: String,
+    pub(super) session_id: String,
+    pub(super) model: String,
+    usage: TokenUsageRaw,
+    pub(super) record_id: String,
+}
+
+/// Parses one `session.jsonl` event-sourced stream into one `MuseEntry` per
+/// `model_completed` record that carries token metrics. `recorded_at` is
+/// microseconds since the Unix epoch, which is why it is divided by 1000 to
+/// reach the millisecond `TimestampMs` every report expects.
+pub(super) fn parse_session_file(contents: &str) -> MuseSession {
+    let mut entries = Vec::new();
+    let mut workspace_root = None;
+    for line in contents.lines() {
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        match value.get("payload_type").and_then(|v| v.as_str()) {
+            Some("runtime.session") => {
+                if let Some(entry) = parse_model_completed(&value) {
+                    entries.push(entry);
+                }
+            }
+            Some("runtime.session.metadata") => {
+                if workspace_root.is_none()
+                    && let Some(root) = value
+                        .get("payload")
+                        .and_then(|p| p.get("record"))
+                        .and_then(|r| r.get("workspace_root"))
+                        .and_then(|v| v.as_str())
+                {
+                    workspace_root = Some(root.to_string());
+                }
+            }
+            // Tombstones and every other payload type carry no usage.
+            _ => {}
+        }
+    }
+    MuseSession {
+        entries,
+        workspace_root,
+    }
+}
+
+fn parse_model_completed(envelope: &Value) -> Option<MuseEntry> {
+    let event = envelope.get("payload")?.get("event")?;
+    if event.get("kind").and_then(|v| v.as_str()) != Some("model_completed") {
+        return None;
+    }
+    let model = event
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .trim()
+        .to_string();
+    if model.is_empty() {
+        return None;
+    }
+    let usage = event.get("usage").map(parse_usage).unwrap_or_default();
+    if usage.input_tokens == 0
+        && usage.output_tokens == 0
+        && usage.cache_read_input_tokens == 0
+        && usage.cache_creation_input_tokens == 0
+    {
+        return None;
+    }
+    let recorded_at = envelope.get("recorded_at").and_then(|v| v.as_u64())?;
+    if recorded_at == 0 {
+        return None;
+    }
+    let session_id = envelope
+        .get("stream")
+        .and_then(|s| s.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let record_id = envelope
+        .get("id")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default()
+        .to_string();
+    let timestamp = TimestampMs::from_millis((recorded_at / 1000) as i64);
+    Some(MuseEntry {
+        timestamp,
+        timestamp_text: format_rfc3339_millis(timestamp),
+        session_id,
+        model,
+        usage,
+        record_id,
+    })
+}
+
+/// Muse reports `input_tokens` gross — the cached prefix is part of it — so it
+/// must be netted before storing or the cached tokens would be counted twice
+/// against the input rate. `output_tokens` is gross too, with
+/// `reasoning_tokens` a subset of it, which is how every other adapter treats
+/// reasoning and costs it at the output rate.
+fn parse_usage(usage: &Value) -> TokenUsageRaw {
+    let cache_read = usage
+        .get("cache_read_tokens")
+        .and_then(|v| v.as_u64())
+        .or_else(|| usage.get("cached_tokens").and_then(|v| v.as_u64()))
+        .unwrap_or(0);
+    let gross_input = usage
+        .get("input_tokens")
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+    TokenUsageRaw {
+        input_tokens: gross_input.saturating_sub(cache_read),
+        output_tokens: usage
+            .get("output_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        cache_read_input_tokens: cache_read,
+        cache_creation_input_tokens: usage
+            .get("cache_write_tokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        speed: None,
+        cache_creation: None,
+    }
+}
+
+pub(super) fn to_loaded_entry(
+    entry: MuseEntry,
+    tz: Option<&JiffTimeZone>,
+    pricing: &PricingMap,
+    workspace_root: Option<&str>,
+) -> LoadedEntry {
+    let project = workspace_root
+        .and_then(|root| Path::new(root).file_name())
+        .map(|name| name.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "muse".to_string());
+    let cost = calculate_muse_cost(&entry, pricing);
+    let missing_pricing_model = missing_muse_pricing(&entry, pricing);
+    let data = UsageEntry {
+        session_id: Some(entry.session_id.clone()),
+        timestamp: entry.timestamp_text.clone(),
+        version: None,
+        message: UsageMessage {
+            usage: entry.usage,
+            model: Some(entry.model.clone()),
+            id: Some(format!("muse:{}", entry.record_id)),
+        },
+        cost_usd: None,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        date: format_date_tz(entry.timestamp, tz),
+        timestamp: entry.timestamp,
+        project: Arc::from(project.as_str()),
+        session_id: Arc::from(entry.session_id.as_str()),
+        project_path: Arc::from(project.as_str()),
+        cost,
+        credits: None,
+        extra_total_tokens: 0,
+        message_count: None,
+        model: Some(entry.model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        data,
+    }
+}
+
+/// Muse logs no cost, so every entry is priced from the pricing map by model.
+fn calculate_muse_cost(entry: &MuseEntry, pricing: &PricingMap) -> f64 {
+    let cost = calculate_cost_for_usage(
+        Some(&entry.model),
+        entry.usage,
+        None,
+        CostMode::Calculate,
+        Some(pricing),
+    );
+    if cost.is_finite() && cost > 0.0 {
+        cost
+    } else {
+        0.0
+    }
+}
+
+fn missing_muse_pricing(entry: &MuseEntry, pricing: &PricingMap) -> Option<String> {
+    missing_pricing_model_for_candidates(
+        &entry.model,
+        std::iter::once(entry.model.clone()),
+        crate::total_usage_tokens(entry.usage),
+        Some(pricing),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ccusage_test_support::fs_fixture;
+    use std::fs;
+
+    fn envelope(
+        payload_type: &str,
+        id: &str,
+        stream_id: &str,
+        recorded_at_us: u64,
+        event: &str,
+    ) -> String {
+        format!(
+            r#"{{"schema_version":1,"id":"{id}","stream":{{"kind":"session","id":"{stream_id}"}},"sequence":1,"recorded_at":{recorded_at_us},"record_type":"event","durability":"durable","causation_id":null,"payload_type":"{payload_type}","payload_schema_version":1,"payload":{event}}}"#
+        )
+    }
+
+    #[test]
+    fn parses_model_completed_records_with_netted_tokens() {
+        let contents = [
+            envelope(
+                "runtime.session.metadata",
+                "meta-1",
+                "sess-a",
+                1_785_962_827_173_826,
+                r#"{"record":{"workspace_root":"/home/user/projects/ccusage"}}"#,
+            ),
+            envelope(
+                "runtime.session",
+                "rec-2",
+                "sess-a",
+                1_785_962_827_173_826,
+                r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"cache_read_tokens":15665,"cache_write_tokens":0,"cached_tokens":15665,"input_tokens":15924,"output_tokens":355,"reasoning_tokens":111}},"kind":"run"}"#,
+            ),
+            envelope(
+                "runtime.session",
+                "rec-3",
+                "sess-a",
+                1_785_962_828_000_000,
+                r#"{"event":{"kind":"started","prompt":"hi"}}"#,
+            ),
+        ]
+        .join("\n");
+
+        let session = parse_session_file(&contents);
+
+        assert_eq!(
+            session.workspace_root.as_deref(),
+            Some("/home/user/projects/ccusage")
+        );
+        assert_eq!(session.entries.len(), 1);
+        let entry = &session.entries[0];
+        assert_eq!(entry.session_id, "sess-a");
+        assert_eq!(entry.model, "muse-spark-1.2");
+        assert_eq!(entry.usage.input_tokens, 259);
+        assert_eq!(entry.usage.cache_read_input_tokens, 15665);
+        assert_eq!(entry.usage.output_tokens, 355);
+        assert_eq!(entry.usage.cache_creation_input_tokens, 0);
+        assert_eq!(entry.timestamp.as_millis(), 1_785_962_827_173);
+    }
+
+    #[test]
+    fn falls_back_to_cached_tokens_and_skips_zero_usage_records() {
+        let contents = [
+            envelope(
+                "runtime.session",
+                "rec-1",
+                "sess-a",
+                1_785_962_827_173_826,
+                r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2-contributor","usage":{"cache_write_tokens":0,"input_tokens":100,"output_tokens":10,"reasoning_tokens":0}}}"#,
+            ),
+            envelope(
+                "runtime.session",
+                "rec-2",
+                "sess-a",
+                1_785_962_827_173_826,
+                r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"input_tokens":0,"output_tokens":0}}}"#,
+            ),
+        ]
+        .join("\n");
+
+        let session = parse_session_file(&contents);
+
+        assert_eq!(session.entries.len(), 1);
+        assert_eq!(session.entries[0].usage.input_tokens, 100);
+        assert_eq!(session.entries[0].usage.cache_read_input_tokens, 0);
+    }
+
+    #[test]
+    fn ignores_tombstone_lines_and_non_json_lines() {
+        let contents = [
+            r#"{"retained_marker":"omitted_live_only","stream":{"kind":"session","id":"sess-a"},"position":1,"omitted_record":{}}"#
+                .to_string(),
+            "not json".to_string(),
+            envelope(
+                "runtime.session",
+                "rec-1",
+                "sess-a",
+                1_785_962_827_173_826,
+                r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"input_tokens":5,"output_tokens":2}}}"#,
+            ),
+        ]
+        .join("\n");
+
+        let session = parse_session_file(&contents);
+
+        assert_eq!(session.entries.len(), 1);
+        assert_eq!(session.entries[0].model, "muse-spark-1.2");
+    }
+
+    #[test]
+    fn maps_workspace_root_to_project_name() {
+        let fixture = fs_fixture!({
+            "muse/sessions/2026/08/01/11111111-1111-1111-1111-111111111111/session.jsonl": [
+                envelope(
+                    "runtime.session.metadata",
+                    "meta-1",
+                    "11111111-1111-1111-1111-111111111111",
+                    1_785_962_827_173_826,
+                    r#"{"record":{"workspace_root":"/home/user/projects/ccusage"}}"#,
+                ),
+                envelope(
+                    "runtime.session",
+                    "rec-2",
+                    "11111111-1111-1111-1111-111111111111",
+                    1_785_962_827_173_826,
+                    r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"input_tokens":100,"output_tokens":10}}}"#,
+                ),
+            ]
+            .join("\n"),
+        });
+
+        let _xdg = ccusage_test_support::EnvVarGuard::set("XDG_DATA_HOME", fixture.root());
+        let files = crate::paths::muse_session_files().unwrap();
+        assert_eq!(files.len(), 1);
+        let contents = fs::read_to_string(&files[0]).unwrap();
+        let session = parse_session_file(&contents);
+        let entry = to_loaded_entry(
+            session.entries.into_iter().next().unwrap(),
+            Some(&jiff::tz::TimeZone::UTC),
+            &PricingMap::default(),
+            session.workspace_root.as_deref(),
+        );
+
+        assert_eq!(entry.project.as_ref(), "ccusage");
+        assert_eq!(entry.project_path.as_ref(), "ccusage");
+        assert_eq!(entry.date, "2026-08-05");
+    }
+}

--- a/rust/adapters/muse/src/paths.rs
+++ b/rust/adapters/muse/src/paths.rs
@@ -1,0 +1,131 @@
+use std::{
+    collections::HashSet,
+    env, fs,
+    path::{Path, PathBuf},
+};
+
+use crate::Result;
+
+const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
+
+/// Discovers Muse Code `session.jsonl` logs under the data directory. Each
+/// session directory `sessions/YYYY/MM/DD/<session-uuid>/` holds one log, and
+/// `subagent/<child-uuid>/` logs hold the child agents' own model calls, which
+/// the parent log does not record — they must be walked too or the session
+/// undercounts.
+///
+/// Muse Code currently ships Linux and macOS builds only, and writes its
+/// XDG-shaped tree under `$XDG_DATA_HOME` (default `~/.local/share`) on both.
+/// The macOS (`~/Library/Application Support`) and Windows (`%APPDATA%`)
+/// locations are scanned too as defensive candidates: they are harmless when
+/// absent and keep discovery working if Muse later ships there.
+pub(super) fn muse_session_files() -> Result<Vec<PathBuf>> {
+    let mut roots = Vec::new();
+    if let Ok(dir) = env::var(XDG_DATA_HOME_ENV) {
+        if dir.is_empty() {
+            return Ok(Vec::new());
+        }
+        roots.push(PathBuf::from(dir));
+    } else {
+        let home =
+            crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
+        roots.push(home.join(".local").join("share"));
+
+        #[cfg(target_os = "macos")]
+        roots.push(home.join("Library").join("Application Support"));
+
+        #[cfg(target_os = "windows")]
+        if let Ok(appdata) = env::var("APPDATA") {
+            if !appdata.is_empty() {
+                roots.push(PathBuf::from(appdata));
+            }
+        }
+    }
+
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+    for root in roots {
+        collect_session_files(&root.join("muse").join("sessions"), &mut files, &mut seen);
+    }
+    files.sort_by(|a, b| a.to_string_lossy().cmp(&b.to_string_lossy()));
+    files.dedup();
+    Ok(files)
+}
+
+fn collect_session_files(dir: &Path, files: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if file_type.is_file()
+            && path.file_name().is_some_and(|name| name == "session.jsonl")
+            && seen.insert(path.clone())
+        {
+            files.push(path);
+        } else if file_type.is_dir() {
+            collect_session_files(&path, files, seen);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, EnvVarsGuard, fs_fixture};
+
+    #[test]
+    fn xdg_override_discovers_session_logs_recursively() {
+        let fixture = fs_fixture!({
+            "muse/sessions/2099/01/02/sess-a/session.jsonl": "",
+            "muse/sessions/2099/01/02/sess-a/subagent/child-1/session.jsonl": "",
+            "muse/sessions/2099/01/02/sess-b/session.jsonl": "",
+            "muse/sessions/2099/01/02/sess-b/notes.txt": "",
+        });
+        let _cleanup = EnvVarGuard::set(XDG_DATA_HOME_ENV, fixture.root());
+
+        let paths = muse_session_files().unwrap();
+
+        let names = paths
+            .iter()
+            .map(|path| path.to_string_lossy().to_string())
+            .collect::<Vec<_>>();
+        // Sorted, deduped, and including the subagent tree.
+        assert_eq!(names.len(), 3);
+        assert!(names[0].ends_with("sess-a/session.jsonl"));
+        assert!(names[1].ends_with("sess-a/subagent/child-1/session.jsonl"));
+        assert!(names[2].ends_with("sess-b/session.jsonl"));
+    }
+
+    #[test]
+    fn empty_xdg_override_returns_no_files() {
+        let fixture = fs_fixture!({});
+        let _cleanup = EnvVarsGuard::set_many([
+            (XDG_DATA_HOME_ENV, Some(OsString::new())),
+            ("HOME", Some(fixture.root().as_os_str().to_owned())),
+        ]);
+
+        assert!(muse_session_files().unwrap().is_empty());
+    }
+
+    #[test]
+    fn default_fallback_roots_resolve_without_error() {
+        let fixture = fs_fixture!({});
+        let _cleanup = EnvVarsGuard::set_many([
+            (XDG_DATA_HOME_ENV, None::<OsString>),
+            ("HOME", Some(fixture.root().as_os_str().to_owned())),
+            ("USERPROFILE", Some(fixture.root().as_os_str().to_owned())),
+            #[cfg(target_os = "windows")]
+            ("APPDATA", Some(fixture.root().as_os_str().to_owned())),
+        ]);
+
+        // The fixture home holds no Muse tree; discovery must still resolve
+        // the per-OS default roots and come back empty rather than error.
+        assert!(muse_session_files().unwrap().is_empty());
+    }
+}

--- a/rust/adapters/muse/src/report.rs
+++ b/rust/adapters/muse/src/report.rs
@@ -1,0 +1,67 @@
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -18,6 +18,7 @@ ccusage-adapter-grok.workspace = true
 ccusage-adapter-hermes.workspace = true
 ccusage-adapter-kilo.workspace = true
 ccusage-adapter-kimi.workspace = true
+ccusage-adapter-muse.workspace = true
 ccusage-adapter-openclaw.workspace = true
 ccusage-adapter-opencode.workspace = true
 ccusage-adapter-pi.workspace = true

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -21,6 +21,7 @@ mod adapter {
     pub use ccusage_adapter_hermes as hermes;
     pub use ccusage_adapter_kilo as kilo;
     pub use ccusage_adapter_kimi as kimi;
+    pub use ccusage_adapter_muse as muse;
     pub use ccusage_adapter_openclaw as openclaw;
     pub use ccusage_adapter_opencode as opencode;
     pub use ccusage_adapter_pi as pi;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -12,7 +12,7 @@ use crate::{
     SessionAccumulator, UsageSummary,
     adapter::{
         amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        muse, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -323,6 +323,21 @@ fn load_base_rows(
                 )?;
                 rows.detected = rows.detected || grok::has_data();
                 Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("Muse Code"),
+            load: Box::new(|| {
+                load_priced_summary_agent_rows(
+                    "muse",
+                    load_kind,
+                    &loader_shared,
+                    pricing,
+                    muse::load_entries,
+                    muse::summarize_entries,
+                )
             }),
         },
     ];

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -495,8 +495,7 @@ fn multi_section_claude_fixture_matches_standalone_sections_for_daily_and_sessio
     });
     let _env = isolated_agent_env(
         &fixture,
-        "CLAUDE_CONFIG_DIR",
-        fixture.root().as_os_str().into(),
+        &[("CLAUDE_CONFIG_DIR", fixture.root().as_os_str().into())],
     );
     let shared = fixture_shared("20990102", "20990102");
 
@@ -517,12 +516,60 @@ fn multi_section_codex_fixture_matches_standalone_sections_for_daily_and_session
     });
     let _env = isolated_agent_env(
         &fixture,
-        "CODEX_HOME",
-        fixture.path("codex").into_os_string(),
+        &[("CODEX_HOME", fixture.path("codex").into_os_string())],
     );
     let shared = fixture_shared("20990201", "20990202");
 
     assert_daily_family_and_session_sections_match_standalone(&shared);
+}
+
+/// One Muse Code event envelope recorded at 2099-01-02T00:00:00Z.
+fn muse_envelope(payload_type: &str, id: &str, stream_id: &str, event: &str) -> String {
+    format!(
+        r#"{{"schema_version":1,"id":"{id}","stream":{{"kind":"session","id":"{stream_id}"}},"sequence":1,"recorded_at":4070995200000000,"record_type":"event","durability":"durable","causation_id":null,"payload_type":"{payload_type}","payload_schema_version":1,"payload":{event}}}"#
+    )
+}
+
+#[test]
+fn detects_muse_source_through_production_wiring() {
+    let fixture = fs_fixture!({
+        "muse/sessions/2099/01/02/sess-a/session.jsonl": [
+            muse_envelope(
+                "runtime.session.metadata",
+                "meta-1",
+                "sess-a",
+                r#"{"record":{"workspace_root":"/home/user/projects/ccusage"}}"#,
+            ),
+            muse_envelope(
+                "runtime.session",
+                "rec-1",
+                "sess-a",
+                r#"{"event":{"kind":"model_completed","model":"muse-spark-1.2","usage":{"cache_read_tokens":0,"input_tokens":100,"output_tokens":10}},"kind":"run"}"#,
+            ),
+        ]
+        .join("\n"),
+    });
+    let _env = isolated_agent_env(
+        &fixture,
+        &[("XDG_DATA_HOME", fixture.root().as_os_str().into())],
+    );
+    let shared = fixture_shared("20990102", "20990102");
+
+    let result = load_rows(AgentReportKind::Daily, &shared).unwrap();
+
+    assert!(
+        result.detected_agents.contains(&"muse"),
+        "detected agents: {:?}",
+        result.detected_agents
+    );
+    assert_eq!(result.rows.len(), 1);
+    let muse = result.rows[0]
+        .agent_breakdowns
+        .as_ref()
+        .and_then(|rows| rows.iter().find(|row| row.agent == "muse"))
+        .expect("muse breakdown present");
+    assert_eq!(muse.input_tokens, 100);
+    assert_eq!(muse.output_tokens, 10);
 }
 
 fn fixture_shared(since: &str, until: &str) -> SharedArgs {
@@ -538,8 +585,7 @@ fn fixture_shared(since: &str, until: &str) -> SharedArgs {
 
 fn isolated_agent_env(
     fixture: &ccusage_test_support::Fixture,
-    source_key: &'static str,
-    source_value: OsString,
+    sources: &[(&'static str, OsString)],
 ) -> EnvVarsGuard {
     let home = fixture.path("empty-home").into_os_string();
     let xdg_config = fixture.path("empty-xdg-config").into_os_string();
@@ -570,7 +616,9 @@ fn isolated_agent_env(
         Some(fixture.path("empty-userprofile").into_os_string()),
     ));
     vars.push(("XDG_CONFIG_HOME", Some(xdg_config)));
-    vars.push((source_key, Some(source_value)));
+    for (source_key, source_value) in sources {
+        vars.push((*source_key, Some(source_value.clone())));
+    }
     EnvVarsGuard::set_many(vars)
 }
 
@@ -579,7 +627,10 @@ fn assert_unified_rows_use_grok_home(kind: AgentReportKind) {
     let fixture = fs_fixture!({
         "grok/sessions/proj/sess-grok/updates.jsonl": line,
     });
-    let _env = isolated_agent_env(&fixture, "GROK_HOME", fixture.path("grok").into_os_string());
+    let _env = isolated_agent_env(
+        &fixture,
+        &[("GROK_HOME", fixture.path("grok").into_os_string())],
+    );
     let shared = fixture_shared("20250615", "20250615");
 
     let result = loader::load_rows(kind, &shared).unwrap();

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -102,6 +102,10 @@
 				"description": "Show OpenClaw usage commands"
 			},
 			{
+				"name": "muse",
+				"description": "Show Muse Code usage commands"
+			},
+			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
 			}
@@ -738,6 +742,43 @@
 			"description": "Show OpenClaw usage grouped by session",
 			"usage": "ccusage openclaw session <OPTIONS>",
 			"options": "openclaw_combined_options"
+		},
+		{
+			"path": ["muse"],
+			"description": "Usage reports for muse.",
+			"usage": "ccusage muse <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Muse Code usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Muse Code usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Muse Code usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["muse", "daily"],
+			"description": "Show Muse Code usage grouped by date",
+			"usage": "ccusage muse daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["muse", "monthly"],
+			"description": "Show Muse Code usage grouped by month",
+			"usage": "ccusage muse monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["muse", "session"],
+			"description": "Show Muse Code usage grouped by session",
+			"usage": "ccusage muse session <OPTIONS>",
+			"options": "agent_options"
 		},
 		{
 			"path": ["grok"],

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -318,6 +318,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Gemini,
         ),
+        "muse" => parse_basic_agent_command(
+            parser,
+            shared,
+            "muse",
+            STANDARD_AGENT_REPORTS,
+            Command::Muse,
+        ),
         "kimi" => parse_basic_agent_command(
             parser,
             shared,
@@ -770,6 +777,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "muse"
             | "grok"
     )
 }
@@ -943,7 +951,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "muse" | "grok" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -965,6 +973,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "copilot" => "GitHub Copilot CLI",
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
+        "muse" => "Muse Code",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
@@ -1048,6 +1057,7 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Muse(args)
             | Command::Grok(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -28,6 +28,7 @@ COMMANDS:
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
+  muse                       Show Muse Code usage commands
   grok                       Show Grok Build CLI usage commands
 
 For more info, run any command with the `--help` flag:
@@ -52,6 +53,7 @@ For more info, run any command with the `--help` flag:
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help
+  ccusage muse --help
   ccusage grok --help
 
 OPTIONS:

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -204,6 +204,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Muse(args)) => agent_command_snapshot("muse", args),
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
     }
 }
@@ -647,7 +648,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok", "muse",
     ];
 
     for agent in agents {

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    Muse(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok", "muse",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -29,6 +29,7 @@ ccusage-adapter-grok.workspace = true
 ccusage-adapter-hermes.workspace = true
 ccusage-adapter-kilo.workspace = true
 ccusage-adapter-kimi.workspace = true
+ccusage-adapter-muse.workspace = true
 ccusage-adapter-openclaw.workspace = true
 ccusage-adapter-opencode.workspace = true
 ccusage-adapter-pi.workspace = true

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -11,6 +11,7 @@ pub(crate) use ccusage_adapter_grok as grok;
 pub(crate) use ccusage_adapter_hermes as hermes;
 pub(crate) use ccusage_adapter_kilo as kilo;
 pub(crate) use ccusage_adapter_kimi as kimi;
+pub(crate) use ccusage_adapter_muse as muse;
 pub(crate) use ccusage_adapter_openclaw as openclaw;
 pub(crate) use ccusage_adapter_opencode as opencode;
 pub(crate) use ccusage_adapter_pi as pi;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,6 +49,7 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Muse(args)
             | Command::Grok(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::Muse(args)) => adapter::muse::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,7 +87,7 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
@@ -98,13 +99,14 @@ mod tests {
             ccusage_adapter_hermes::run,
             ccusage_adapter_kilo::run,
             ccusage_adapter_kimi::run,
+            ccusage_adapter_muse::run,
             ccusage_adapter_openclaw::run,
             ccusage_adapter_opencode::run,
             ccusage_adapter_pi::run,
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a `ccusage-adapter-muse` crate that turns Muse Code (Meta) usage into the shared report format, exposed as `ccusage muse daily|monthly|session` and included in unified reports (`ccusage daily` and friends).

## What it reads

Muse Code writes one append-only, event-sourced `session.jsonl` per session under `sessions/YYYY/MM/DD/<session-uuid>/`. Child agents log under `subagent/<child-uuid>/session.jsonl`; those trees are walked too because the parent log does not record the child agents' model calls.

The parser reads `runtime.session.metadata` records for the project name and `runtime.session` records with `event.kind == "model_completed"` for one usage entry per model call. `recorded_at` is microseconds and is converted to milliseconds. Dedupe identity is `(stream.id, id)`, since sequence numbers restart per turn and record ids repeat across sessions.

## Discovery

| OS      | Roots scanned (when `XDG_DATA_HOME` is unset)                  |
| ------- | -------------------------------------------------------------- |
| Linux   | `~/.local/share/muse/sessions/`                                |
| macOS   | `~/.local/share/muse/sessions/`, `~/Library/Application Support/muse/sessions/` |
| Windows | `~/.local/share/muse/sessions/`, `%APPDATA%\muse\sessions\`    |

- `XDG_DATA_HOME` overrides the root on every OS; an empty value disables Muse discovery.
- Muse Code currently ships Linux and macOS builds only; the macOS `~/Library/Application Support` and Windows `%APPDATA%` candidates are scanned defensively (harmless when absent) so discovery keeps working if Muse later writes there.
- All roots are collected into one list, scanned, then sorted and deduped, so overlapping roots never double-count a log.

## Token handling

`model_completed.usage` reports `input_tokens` gross (it includes `cache_read_tokens`), so the adapter nets cache reads out of input before storing, matching how the other adapters report. `cache_write_tokens` maps to cache creation; `reasoning_tokens` stays a subset of output priced at the output rate. Muse logs no cost, so entries are priced from the shared pricing map by model name.

## Validation

```
cd rust
CCUSAGE_PRICING_JSON_PATH=<litellm snapshot> cargo test -p ccusage-adapter-muse -p ccusage-cli-parser -p ccusage -p ccusage-adapter-all --quiet
CCUSAGE_PRICING_JSON_PATH=<litellm snapshot> cargo check --workspace
```

All green: 173 tests across those crates (including new path-discovery tests for XDG override recursive discovery with subagent dirs, empty override, and default fallback, plus a production-wiring detection test through the unified loader), and a clean workspace check. Formatted with `cargo fmt`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Muse Code usage support via `ccusage-adapter-muse` with cross‑platform discovery, and includes Muse in unified reports. Previously Muse usage was not detected; now `ccusage muse daily|monthly|session` is available and `ccusage daily|weekly|monthly|session` include Muse data.

- Parses Muse event‑sourced `session.jsonl` logs (including `subagent/*/session.jsonl`) and dedupes by `(stream.id, id)`; converts `recorded_at` from microseconds to milliseconds.
- Discovers sessions under `$XDG_DATA_HOME/muse/sessions` (default `~/.local/share`), and defensively scans `~/Library/Application Support` (macOS) and `%APPDATA%` (Windows). An empty `XDG_DATA_HOME` disables Muse discovery. Overlapping roots are sorted and deduped.
- Nets `cache_read_tokens` out of `input_tokens` before storing; treats `reasoning_tokens` as part of output; prices entries from the shared pricing map by model name and surfaces missing‑pricing warnings when applicable.
- Adds CLI namespace and help for Muse: `ccusage muse daily|monthly|session`; wires Muse into unified loader (`ccusage-adapter-all`), parser, and docs; updates `BUILT_IN_AGENT_NAMES` to include `muse`. Extensive tests cover discovery, parsing, dedupe, and unified wiring.

<sup>Written for commit 594473da95a293193405548e0ac273f16e9d0267. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

