### PR TITLE
fix(renovate): keep automated updates buildable

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,26 @@
 	},
 	"minimumReleaseAge": "3 days",
 	"mode": "full",
+	"packageRules": [
+		{
+			"description": "Keep schemars on the 0.x API until its schema generator is migrated deliberately.",
+			"matchPackageNames": ["schemars"],
+			"allowedVersions": "<0.9.0"
+		},
+		{
+			"description": "The Rust compiler must stay paired with the pinned cargo-hawk binary and rust-overlay.",
+			"matchManagers": ["rust-toolchain"],
+			"matchDepTypes": ["toolchain"],
+			"enabled": false
+		}
+	],
+	"postUpgradeTasks": {
+		"commands": ["nix run .#generate-bun-nix"],
+		"executionMode": "branch",
+		"installTools": {
+			"nix": {}
+		}
+	},
 	"postUpdateOptions": ["pnpmDedupe"],
 	"rangeStrategy": "bump",
 	"vulnerabilityAlerts": {

--- a/nix/treefmt.nix
+++ b/nix/treefmt.nix
@@ -62,6 +62,20 @@ in
           fi
         '';
       };
+      generateBunNix = pkgs.writeShellApplication {
+        name = "generate-bun-nix";
+        runtimeInputs = [
+          inputs.bun2nix.packages.${system}.default
+          pkgs.coreutils
+        ];
+        text = ''
+          for lockfile in nix/tools/*/bun.lock; do
+            toolDir="$(dirname "$lockfile")"
+            echo "Regenerating $toolDir"
+            (cd "$toolDir" && bun2nix -o bun.nix)
+          done
+        '';
+      };
     in
     {
       treefmt = {
@@ -211,6 +225,14 @@ in
       apps.generate-schema = {
         type = "app";
         program = lib.getExe schemaGen;
+      };
+      # `nix run .#generate-bun-nix` derives every committed bun.nix from its
+      # sibling bun.lock. Renovate uses this before committing dependency
+      # updates, while contributors can use `just gen-bun-nix` when a manifest
+      # also needs Bun to resolve a new lockfile.
+      apps.generate-bun-nix = {
+        type = "app";
+        program = lib.getExe generateBunNix;
       };
     };
 }


### PR DESCRIPTION
## Summary

Renovate PRs were failing for three deterministic reasons: schemars updates crossed the API boundary used by the repository, Rust toolchain updates got ahead of the pinned rust-overlay and cargo-hawk pair, and Bun lockfile updates left committed bun.nix files stale.

## What changed

- Keep schemars below 0.9 until the schema generator is migrated deliberately.
- Disable automatic Rust toolchain updates until the compiler, rust-overlay, and cargo-hawk move together.
- Add `nix run .#generate-bun-nix` and run it from Renovate post-upgrade tasks so generated Bun Nix metadata stays synchronized.

## Testing

- Commit and pre-push hooks: Renovate config validation, treefmt, gitleaks, and commit scope.
- `nix run .#generate-bun-nix` (no generated diffs).
- `nix build .#checks.aarch64-darwin.bun-nix --no-link --print-build-logs`.
- `nix build .#checks.aarch64-darwin.treefmt --no-link --print-build-logs`.
- `jq empty .github/renovate.json` and `git diff --check`.
- Full `nix flake check --no-build` remains blocked while evaluating `checks.aarch64-darwin.ccusage-clippy` by `path 'a5ppnahl6ph9ykas2qh839v9c73xzmsq-source' is not valid`.

## Operational note

Renovate `postUpgradeTasks` requires the instance-level `allowedCommands` policy to permit `nix run .#generate-bun-nix`; the repository configuration alone cannot enable that host-level setting.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps Renovate update branches buildable by constraining update paths that cross pinned toolchain boundaries and resynchronizing generated Bun Nix files before each commit.

- Pin `schemars` below 0.9.0 until its schema generator is migrated deliberately.
- Disable automatic `rust-toolchain` updates; the compiler must stay paired with the pinned `rust-overlay` and `cargo-hawk`.
- Add a `generate-bun-nix` Nix app that rebuilds every committed `bun.nix` from its sibling `bun.lock`.
- Run `nix run .#generate-bun-nix` from Renovate `postUpgradeTasks` in branch mode.
- Rollout action: the Renovate instance must permit `nix run .#generate-bun-nix` in its `allowedCommands` policy; the repository config can't enable that host-level setting.

<sup>Written for commit d737aa07e60557753bae22b5949def179d376e57. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update workflows.
  * Added safeguards for selected dependency and toolchain updates.
  * Added an automated command to regenerate Bun dependency metadata.
  * Exposed the regeneration task through the project’s Nix tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->