### PR TITLE
feat(adapter-cline): add Cline usage adapter with cross-platform discovery

### DIFF
--- a/apps/ccusage/README.md
+++ b/apps/ccusage/README.md
@@ -78,6 +78,7 @@ ccusage reads local usage data from coding agent CLIs and turns it into daily, w
 | Qwen               | `ccusage qwen daily`     |
 | GitHub Copilot CLI | `ccusage copilot daily`  |
 | Gemini CLI         | `ccusage gemini daily`   |
+| Cline              | `ccusage cline daily`    |
 | Grok Build CLI     | `ccusage grok daily`     |
 
 Use `ccusage daily`, `ccusage weekly`, `ccusage monthly`, or `ccusage session` to include every detected source in one report.
@@ -166,7 +167,7 @@ bunx ccusage monthly --compact  # Compact monthly report
 - 📊 **Daily Report**: View token usage and costs aggregated by date
 - 📅 **Monthly Report**: View token usage and costs aggregated by month
 - 💬 **Session Report**: View usage grouped by conversation sessions
-- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI usage from one CLI
+- 🤖 **Unified CLI Reports**: View Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Cline, and Grok Build CLI usage from one CLI
 - ⏰ **5-Hour Blocks Report**: Track usage within Claude's billing windows with active block monitoring
 - 🚀 **Statusline Integration**: Compact usage display for Claude Code status bar hooks (Beta)
 - 🤖 **Model Tracking**: See which models are used across supported sources

--- a/docs/guide/all-reports.md
+++ b/docs/guide/all-reports.md
@@ -34,7 +34,7 @@ ccusage daily --by-agent --json
 
 ## How Unified Views Work
 
-ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
+ccusage detects local usage files from Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Cline, and Grok Build CLI. The same daily, weekly, monthly, and session views can run in two modes:
 
 | Mode    | Command example        | What it shows                           |
 | ------- | ---------------------- | --------------------------------------- |

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -2,7 +2,7 @@
 
 ![ccusage daily report showing token usage and costs by date](/screenshot.png)
 
-**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI.
+**ccusage** is a local CLI for understanding coding (agent) CLI token usage and estimated costs across Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Cline, and Grok Build CLI.
 
 The original **“cc”** came from **C**laude **C**ode usage and now also fits **C**odex **C**LI usage. As OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, Gemini CLI, Grok Build CLI, and other coding (agent) CLIs became part of the same workflow, ccusage expanded into a general name for local coding CLI usage analysis.
 
@@ -19,7 +19,7 @@ Modern coding (agent) CLI usage is split across several local data formats. That
 
 ccusage reads the local usage files that coding CLIs already generate and provides:
 
-- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, and Grok Build CLI in one CLI
+- **All Sources by Default** - Claude Code, Codex, OpenCode, Amp, Droid, Codebuff, Hermes Agent, pi-agent, Goose, OpenClaw, Kilo, Kimi, Qwen, GitHub Copilot CLI, Gemini CLI, Cline, and Grok Build CLI in one CLI
 - **Usage Views** - Daily, weekly, monthly, and session-based breakdowns
 - **Cost Analysis** - Estimated costs based on token usage and model pricing
 - **Focused Data Source Views** - Start with all detected sources, then narrow the same usage views to one source when needed

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -122,6 +122,7 @@ dependencies = [
  "ccusage-adapter-all",
  "ccusage-adapter-amp",
  "ccusage-adapter-claude",
+ "ccusage-adapter-cline",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
  "ccusage-adapter-common",
@@ -154,6 +155,7 @@ version = "0.0.0"
 dependencies = [
  "ccusage-adapter-amp",
  "ccusage-adapter-claude",
+ "ccusage-adapter-cline",
  "ccusage-adapter-codebuff",
  "ccusage-adapter-codex",
  "ccusage-adapter-common",
@@ -200,6 +202,17 @@ dependencies = [
  "memchr",
  "rustc-hash",
  "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "ccusage-adapter-cline"
+version = "0.0.0"
+dependencies = [
+ "ccusage-adapter-common",
+ "ccusage-core",
+ "ccusage-test-support",
+ "jiff",
  "serde_json",
 ]
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,7 @@ ccusage-adapter-all = { path = "crates/ccusage-adapter-all" }
 ccusage-adapter-amp = { path = "adapters/amp" }
 ccusage-adapter-claude = { path = "adapters/claude" }
 ccusage-adapter-codebuff = { path = "adapters/codebuff" }
+ccusage-adapter-cline = { path = "adapters/cline" }
 ccusage-adapter-codex = { path = "adapters/codex" }
 ccusage-adapter-common = { path = "adapters/common" }
 ccusage-adapter-copilot = { path = "adapters/copilot" }

--- a/rust/adapters/cline/Cargo.toml
+++ b/rust/adapters/cline/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "ccusage-adapter-cline"
+version.workspace = true
+edition.workspace = true
+publish.workspace = true
+
+[dependencies]
+ccusage-adapter-common.workspace = true
+ccusage-core.workspace = true
+jiff.workspace = true
+serde_json.workspace = true
+
+[dev-dependencies]
+ccusage-test-support.workspace = true

--- a/rust/adapters/cline/README.md
+++ b/rust/adapters/cline/README.md
@@ -1,0 +1,46 @@
+# ccusage-adapter-cline
+
+The Cline adapter: it turns Cline session transcripts
+into the usage entries the reports render.
+
+## Owns
+
+- `loader.rs` — reading the source, dedupe, and date filtering.
+- `parser.rs` — raw record parsing, token mapping, and model naming.
+- `paths.rs` — environment variables, default directories, and file discovery.
+- `report.rs` — the JSON and table shapes where they differ from the shared ones.
+
+## Data source
+
+Cline writes the same `*.messages.json` per-message transcript format in two
+places, and both are discovered:
+
+- `${CLINE_HOME:-~/.cline}` — the Cline CLI and the JetBrains plugin share
+  `~/.cline` (`%USERPROFILE%\.cline` on Windows), with historical sessions
+  under `data/sessions`. The whole root is scanned.
+- VS Code extension `globalStorage` — `User/globalStorage/saoudrizwan.claude-dev`
+  under every stock VS Code user-data root:
+  - Linux: `~/.config/{Code,Code - Insiders,VSCodium}/User`
+  - macOS: `~/Library/Application Support/{Code,Code - Insiders,VSCodium}/User`
+  - Windows: `%APPDATA%\{Code,Code - Insiders,VSCodium}\User`
+
+`CLINE_HOME` accepts a comma-separated list of directories and takes
+precedence over all default roots; a blank value falls back to the defaults.
+
+Each assistant message carries its own `modelInfo.id` and `metrics`
+(token counts + cost), so sessions that switch models mid-conversation show
+up as separate per-model rows in the report.
+
+## Public surface
+
+- `loader::load_entries`
+- `report::report_from_rows`
+- `report::summarize_entries`
+- `run`
+
+## Depends on
+
+- `ccusage-adapter-common`
+- `ccusage-core`
+- `jiff`
+- `serde_json`

--- a/rust/adapters/cline/src/lib.rs
+++ b/rust/adapters/cline/src/lib.rs
@@ -1,0 +1,45 @@
+use ccusage_adapter_common::{filter_loaded_entries_by_date, read_files_parallel};
+use ccusage_core::*;
+
+mod loader;
+mod parser;
+mod paths;
+mod report;
+
+use crate::{
+    PricingMap, Result, cli::AgentCommandArgs, print_json_or_jq, print_usage_table, sort_summaries,
+    wants_json,
+};
+
+pub use loader::load_entries;
+pub(crate) use report::report_from_rows;
+pub use report::summarize_entries;
+
+pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let shared = args.shared;
+    let pricing = PricingMap::load_with_overrides(
+        shared.offline,
+        crate::log_level() != Some(0),
+        shared.pricing_overrides.iter(),
+    );
+    let mut entries = load_entries(&shared, &pricing)?;
+    filter_loaded_entries_by_date(&mut entries, &shared);
+    let mut rows = summarize_entries(&entries, args.kind)?;
+    sort_summaries(&mut rows, &shared.order, ccusage_core::summary_period);
+    if wants_json(&shared) {
+        return print_json_or_jq(
+            report_from_rows(&rows, args.kind),
+            shared.jq.as_deref(),
+            shared.no_cost,
+        );
+    }
+    print_usage_table(
+        "Cline Token Usage Report",
+        ccusage_core::first_column(args.kind),
+        &rows,
+        &shared,
+        false,
+        None,
+    )?;
+    Ok(())
+}

--- a/rust/adapters/cline/src/loader.rs
+++ b/rust/adapters/cline/src/loader.rs
@@ -1,0 +1,54 @@
+use std::{collections::HashSet, fs, path::Path};
+
+use crate::{LoadedEntry, PricingMap, Result, cli::SharedArgs, read_files_parallel};
+
+use super::{
+    parser::{ClineEntry, parse_messages_file, to_loaded_entry},
+    paths::cline_messages_files,
+};
+
+pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    crate::progress::track_usage_load(
+        crate::progress::UsageLoadAgent("Cline"),
+        shared.json,
+        || load_entries_inner(shared, pricing),
+    )
+}
+
+fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
+    let tz = crate::parse_tz(shared.timezone.as_deref());
+    let files = cline_messages_files()?;
+    let loaded = read_files_parallel(&files, shared.single_thread, |file| {
+        load_messages_file(file, shared)
+    });
+    let mut entries = Vec::new();
+    let mut seen = HashSet::new();
+    for file_entries in loaded {
+        for entry in file_entries {
+            // Dedupe by (session_id, timestamp, model) so a re-read of the
+            // same transcript doesn't double-count messages.
+            let key = (
+                entry.session_id.clone(),
+                entry.timestamp.as_millis(),
+                entry.model.clone(),
+            );
+            if !seen.insert(key) {
+                continue;
+            }
+            entries.push(to_loaded_entry(entry, tz.as_ref(), pricing));
+        }
+    }
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_messages_file(file_path: &Path, shared: &SharedArgs) -> Vec<ClineEntry> {
+    let Ok(contents) = fs::read_to_string(file_path) else {
+        crate::debug_log(
+            shared,
+            format!("Failed to read Cline transcript: {}", file_path.display()),
+        );
+        return Vec::new();
+    };
+    parse_messages_file(&contents, shared)
+}

--- a/rust/adapters/cline/src/parser.rs
+++ b/rust/adapters/cline/src/parser.rs
@@ -1,0 +1,197 @@
+use std::sync::Arc;
+
+use jiff::tz::TimeZone as JiffTimeZone;
+use serde_json::Value;
+
+use crate::{
+    LoadedEntry, PricingMap, TimestampMs, TokenUsageRaw, UsageEntry, UsageMessage,
+    calculate_cost_for_usage, cli::CostMode, format_date_tz, format_rfc3339_millis,
+    missing_pricing_model_for_candidates, parse_ts_timestamp,
+};
+
+pub(super) struct ClineEntry {
+    pub(super) timestamp: TimestampMs,
+    timestamp_text: String,
+    pub(super) session_id: String,
+    pub(super) model: String,
+    usage: TokenUsageRaw,
+    cost_usd: Option<f64>,
+}
+
+/// Parses a `*.messages.json` transcript file into one `ClineEntry` per
+/// assistant message that carries token metrics. Each entry keeps the model
+/// that produced it (from `modelInfo.id`), so a session that switches models
+/// shows up as separate per-model rows in the report.
+pub(super) fn parse_messages_file(contents: &str, shared: &crate::cli::SharedArgs) -> Vec<ClineEntry> {
+    let Ok(value) = serde_json::from_str::<Value>(contents) else {
+        crate::debug_log(shared, "Failed to parse Cline messages.json".to_string());
+        return Vec::new();
+    };
+
+    let session_id = value
+        .get("sessionId")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let Some(messages) = value.get("messages").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+
+    let mut entries = Vec::new();
+    for message in messages {
+        let Some(role) = message.get("role").and_then(|v| v.as_str()) else {
+            continue;
+        };
+        if role != "assistant" {
+            continue;
+        }
+
+        let model = message
+            .get("modelInfo")
+            .and_then(|mi| mi.get("id"))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .trim()
+            .to_string();
+        if model.is_empty() {
+            continue;
+        }
+
+        let metrics = message.get("metrics");
+        let usage = metrics.map(parse_metrics).unwrap_or_default();
+        let cost_usd = metrics
+            .and_then(|m| m.get("cost"))
+            .and_then(|v| v.as_f64())
+            .filter(|cost| *cost > 0.0);
+
+        if usage.input_tokens == 0
+            && usage.output_tokens == 0
+            && usage.cache_read_input_tokens == 0
+            && usage.cache_creation_input_tokens == 0
+            && cost_usd.unwrap_or(0.0) == 0.0
+        {
+            continue;
+        }
+
+        let timestamp = message
+            .get("ts")
+            .and_then(|v| v.as_u64())
+            .filter(|ts| *ts > 0)
+            .map(|ts| TimestampMs::from_millis(ts as i64))
+            .or_else(|| {
+                message
+                    .get("ts")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_ts_timestamp)
+            });
+        let Some(timestamp) = timestamp else { continue };
+
+        entries.push(ClineEntry {
+            timestamp,
+            timestamp_text: format_rfc3339_millis(timestamp),
+            session_id: session_id.clone(),
+            model,
+            usage,
+            cost_usd,
+        });
+    }
+    entries
+}
+
+fn parse_metrics(metrics: &Value) -> TokenUsageRaw {
+    TokenUsageRaw {
+        input_tokens: metrics
+            .get("inputTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        output_tokens: metrics
+            .get("outputTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        cache_read_input_tokens: metrics
+            .get("cacheReadTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        cache_creation_input_tokens: metrics
+            .get("cacheWriteTokens")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0),
+        speed: None,
+        cache_creation: None,
+    }
+}
+
+pub(super) fn to_loaded_entry(
+    entry: ClineEntry,
+    tz: Option<&JiffTimeZone>,
+    pricing: &PricingMap,
+) -> LoadedEntry {
+    let cost = calculate_cline_cost(&entry, pricing);
+    let missing_pricing_model = missing_cline_pricing(&entry, pricing);
+    let data = UsageEntry {
+        session_id: Some(entry.session_id.clone()),
+        timestamp: entry.timestamp_text.clone(),
+        version: None,
+        message: UsageMessage {
+            usage: entry.usage,
+            model: Some(entry.model.clone()),
+            id: Some(format!("cline:{}", entry.session_id)),
+        },
+        cost_usd: entry.cost_usd,
+        request_id: None,
+        is_api_error_message: None,
+        is_sidechain: None,
+    };
+    LoadedEntry {
+        date: format_date_tz(entry.timestamp, tz),
+        timestamp: entry.timestamp,
+        project: Arc::from("cline"),
+        session_id: Arc::from(entry.session_id.as_str()),
+        project_path: Arc::from("Cline"),
+        cost,
+        credits: None,
+        extra_total_tokens: 0,
+        message_count: None,
+        model: Some(entry.model),
+        usage_limit_reset_time: None,
+        missing_pricing_model,
+        data,
+    }
+}
+
+fn calculate_cline_cost(entry: &ClineEntry, pricing: &PricingMap) -> f64 {
+    if let Some(cost) = entry.cost_usd.filter(|cost| *cost > 0.0) {
+        return cost;
+    }
+    for candidate in model_candidates(entry) {
+        let cost = calculate_cost_for_usage(
+            Some(&candidate),
+            entry.usage,
+            None,
+            CostMode::Calculate,
+            Some(pricing),
+        );
+        if cost.is_finite() && cost > 0.0 {
+            return cost;
+        }
+    }
+    0.0
+}
+
+fn missing_cline_pricing(entry: &ClineEntry, pricing: &PricingMap) -> Option<String> {
+    if entry.cost_usd.is_some_and(|cost| cost > 0.0) {
+        return None;
+    }
+    missing_pricing_model_for_candidates(
+        &entry.model,
+        model_candidates(entry),
+        crate::total_usage_tokens(entry.usage),
+        Some(pricing),
+    )
+}
+
+fn model_candidates(entry: &ClineEntry) -> Vec<String> {
+    vec![entry.model.clone()]
+}
+

--- a/rust/adapters/cline/src/paths.rs
+++ b/rust/adapters/cline/src/paths.rs
@@ -1,0 +1,231 @@
+use std::{collections::HashSet, env, fs, path::{Path, PathBuf}};
+
+use crate::Result;
+
+const CLINE_HOME_ENV: &str = "CLINE_HOME";
+const CLINE_EXTENSION_ID: &str = "saoudrizwan.claude-dev";
+
+/// Discovers Cline `*.messages.json` transcripts.
+///
+/// Cline writes the same `*.messages.json` transcript format in two places:
+///
+/// - the Cline CLI (and the JetBrains plugin, which shares its data dir)
+///   stores them under `~/.cline` (`%USERPROFILE%\.cline` on Windows), with
+///   historical sessions under `data/sessions`;
+/// - the VS Code extension stores them in its `globalStorage` directory,
+///   whose parent `User` folder lives under a per-OS VS Code data root.
+///
+/// Scanning both surfaces usage regardless of which front end produced the
+/// session, and each assistant message carries its own model + metrics, which
+/// is what lets ccusage show a per-model breakdown when a session switches
+/// models mid-conversation.
+pub(super) fn cline_messages_files() -> Result<Vec<PathBuf>> {
+    let roots = discovery_roots()?;
+    let mut seen = HashSet::new();
+    let mut files = Vec::new();
+    for root in &roots {
+        collect_messages_files(root, &mut files, &mut seen);
+    }
+    files.sort();
+    files.dedup();
+    Ok(files)
+}
+
+/// Roots to search for Cline transcripts, honoring `CLINE_HOME`.
+///
+/// The override accepts comma-separated directories, like every other
+/// source-specific path variable, so a current profile and an archive can be
+/// reported together. A blank value falls back to the default roots.
+fn discovery_roots() -> Result<Vec<PathBuf>> {
+    if let Ok(env_roots) = env::var(CLINE_HOME_ENV) {
+        let roots = env_roots
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+            .map(PathBuf::from)
+            .collect::<Vec<_>>();
+        if !roots.is_empty() {
+            return Ok(roots);
+        }
+    }
+    let home =
+        ccusage_core::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
+
+    // The CLI and JetBrains plugin share `~/.cline`. `data/sessions` holds the
+    // historical layout, but newer builds also write transcripts elsewhere
+    // under the root, so discovery scans both from the root itself.
+    let mut roots = vec![home.join(".cline")];
+
+    // VS Code's globalStorage parent differs per OS because VS Code itself
+    // keeps its user data in a platform-specific location.
+    let mut code_roots = vs_code_user_roots(&home);
+    roots.append(&mut code_roots);
+
+    for root in &mut roots {
+        if let Ok(canonical) = root.canonicalize() {
+            *root = canonical;
+        }
+    }
+    roots.sort();
+    roots.dedup();
+    Ok(roots)
+}
+
+/// `User` directories of every stock VS Code distribution worth scanning.
+///
+/// Insiders and VSCodium builds keep separate user-data directories, so each
+/// one may hold its own Cline `globalStorage`.
+fn vs_code_user_roots(home: &Path) -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    let mut push_code_root = |user_dir: PathBuf| {
+        roots.push(user_dir.join("globalStorage").join(CLINE_EXTENSION_ID));
+    };
+
+    #[cfg(target_os = "linux")]
+    {
+        let config = home.join(".config");
+        for name in ["Code", "Code - Insiders", "VSCodium"] {
+            push_code_root(config.join(name).join("User"));
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let app_support = home.join("Library").join("Application Support");
+        for name in ["Code", "Code - Insiders", "VSCodium"] {
+            push_code_root(app_support.join(name).join("User"));
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        if let Ok(appdata) = env::var("APPDATA") {
+            let appdata = PathBuf::from(appdata);
+            for name in ["Code", "Code - Insiders", "VSCodium"] {
+                push_code_root(appdata.join(name).join("User"));
+            }
+        }
+    }
+
+    roots.retain(|root| root.is_dir());
+    roots
+}
+
+fn collect_messages_files(dir: &Path, files: &mut Vec<PathBuf>, seen: &mut HashSet<PathBuf>) {
+    let Ok(entries) = fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        let path = entry.path();
+        if file_type.is_file()
+            && path
+                .file_name()
+                .is_some_and(|name| name.to_string_lossy().ends_with(".messages.json"))
+            && seen.insert(path.clone())
+        {
+            files.push(path);
+        } else if file_type.is_dir() {
+            collect_messages_files(&path, files, seen);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use super::*;
+    use ccusage_test_support::{EnvVarGuard, EnvVarsGuard, fs_fixture};
+
+    fn file_names(paths: &[PathBuf]) -> Vec<String> {
+        paths
+            .iter()
+            .map(|path| path.file_name().unwrap().to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn discovers_transcripts_recursively_under_cline_home() {
+        let fixture = fs_fixture!({
+            "data/sessions/sess-a/sess-a.messages.json": "",
+            "tasks/sess-b/sess-b.messages.json": "",
+            "data/sessions/sess-a/notes.json": "",
+            "data/sessions/sess-a/sess-a.ui_messages.json": "",
+        });
+        let _cleanup = EnvVarGuard::set(CLINE_HOME_ENV, fixture.root());
+
+        let names = file_names(&cline_messages_files().unwrap());
+        assert_eq!(names, vec!["sess-a.messages.json", "sess-b.messages.json"]);
+    }
+
+    #[test]
+    fn ignores_a_blank_cline_home_override() {
+        let fixture = fs_fixture!({});
+        // Pin `HOME` alongside the override so the fallback roots live under
+        // the fixture rather than whatever home directory the test process
+        // inherits. The fixture holds no Cline data.
+        let _cleanup = EnvVarsGuard::set_many([
+            (CLINE_HOME_ENV, Some(OsString::from("   "))),
+            ("HOME", Some(fixture.root().as_os_str().to_owned())),
+        ]);
+
+        assert!(cline_messages_files().unwrap().is_empty());
+    }
+
+    #[test]
+    fn reads_comma_separated_cline_homes() {
+        let current = fs_fixture!({ "data/sessions/sess-a/sess-a.messages.json": "" });
+        let archive = fs_fixture!({ "sessions/sess-b/sess-b.messages.json": "" });
+        let _cleanup = EnvVarGuard::set(
+            CLINE_HOME_ENV,
+            format!("{}, {}", current.root().display(), archive.root().display()),
+        );
+
+        // Snapshot tempdirs may be created out of order, so assert as a set;
+        // path-level ordering is covered by the sorting in cline_messages_files.
+        let mut names = file_names(&cline_messages_files().unwrap());
+        names.sort();
+        assert_eq!(names, vec!["sess-a.messages.json", "sess-b.messages.json"]);
+    }
+
+    #[test]
+    fn dedupes_overlapping_cline_homes() {
+        let root = fs_fixture!({ "data/sessions/sess-a/sess-a.messages.json": "" });
+        let _cleanup = EnvVarGuard::set(
+            CLINE_HOME_ENV,
+            format!("{},{}", root.root().display(), root.root().display()),
+        );
+
+        let names = file_names(&cline_messages_files().unwrap());
+        assert_eq!(names, vec!["sess-a.messages.json"]);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn discovers_vs_code_extension_transcripts() {
+        let fixture = fs_fixture!({});
+        // Point the default `~/.config` at the fixture through `HOME` while
+        // clearing the override, exercising the default discovery path.
+        let _cleanup = EnvVarsGuard::set_many([
+            (CLINE_HOME_ENV, None),
+            ("HOME", Some(fixture.root().as_os_str().to_owned())),
+        ]);
+        let global_storage = fixture
+            .root()
+            .join(".config")
+            .join("Code")
+            .join("User")
+            .join("globalStorage")
+            .join(CLINE_EXTENSION_ID)
+            .join("tasks")
+            .join("sess-v");
+        std::fs::create_dir_all(&global_storage).unwrap();
+        std::fs::write(global_storage.join("sess-v.messages.json"), "").unwrap();
+
+        let names = file_names(&cline_messages_files().unwrap());
+        assert_eq!(names, vec!["sess-v.messages.json"]);
+    }
+}

--- a/rust/adapters/cline/src/report.rs
+++ b/rust/adapters/cline/src/report.rs
@@ -1,0 +1,67 @@
+use serde_json::{Value, json};
+
+use crate::{
+    BucketKind, LoadedEntry, Result, UsageSummary,
+    cli::{AgentReportKind, WeekDay},
+    summarize_by_key, summarize_summaries_by_bucket, totals_json,
+};
+
+pub fn report_from_rows(rows: &[UsageSummary], kind: AgentReportKind) -> Value {
+    let rows_json = rows
+        .iter()
+        .map(|row| ccusage_core::agent_summary_json(row, kind, false))
+        .collect::<Vec<_>>();
+    json!({
+        rows_key(kind): rows_json,
+        "totals": totals_json(rows),
+    })
+}
+
+pub fn summarize_entries(
+    entries: &[LoadedEntry],
+    kind: AgentReportKind,
+) -> Result<Vec<UsageSummary>> {
+    match kind {
+        AgentReportKind::Daily => summarize_by_key(
+            entries,
+            |entry| entry.date.clone(),
+            |date| (date.to_string(), None),
+        ),
+        AgentReportKind::Monthly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Monthly,
+                WeekDay::Sunday,
+            ))
+        }
+        AgentReportKind::Session => summarize_by_key(
+            entries,
+            |entry| entry.session_id.to_string(),
+            |session_id| (session_id.to_string(), None),
+        )
+        .map(|mut rows| {
+            for row in &mut rows {
+                row.session_id = row.date.take();
+            }
+            rows
+        }),
+        AgentReportKind::Weekly => {
+            let daily = summarize_entries(entries, AgentReportKind::Daily)?;
+            Ok(summarize_summaries_by_bucket(
+                &daily,
+                BucketKind::Weekly,
+                WeekDay::Sunday,
+            ))
+        }
+    }
+}
+
+fn rows_key(kind: AgentReportKind) -> &'static str {
+    match kind {
+        AgentReportKind::Daily => "daily",
+        AgentReportKind::Weekly => "weekly",
+        AgentReportKind::Monthly => "monthly",
+        AgentReportKind::Session => "sessions",
+    }
+}

--- a/rust/crates/ccusage-adapter-all/Cargo.toml
+++ b/rust/crates/ccusage-adapter-all/Cargo.toml
@@ -7,6 +7,7 @@ publish.workspace = true
 [dependencies]
 ccusage-adapter-amp.workspace = true
 ccusage-adapter-claude.workspace = true
+ccusage-adapter-cline.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true
 ccusage-adapter-common.workspace = true

--- a/rust/crates/ccusage-adapter-all/src/lib.rs
+++ b/rust/crates/ccusage-adapter-all/src/lib.rs
@@ -11,6 +11,7 @@ use ccusage_core::*;
 mod adapter {
     pub use ccusage_adapter_amp as amp;
     pub use ccusage_adapter_claude as claude;
+    pub use ccusage_adapter_cline as cline;
     pub use ccusage_adapter_codebuff as codebuff;
     pub use ccusage_adapter_codex as codex;
     pub use ccusage_adapter_copilot as copilot;

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -11,8 +11,8 @@ use crate::{
     BUILT_IN_AGENT_NAMES, CodexGroup, LoadedEntry, ModelBreakdown, PricingMap, Result,
     SessionAccumulator, UsageSummary,
     adapter::{
-        amp, claude, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo, kimi,
-        openclaw, opencode, pi, qwen,
+        amp, claude, cline, codebuff, codex, copilot, droid, gemini, goose, grok, hermes, kilo,
+        kimi, openclaw, opencode, pi, qwen,
     },
     cli::{AgentReportKind, CodexSpeed, NamedPiStore, SharedArgs, WeekDay},
     filter_loaded_entries_by_date, json_float,
@@ -323,6 +323,21 @@ fn load_base_rows(
                 )?;
                 rows.detected = rows.detected || grok::has_data();
                 Ok(rows)
+            }),
+        },
+        AgentLoadSpec {
+            index: 16,
+            agent: BUILT_IN_AGENT_NAMES[16],
+            progress_agent: crate::progress::UsageLoadAgent("Cline"),
+            load: Box::new(|| {
+                load_priced_summary_agent_rows(
+                    "cline",
+                    load_kind,
+                    &loader_shared,
+                    pricing,
+                    cline::load_entries,
+                    cline::summarize_entries,
+                )
             }),
         },
     ];

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -495,8 +495,7 @@ fn multi_section_claude_fixture_matches_standalone_sections_for_daily_and_sessio
     });
     let _env = isolated_agent_env(
         &fixture,
-        "CLAUDE_CONFIG_DIR",
-        fixture.root().as_os_str().into(),
+        &[("CLAUDE_CONFIG_DIR", fixture.root().as_os_str().into())],
     );
     let shared = fixture_shared("20990102", "20990102");
 
