### PR TITLE
fix: evaluate contribution gate comment predicate

### DIFF
--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -4,6 +4,7 @@
 use ./contribution-gate/coauthor.nu [coauthor-validation]
 use ./contribution-gate/context.nu [issue-context-record]
 use ./contribution-gate/core.nu [parse-issue-number]
+use ./contribution-gate/mutations.nu [is-contribution-gate-comment]
 use ./contribution-gate/verdict.nu [issue-verdict-record]
 use ./contribution-gate/requests.nu [
     CLOSING_PULL_REQUEST_QUERY
@@ -540,6 +541,22 @@ def test-forced-issue-implementation []: nothing -> nothing {
     ) false
 }
 
+def test-contribution-gate-comment []: nothing -> nothing {
+    let comment = {
+        user: {login: 'github-actions[bot]'}
+        body: 'Automated result. <!-- pullfrog-contribution-gate -->'
+    }
+    expect 'recognizes the contribution gate comment' (
+        is-contribution-gate-comment $comment
+    ) true
+    expect 'rejects a comment from another author' (
+        is-contribution-gate-comment ($comment | upsert user.login pullfrog)
+    ) false
+    expect 'rejects a comment without the marker' (
+        is-contribution-gate-comment ($comment | upsert body 'Automated result.')
+    ) false
+}
+
 def main [] {
     test-coauthor-validation
     test-coauthor-email
@@ -550,5 +567,6 @@ def main [] {
     test-issue-context
     test-issue-number
     test-forced-issue-implementation
+    test-contribution-gate-comment
     print 'contribution-gate Nushell tests passed.'
 }

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -126,6 +126,13 @@ def patch-comment [
     }) | ignore
 }
 
+export def is-contribution-gate-comment [comment: record]: nothing -> bool {
+    (
+        (($comment | get --optional user.login) == 'github-actions[bot]')
+        and (($comment | get --optional body | default '') | str contains $COMMENT_MARKER)
+    )
+}
+
 export def upsert-comment [
     repo: string
     number: int
@@ -142,10 +149,7 @@ export def upsert-comment [
     )
     let existing = (
         $comments
-        | where {|comment|
-            ($comment | get --optional user.login) == 'github-actions[bot]'
-            and (($comment | get --optional body | default '') | str contains $COMMENT_MARKER)
-        }
+        | where {|comment| is-contribution-gate-comment $comment}
         | sort-by created_at
         | last
     )


### PR DESCRIPTION
## Summary

- evaluate the contribution-gate comment predicate as one Nushell expression
- exercise the runtime predicate in the Nushell test suite
- preserve matching by GitHub Actions author and contribution-gate marker

## Why

All 28 manual issue implementation dispatches failed in the apply job because Nushell interpreted a line-leading boolean operator as an external command. No implementation or publication job ran.

## Validation

- contribution-gate Nushell tests
- Nushell IDE checks for both changed files
- targeted treefmt
- git diff --check
- pre-commit and pre-push hooks
- Sol review: no actionable findings

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the contribution gate comment predicate so manual issue dispatches no longer fail. Previously, Nushell treated the line-leading boolean operator as an external command, which caused every manual dispatch to fail before implementation.

- Extracts the predicate into a pure `is-contribution-gate-comment` helper and uses it in the upsert path.
- Adds Nushell tests covering author and marker matching.

<sup>Written for commit 0e843b8937bf4a96357b76f0a24b277de10f140f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of automated contribution-gate comments, ensuring only correctly authored comments with the expected marker are matched.

* **Tests**
  * Added coverage for valid comments and cases with incorrect authors or missing markers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->