@@ -517,8 +516,7 @@ fn multi_section_codex_fixture_matches_standalone_sections_for_daily_and_session
     });
     let _env = isolated_agent_env(
         &fixture,
-        "CODEX_HOME",
-        fixture.path("codex").into_os_string(),
+        &[("CODEX_HOME", fixture.path("codex").into_os_string())],
     );
     let shared = fixture_shared("20990201", "20990202");
 
@@ -538,8 +536,7 @@ fn fixture_shared(since: &str, until: &str) -> SharedArgs {
 
 fn isolated_agent_env(
     fixture: &ccusage_test_support::Fixture,
-    source_key: &'static str,
-    source_value: OsString,
+    sources: &[(&'static str, OsString)],
 ) -> EnvVarsGuard {
     let home = fixture.path("empty-home").into_os_string();
     let xdg_config = fixture.path("empty-xdg-config").into_os_string();
@@ -560,6 +557,7 @@ fn isolated_agent_env(
         "KIMI_DATA_DIR",
         "QWEN_DATA_DIR",
         "GROK_HOME",
+        "CLINE_HOME",
     ]
     .into_iter()
     .map(|key| (key, None::<OsString>))
@@ -570,7 +568,9 @@ fn isolated_agent_env(
         Some(fixture.path("empty-userprofile").into_os_string()),
     ));
     vars.push(("XDG_CONFIG_HOME", Some(xdg_config)));
-    vars.push((source_key, Some(source_value)));
+    for (source_key, source_value) in sources {
+        vars.push((*source_key, Some(source_value.clone())));
+    }
     EnvVarsGuard::set_many(vars)
 }
 
@@ -579,7 +579,10 @@ fn assert_unified_rows_use_grok_home(kind: AgentReportKind) {
     let fixture = fs_fixture!({
         "grok/sessions/proj/sess-grok/updates.jsonl": line,
     });
-    let _env = isolated_agent_env(&fixture, "GROK_HOME", fixture.path("grok").into_os_string());
+    let _env = isolated_agent_env(
+        &fixture,
+        &[("GROK_HOME", fixture.path("grok").into_os_string())],
+    );
     let shared = fixture_shared("20250615", "20250615");
 
     let result = loader::load_rows(kind, &shared).unwrap();
@@ -593,6 +596,36 @@ fn assert_unified_rows_use_grok_home(kind: AgentReportKind) {
     assert_eq!(result.rows[0].input_tokens, 60);
     assert_eq!(result.rows[0].cache_read_tokens, 40);
     assert_eq!(result.rows[0].output_tokens, 20);
+}
+
+#[test]
+fn detects_cline_source_through_production_wiring() {
+    let fixture = fs_fixture!({
+        "cline/data/sessions/sess-c/sess-c.messages.json":
+            r#"{"sessionId":"sess-c","messages":[{"ts":1750000000000,"role":"assistant","modelInfo":{"id":"claude-sonnet-4-20250514"},"metrics":{"inputTokens":100,"cacheReadTokens":25,"cacheWriteTokens":0,"outputTokens":10,"cost":0.01}}]}"#,
+    });
+    let _env = isolated_agent_env(
+        &fixture,
+        &[("CLINE_HOME", fixture.path("cline").into_os_string())],
+    );
+    let shared = fixture_shared("20250615", "20250615");
+
+    let result = loader::load_rows(AgentReportKind::Daily, &shared).unwrap();
+
+    assert!(
+        result.detected_agents.contains(&"cline"),
+        "detected agents: {:?}",
+        result.detected_agents
+    );
+    assert_eq!(result.rows.len(), 1);
+    let cline = result.rows[0]
+        .agent_breakdowns
+        .as_ref()
+        .and_then(|rows| rows.iter().find(|row| row.agent == "cline"))
+        .expect("cline breakdown present");
+    assert_eq!(cline.input_tokens, 100);
+    assert_eq!(cline.cache_read_tokens, 25);
+    assert_eq!(cline.output_tokens, 10);
 }
 
 #[test]

--- a/rust/crates/ccusage-cli-parser/src/cli-commands.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-commands.json
@@ -102,6 +102,10 @@
 				"description": "Show OpenClaw usage commands"
 			},
 			{
+				"name": "cline",
+				"description": "Show Cline usage commands"
+			},
+			{
 				"name": "grok",
 				"description": "Show Grok Build CLI usage commands"
 			}
@@ -738,6 +742,43 @@
 			"description": "Show OpenClaw usage grouped by session",
 			"usage": "ccusage openclaw session <OPTIONS>",
 			"options": "openclaw_combined_options"
+		},
+		{
+			"path": ["cline"],
+			"description": "Usage reports for cline.",
+			"usage": "ccusage cline <COMMANDS>",
+			"commands": [
+				{
+					"name": "daily",
+					"description": "Show Cline usage grouped by date"
+				},
+				{
+					"name": "monthly",
+					"description": "Show Cline usage grouped by month"
+				},
+				{
+					"name": "session",
+					"description": "Show Cline usage grouped by session"
+				}
+			]
+		},
+		{
+			"path": ["cline", "daily"],
+			"description": "Show Cline usage grouped by date",
+			"usage": "ccusage cline daily <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["cline", "monthly"],
+			"description": "Show Cline usage grouped by month",
+			"usage": "ccusage cline monthly <OPTIONS>",
+			"options": "agent_period_options"
+		},
+		{
+			"path": ["cline", "session"],
+			"description": "Show Cline usage grouped by session",
+			"usage": "ccusage cline session <OPTIONS>",
+			"options": "agent_options"
 		},
 		{
 			"path": ["grok"],

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -318,6 +318,13 @@ fn parse_command(
             STANDARD_AGENT_REPORTS,
             Command::Gemini,
         ),
+        "cline" => parse_basic_agent_command(
+            parser,
+            shared,
+            "cline",
+            STANDARD_AGENT_REPORTS,
+            Command::Cline,
+        ),
         "kimi" => parse_basic_agent_command(
             parser,
             shared,
@@ -770,6 +777,7 @@ fn is_command(arg: &str) -> bool {
             | "gemini"
             | "kimi"
             | "qwen"
+            | "cline"
             | "grok"
     )
 }
@@ -943,7 +951,7 @@ fn agent_report_supported(agent: &str, report: &str) -> bool {
         "codex" => matches!(report, "daily" | "monthly" | "session"),
         "opencode" => matches!(report, "daily" | "weekly" | "monthly" | "session"),
         "amp" | "droid" | "codebuff" | "hermes" | "pi" | "goose" | "kilo" | "copilot"
-        | "gemini" | "kimi" | "qwen" | "openclaw" | "grok" => {
+        | "gemini" | "kimi" | "qwen" | "openclaw" | "cline" | "grok" => {
             matches!(report, "daily" | "monthly" | "session")
         }
         _ => false,
@@ -965,6 +973,7 @@ fn agent_display_name(agent: &str) -> &'static str {
         "copilot" => "GitHub Copilot CLI",
         "gemini" => "Gemini CLI",
         "kimi" => "Kimi",
+        "cline" => "Cline",
         "qwen" => "Qwen",
         "openclaw" => "OpenClaw",
         "grok" => "Grok",
@@ -1048,6 +1057,7 @@ fn last_option_error(command: Option<&Command>, root_shared: &SharedArgs) -> Opt
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Cline(args)
             | Command::Grok(args),
         ) => (&args.shared, args.kind != AgentReportKind::Session),
     };

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__root_help.snap
@@ -28,6 +28,7 @@ COMMANDS:
   kimi                       Show Kimi usage commands
   qwen                       Show Qwen usage commands
   openclaw                   Show OpenClaw usage commands
+  cline                      Show Cline usage commands
   grok                       Show Grok Build CLI usage commands
 
 For more info, run any command with the `--help` flag:
@@ -52,6 +53,7 @@ For more info, run any command with the `--help` flag:
   ccusage kimi --help
   ccusage qwen --help
   ccusage openclaw --help
+  ccusage cline --help
   ccusage grok --help
 
 OPTIONS:

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -204,6 +204,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
         Some(Command::Kimi(args)) => agent_command_snapshot("kimi", args),
         Some(Command::Qwen(args)) => agent_command_snapshot("qwen", args),
         Some(Command::OpenClaw(args)) => agent_command_snapshot("openclaw", args),
+        Some(Command::Cline(args)) => agent_command_snapshot("cline", args),
         Some(Command::Grok(args)) => agent_command_snapshot("grok", args),
     }
 }
@@ -647,7 +648,7 @@ fn root_help_lists_agent_namespaces_without_nested_commands() {
     let help = help_text();
     let agents = [
         "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "kilo",
-        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok",
+        "copilot", "gemini", "kimi", "qwen", "openclaw", "grok", "cline",
     ];
 
     for agent in agents {

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -26,6 +26,7 @@ pub enum Command {
     Qwen(AgentCommandArgs),
     OpenClaw(AgentCommandArgs),
     Grok(AgentCommandArgs),
+    Cline(AgentCommandArgs),
 }
 
 #[derive(Clone, Debug, Default)]

--- a/rust/crates/ccusage-core/src/lib.rs
+++ b/rust/crates/ccusage-core/src/lib.rs
@@ -56,7 +56,7 @@ pub const USAGE_COMPACT_WIDTH_THRESHOLD: usize = 100;
 
 pub const BUILT_IN_AGENT_NAMES: &[&str] = &[
     "claude", "codex", "opencode", "amp", "droid", "codebuff", "hermes", "pi", "goose", "openclaw",
-    "kilo", "copilot", "gemini", "kimi", "qwen", "grok",
+    "kilo", "copilot", "gemini", "kimi", "qwen", "grok", "cline",
 ];
 
 pub type Result<T> = std::result::Result<T, CliError>;

--- a/rust/crates/ccusage/Cargo.toml
+++ b/rust/crates/ccusage/Cargo.toml
@@ -18,6 +18,7 @@ fetch-litellm-pricing = ["ccusage-core/fetch-litellm-pricing"]
 ccusage-adapter-all.workspace = true
 ccusage-adapter-amp.workspace = true
 ccusage-adapter-claude.workspace = true
+ccusage-adapter-cline.workspace = true
 ccusage-adapter-codebuff.workspace = true
 ccusage-adapter-codex.workspace = true
 ccusage-adapter-common.workspace = true

--- a/rust/crates/ccusage/src/adapter/mod.rs
+++ b/rust/crates/ccusage/src/adapter/mod.rs
@@ -1,6 +1,7 @@
 pub(crate) use ccusage_adapter_all as all;
 pub(crate) use ccusage_adapter_amp as amp;
 pub(crate) use ccusage_adapter_claude as claude;
+pub(crate) use ccusage_adapter_cline as cline;
 pub(crate) use ccusage_adapter_codebuff as codebuff;
 pub(crate) use ccusage_adapter_codex as codex;
 pub(crate) use ccusage_adapter_copilot as copilot;

--- a/rust/crates/ccusage/src/cli/last_window.rs
+++ b/rust/crates/ccusage/src/cli/last_window.rs
@@ -49,6 +49,7 @@ fn window_target(cli: &mut Cli) -> Option<(&mut SharedArgs, PeriodUnit, WeekDay)
             | Command::Kimi(args)
             | Command::Qwen(args)
             | Command::OpenClaw(args)
+            | Command::Cline(args)
             | Command::Grok(args),
         ) => agent_window_target(args),
         Some(Command::Session(_) | Command::Blocks(_) | Command::Statusline(_)) => None,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -48,6 +48,7 @@ fn main() -> Result<()> {
         Some(Command::Kimi(args)) => adapter::kimi::run(args),
         Some(Command::OpenClaw(args)) => adapter::openclaw::run(args),
         Some(Command::Grok(args)) => adapter::grok::run(args),
+        Some(Command::Cline(args)) => adapter::cline::run(args),
         None => {
             let args = AgentCommandArgs {
                 shared: cli.shared,
@@ -86,8 +87,9 @@ mod tests {
 
     #[test]
     fn agent_commands_are_exposed_by_independent_crates() {
-        let runs: [fn(AgentCommandArgs) -> Result<()>; 15] = [
+        let runs: [fn(AgentCommandArgs) -> Result<()>; 16] = [
             ccusage_adapter_amp::run,
+            ccusage_adapter_cline::run,
             ccusage_adapter_codebuff::run,
             ccusage_adapter_codex::run,
             ccusage_adapter_copilot::run,
@@ -104,7 +106,7 @@ mod tests {
             ccusage_adapter_qwen::run,
         ];
 
-        assert_eq!(runs.len(), 15);
+        assert_eq!(runs.len(), 16);
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds a `ccusage cline` usage adapter that reads Cline `*.messages.json` transcripts, with cross-platform data discovery on Linux, macOS, and Windows.

## Data discovery

Cline writes the same per-message transcript format in two places, and both are scanned:

1. **Cline CLI / JetBrains plugin** — `~/.cline` (`%USERPROFILE%\.cline` on Windows), including historical sessions under `data/sessions` and any newer layout elsewhere under the root.
2. **VS Code extension globalStorage** — `User/globalStorage/saoudrizwan.claude-dev` under each stock VS Code user-data root:

| OS      | VS Code roots scanned |
| ------- | --------------------- |
| Linux   | `~/.config/Code`, `~/.config/Code - Insiders`, `~/.config/VSCodium` |
| macOS   | `~/Library/Application Support/{Code, Code - Insiders, VSCodium}` |
| Windows | `%APPDATA%\{Code, Code - Insiders, VSCodium}` |

`CLINE_HOME` overrides discovery with a comma-separated list of directories and takes precedence over all default roots; a blank value falls back to the defaults. Results are canonicalized, sorted, and deduplicated deterministically.

## Cost handling

Each assistant message carries its own `modelInfo.id` and `metrics`. Cost uses the transcript's `metrics.cost` when present and non-zero; otherwise it is computed from token usage via the embedded LiteLLM pricing tables.

## Validation

```
cd rust
CCUSAGE_PRICING_JSON_PATH=<pricing snapshot> cargo test -p ccusage-adapter-cline -p ccusage-cli-parser -p ccusage -p ccusage-adapter-all --quiet
CCUSAGE_PRICING_JSON_PATH=<pricing snapshot> cargo check --workspace
```

All green on Linux; no warnings. OS-specific discovery branches are gated with `#[cfg(target_os)]` following the existing adapter pattern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `ccusage cline` with cross‑platform discovery of Cline `*.messages.json` transcripts. Previously Cline usage was not detected; now it appears in unified and per‑agent reports with correct token and cost accounting.

- Discovers transcripts under `~/.cline` (or `%USERPROFILE%\.cline`) and VS Code `User/globalStorage/saoudrizwan.claude-dev` roots on Linux, macOS, and Windows; `CLINE_HOME` accepts a comma‑separated override list and takes precedence.
- Dedupes messages across overlapping locations by `(session_id, timestamp, model)` and sorts results deterministically.
- Uses `metrics.cost` when present; otherwise computes from token usage via the existing `PricingMap` (LiteLLM pricing) so mixed‑model sessions are costed correctly per message.
- Wires the new adapter into `ccusage` and `ccusage-adapter-all`; adds CLI namespace and help, updates docs, and extends tests to cover env overrides and default discovery.

**Usage and rollout**
- New commands: `ccusage cline daily|monthly|session`. Unified `ccusage daily|monthly|session` now includes Cline automatically.
- Optional: set `CLINE_HOME=/path1,/path2` to point at nonstandard or archive directories; unset or blank falls back to defaults.
- No breaking changes or migrations required.

<sup>Written for commit 01ce54de472d35ae4c24892988006b341bc3301d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cline as a supported coding-agent data source.
  * Added `ccusage cline` commands for daily, monthly, and session usage reports.
  * Cline transcripts are automatically discovered, parsed, deduplicated, and summarized.
  * Added support for filtering reports with `--last` and including Cline in unified reports.

* **Documentation**
  * Updated guides and adapter documentation to describe Cline support and transcript discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->