### PR TITLE
fix(opencode): respect XDG data home

### DIFF
--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -10,7 +10,7 @@ ccusage detects supported data source files from conventional locations by defau
 | --------------------------------- | -------------- | ---------------------------------- |
 | `CLAUDE_CONFIG_DIR`               | Claude Code    | `~/.config/claude` and `~/.claude` |
 | `CODEX_HOME`                      | Codex          | `~/.codex`                         |
-| `OPENCODE_DATA_DIR`               | OpenCode       | `~/.local/share/opencode`          |
+| `OPENCODE_DATA_DIR`               | OpenCode       | `${XDG_DATA_HOME:-$HOME/.local/share}/opencode` |
 | `AMP_DATA_DIR`                    | Amp            | `~/.local/share/amp`               |
 | `DROID_SESSIONS_DIR`              | Droid          | `~/.factory/sessions`              |
 | `CODEBUFF_DATA_DIR`               | Codebuff       | `~/.config/manicode`               |

--- a/docs/guide/environment-variables.md
+++ b/docs/guide/environment-variables.md
@@ -6,24 +6,24 @@ ccusage supports several environment variables for configuration and customizati
 
 ccusage detects supported data source files from conventional locations by default. Set these variables when your data lives somewhere else. Directory variables can be one directory or a comma-separated list of directories; the Copilot variable points at one explicit JSONL export file, and `GROK_HOME` accepts a single root only:
 
-| Variable                          | Agent          | Default                            |
-| --------------------------------- | -------------- | ---------------------------------- |
-| `CLAUDE_CONFIG_DIR`               | Claude Code    | `~/.config/claude` and `~/.claude` |
-| `CODEX_HOME`                      | Codex          | `~/.codex`                         |
+| Variable                          | Agent          | Default                                         |
+| --------------------------------- | -------------- | ----------------------------------------------- |
+| `CLAUDE_CONFIG_DIR`               | Claude Code    | `~/.config/claude` and `~/.claude`              |
+| `CODEX_HOME`                      | Codex          | `~/.codex`                                      |
 | `OPENCODE_DATA_DIR`               | OpenCode       | `${XDG_DATA_HOME:-$HOME/.local/share}/opencode` |
-| `AMP_DATA_DIR`                    | Amp            | `~/.local/share/amp`               |
-| `DROID_SESSIONS_DIR`              | Droid          | `~/.factory/sessions`              |
-| `CODEBUFF_DATA_DIR`               | Codebuff       | `~/.config/manicode`               |
-| `HERMES_HOME`                     | Hermes Agent   | `~/.hermes`                        |
-| `PI_AGENT_DIR`                    | pi-agent       | `~/.pi/agent/sessions`             |
-| `GOOSE_PATH_ROOT`                 | Goose          | Standard Goose data roots          |
-| `OPENCLAW_DIR`                    | OpenClaw       | `~/.openclaw`                      |
-| `KILO_DATA_DIR`                   | Kilo           | `~/.local/share/kilo`              |
-| `KIMI_DATA_DIR`                   | Kimi           | `~/.kimi`, `~/.kimi-code`          |
-| `QWEN_DATA_DIR`                   | Qwen           | `~/.qwen`                          |
-| `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI    | Explicit `.jsonl` file             |
-| `GEMINI_DATA_DIR`                 | Gemini CLI     | `~/.gemini/tmp`                    |
-| `GROK_HOME`                       | Grok Build CLI | `~/.grok`                          |
+| `AMP_DATA_DIR`                    | Amp            | `~/.local/share/amp`                            |
+| `DROID_SESSIONS_DIR`              | Droid          | `~/.factory/sessions`                           |
+| `CODEBUFF_DATA_DIR`               | Codebuff       | `~/.config/manicode`                            |
+| `HERMES_HOME`                     | Hermes Agent   | `~/.hermes`                                     |
+| `PI_AGENT_DIR`                    | pi-agent       | `~/.pi/agent/sessions`                          |
+| `GOOSE_PATH_ROOT`                 | Goose          | Standard Goose data roots                       |
+| `OPENCLAW_DIR`                    | OpenClaw       | `~/.openclaw`                                   |
+| `KILO_DATA_DIR`                   | Kilo           | `~/.local/share/kilo`                           |
+| `KIMI_DATA_DIR`                   | Kimi           | `~/.kimi`, `~/.kimi-code`                       |
+| `QWEN_DATA_DIR`                   | Qwen           | `~/.qwen`                                       |
+| `COPILOT_OTEL_FILE_EXPORTER_PATH` | Copilot CLI    | Explicit `.jsonl` file                          |
+| `GEMINI_DATA_DIR`                 | Gemini CLI     | `~/.gemini/tmp`                                 |
+| `GROK_HOME`                       | Grok Build CLI | `~/.grok`                                       |
 
 Example:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -164,7 +164,7 @@ If ccusage shows no data, check:
 2. **Data directory exists** - Common locations:
    - Claude Code: `~/.config/claude/projects/` or `~/.claude/projects/`
    - Codex: `${CODEX_HOME:-~/.codex}`
-   - OpenCode: `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`
+   - OpenCode: `${OPENCODE_DATA_DIR-${XDG_DATA_HOME:-$HOME/.local/share}/opencode}` (the fallback applies only when `OPENCODE_DATA_DIR` is unset)
    - Amp: `${AMP_DATA_DIR:-~/.local/share/amp}`
    - Droid: `${DROID_SESSIONS_DIR:-~/.factory/sessions}`
    - Codebuff: `${CODEBUFF_DATA_DIR:-~/.config/manicode}`

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -76,7 +76,7 @@ ccusage reads from local coding CLI data directories:
 | -------------- | ---------- | ------------------------------------------------- |
 | Claude Code    | `claude`   | `~/.config/claude/projects/`, `~/.claude/`        |
 | Codex          | `codex`    | `${CODEX_HOME:-~/.codex}`                         |
-| OpenCode       | `opencode` | `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`   |
+| OpenCode       | `opencode` | `${OPENCODE_DATA_DIR-${XDG_DATA_HOME:-$HOME/.local/share}/opencode}` |
 | Amp            | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`             |
 | Droid          | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`      |
 | Codebuff       | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`        |
@@ -90,6 +90,8 @@ ccusage reads from local coding CLI data directories:
 | Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
 | Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
 | Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                           |
+
+For OpenCode, the `OPENCODE_DATA_DIR` fallback applies only when the variable is unset. A set-but-empty value disables default-path discovery.
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -72,26 +72,26 @@ Each data source page covers the details that only apply to that source, includi
 
 ccusage reads from local coding CLI data directories:
 
-| Agent          | ID         | Default data location                             |
-| -------------- | ---------- | ------------------------------------------------- |
-| Claude Code    | `claude`   | `~/.config/claude/projects/`, `~/.claude/`        |
-| Codex          | `codex`    | `${CODEX_HOME:-~/.codex}`                         |
+| Agent          | ID         | Default data location                                                |
+| -------------- | ---------- | -------------------------------------------------------------------- |
+| Claude Code    | `claude`   | `~/.config/claude/projects/`, `~/.claude/`                           |
+| Codex          | `codex`    | `${CODEX_HOME:-~/.codex}`                                            |
 | OpenCode       | `opencode` | `${OPENCODE_DATA_DIR-${XDG_DATA_HOME:-$HOME/.local/share}/opencode}` |
-| Amp            | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`             |
-| Droid          | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`      |
-| Codebuff       | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`        |
-| Hermes Agent   | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`              |
-| pi-agent       | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`           |
-| Goose          | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`    |
-| OpenClaw       | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                    |
-| Kilo           | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`           |
-| Kimi           | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`) |
-| Qwen           | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                       |
-| Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                         |
-| Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`               |
-| Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                           |
+| Amp            | `amp`      | `${AMP_DATA_DIR:-~/.local/share/amp}`                                |
+| Droid          | `droid`    | `${DROID_SESSIONS_DIR:-~/.factory/sessions}`                         |
+| Codebuff       | `codebuff` | `${CODEBUFF_DATA_DIR:-~/.config/manicode}`                           |
+| Hermes Agent   | `hermes`   | `${HERMES_HOME:-~/.hermes}/state.db`                                 |
+| pi-agent       | `pi`       | `${PI_AGENT_DIR:-~/.pi/agent/sessions}`                              |
+| Goose          | `goose`    | Standard Goose data roots or `GOOSE_PATH_ROOT`                       |
+| OpenClaw       | `openclaw` | `${OPENCLAW_DIR:-~/.openclaw}`                                       |
+| Kilo           | `kilo`     | `${KILO_DATA_DIR:-~/.local/share/kilo}`                              |
+| Kimi           | `kimi`     | `${KIMI_DATA_DIR:-~/.kimi}` (also `~/.kimi-code`)                    |
+| Qwen           | `qwen`     | `${QWEN_DATA_DIR:-~/.qwen}`                                          |
+| Copilot CLI    | `copilot`  | `~/.copilot/otel/*.jsonl`                                            |
+| Gemini CLI     | `gemini`   | `${GEMINI_DATA_DIR:-~/.gemini/tmp}`                                  |
+| Grok Build CLI | `grok`     | `${GROK_HOME:-~/.grok}`                                              |
 
-For OpenCode, the `OPENCODE_DATA_DIR` fallback applies only when the variable is unset. A set-but-empty value disables default-path discovery.
+For OpenCode, `${XDG_DATA_HOME:-$HOME/.local/share}/opencode` is the default-path fallback. When set, `OPENCODE_DATA_DIR` overrides that path; an explicitly empty value disables fallback discovery.
 
 The tool automatically detects available data and aggregates all supported coding CLIs by default.
 Source-specific environment variables that support multiple roots can contain comma-separated directories, which lets unified reports combine current profiles and archives.

--- a/docs/guide/opencode/index.md
+++ b/docs/guide/opencode/index.md
@@ -71,7 +71,7 @@ OpenCode supports subagent sessions. The session report displays:
 | Variable            | Description                                                                                |
 | ------------------- | ------------------------------------------------------------------------------------------ |
 | `OPENCODE_DATA_DIR` | Override the root directory, or comma-separated root directories, containing OpenCode data |
-| `XDG_DATA_HOME`     | Base directory for OpenCode data when `OPENCODE_DATA_DIR` is not set                      |
+| `XDG_DATA_HOME`     | Base directory for OpenCode data when `OPENCODE_DATA_DIR` is not set                       |
 | `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace)                                                    |
 
 ## Cost Calculation

--- a/docs/guide/opencode/index.md
+++ b/docs/guide/opencode/index.md
@@ -32,7 +32,7 @@ The `opencode x` option requires the native version of OpenCode. If you installe
 
 ## Data Source
 
-The CLI reads OpenCode message and session JSON files located under `OPENCODE_DATA_DIR` (defaults to `~/.local/share/opencode`). `OPENCODE_DATA_DIR` can be one directory or a comma-separated list of directories.
+The CLI reads OpenCode message and session JSON files from `OPENCODE_DATA_DIR` when it is set. Otherwise, it uses `${XDG_DATA_HOME:-$HOME/.local/share}/opencode`. `OPENCODE_DATA_DIR` can be one directory or a comma-separated list of directories.
 
 ```bash
 OPENCODE_DATA_DIR="$HOME/.local/share/opencode,/backup/opencode" ccusage opencode daily
@@ -41,7 +41,7 @@ OPENCODE_DATA_DIR="$HOME/.local/share/opencode,/backup/opencode" ccusage opencod
 <!-- eslint-skip -->
 
 ```
-~/.local/share/opencode/
+${XDG_DATA_HOME:-$HOME/.local/share}/opencode/
 └── storage/
     ├── message/{sessionID}/msg_{messageID}.json
     └── session/{projectHash}/{sessionID}.json
@@ -71,6 +71,7 @@ OpenCode supports subagent sessions. The session report displays:
 | Variable            | Description                                                                                |
 | ------------------- | ------------------------------------------------------------------------------------------ |
 | `OPENCODE_DATA_DIR` | Override the root directory, or comma-separated root directories, containing OpenCode data |
+| `XDG_DATA_HOME`     | Base directory for OpenCode data when `OPENCODE_DATA_DIR` is not set                      |
 | `LOG_LEVEL`         | Adjust verbosity (0 silent ... 5 trace)                                                    |
 
 ## Cost Calculation
@@ -80,7 +81,7 @@ OpenCode stores `cost: 0` in message files. Costs are calculated from token coun
 ## Troubleshooting
 
 ::: details No OpenCode usage data found
-Ensure the data directory exists at `~/.local/share/opencode/storage/message/`. Set `OPENCODE_DATA_DIR` for custom paths or comma-separated archive roots.
+Ensure the data directory exists at `${XDG_DATA_HOME:-$HOME/.local/share}/opencode/storage/message/`. Set `OPENCODE_DATA_DIR` for custom paths or comma-separated archive roots.
 :::
 
 ::: details Costs showing as $0.00

--- a/rust/adapters/opencode/README.md
+++ b/rust/adapters/opencode/README.md
@@ -15,7 +15,7 @@ Anything that is not specific to this source belongs in `ccusage-core` or
 
 ## Data source
 
-- `${OPENCODE_DATA_DIR:-~/.local/share/opencode}`
+- `OPENCODE_DATA_DIR`, or `${XDG_DATA_HOME:-$HOME/.local/share}/opencode` when unset
 
 Record shapes, token mapping, and cost rules are documented in [`src/README.md`](src/README.md).
 

--- a/rust/adapters/opencode/src/README.md
+++ b/rust/adapters/opencode/src/README.md
@@ -2,9 +2,14 @@
 
 Data source:
 
+When `OPENCODE_DATA_DIR` is set, the adapter reads databases from that
+directory. Otherwise, it uses `${XDG_DATA_HOME:-$HOME/.local/share}/opencode`:
+
 ```text
-${OPENCODE_DATA_DIR:-~/.local/share/opencode}/opencode.db
-${OPENCODE_DATA_DIR:-~/.local/share/opencode}/opencode-*.db
+${OPENCODE_DATA_DIR}/opencode.db
+${OPENCODE_DATA_DIR}/opencode-*.db
+${XDG_DATA_HOME:-$HOME/.local/share}/opencode/opencode.db
+${XDG_DATA_HOME:-$HOME/.local/share}/opencode/opencode-*.db
 ```
 
 SQLite databases are the primary source. Legacy JSON messages under `storage/message/` are loaded as a fallback and deduplicated behind database rows. Token mapping:

--- a/rust/adapters/opencode/src/paths.rs
+++ b/rust/adapters/opencode/src/paths.rs
@@ -22,8 +22,11 @@ pub(super) fn paths() -> Result<Vec<PathBuf>> {
         return Ok(paths);
     }
 
-    let data_home = match env::var_os(XDG_DATA_HOME_ENV).filter(|path| !path.is_empty()) {
-        Some(path) => PathBuf::from(path),
+    let data_home = match env::var_os(XDG_DATA_HOME_ENV)
+        .map(PathBuf::from)
+        .filter(|path| path.is_absolute())
+    {
+        Some(path) => path,
         None => {
             let home = crate::home::home_dir()
                 .ok_or_else(|| crate::cli_error("home directory is not set"))?;
@@ -112,6 +115,19 @@ mod tests {
     }
 
     #[test]
+    fn falls_back_to_home_data_directory_when_xdg_data_home_is_unset() {
+        let fixture = fs_fixture!({
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(None, None, Some(fixture.path("home").into_os_string()));
+
+        assert_eq!(
+            paths().unwrap(),
+            vec![fixture.path("home/.local/share/opencode")]
+        );
+    }
+
+    #[test]
     fn falls_back_to_home_data_directory_when_xdg_data_home_is_empty() {
         let fixture = fs_fixture!({
             "home/.local/share/opencode/opencode.db": "",
@@ -119,6 +135,23 @@ mod tests {
         let _guard = isolated_env(
             None,
             Some(OsString::new()),
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert_eq!(
+            paths().unwrap(),
+            vec![fixture.path("home/.local/share/opencode")]
+        );
+    }
+
+    #[test]
+    fn falls_back_to_home_data_directory_when_xdg_data_home_is_relative() {
+        let fixture = fs_fixture!({
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(
+            None,
+            Some(OsString::from("relative-xdg-data-home")),
             Some(fixture.path("home").into_os_string()),
         );
 

--- a/rust/adapters/opencode/src/paths.rs
+++ b/rust/adapters/opencode/src/paths.rs
@@ -8,13 +8,17 @@ const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
 pub(super) fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
-    if let Ok(env_paths) = env::var(OPENCODE_DATA_DIR_ENV) {
-        for raw in env_paths
-            .split(',')
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-        {
-            let path = PathBuf::from(raw);
+    if let Some(env_paths) = env::var_os(OPENCODE_DATA_DIR_ENV) {
+        let configured_paths = match env_paths.into_string() {
+            Ok(env_paths) => env_paths
+                .split(',')
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+                .map(PathBuf::from)
+                .collect(),
+            Err(env_path) => vec![PathBuf::from(env_path)],
+        };
+        for path in configured_paths {
             if path.is_dir() && seen.insert(path.clone()) {
                 paths.push(path);
             }
@@ -112,6 +116,47 @@ mod tests {
         );
 
         assert_eq!(paths().unwrap(), vec![first, second]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_fall_back_when_configured_data_dir_is_non_utf8() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let _guard = isolated_env(
+            Some(OsString::from_vec(b"opencode-\xFF".to_vec())),
+            None,
+            None,
+        );
+
+        assert!(paths().unwrap().is_empty());
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn discovers_non_utf8_configured_data_directory() {
+        use std::{os::unix::ffi::OsStringExt, path::PathBuf};
+
+        let fixture = fs_fixture!({});
+        let configured_dir =
+            fixture.create_dir_all(PathBuf::from(OsString::from_vec(b"opencode-\xFF".to_vec())));
+        let _guard = isolated_env(Some(configured_dir.clone().into_os_string()), None, None);
+
+        assert_eq!(paths().unwrap(), vec![configured_dir]);
+    }
+
+    #[test]
+    fn does_not_fall_back_when_configured_data_dir_is_empty() {
+        let fixture = fs_fixture!({
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(
+            Some(OsString::new()),
+            None,
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert!(paths().unwrap().is_empty());
     }
 
     #[test]

--- a/rust/adapters/opencode/src/paths.rs
+++ b/rust/adapters/opencode/src/paths.rs
@@ -2,10 +2,13 @@ use std::{collections::HashSet, env, path::PathBuf};
 
 use crate::Result;
 
+const OPENCODE_DATA_DIR_ENV: &str = "OPENCODE_DATA_DIR";
+const XDG_DATA_HOME_ENV: &str = "XDG_DATA_HOME";
+
 pub(super) fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
-    if let Ok(env_paths) = env::var("OPENCODE_DATA_DIR") {
+    if let Ok(env_paths) = env::var(OPENCODE_DATA_DIR_ENV) {
         for raw in env_paths
             .split(',')
             .map(str::trim)
@@ -19,11 +22,124 @@ pub(super) fn paths() -> Result<Vec<PathBuf>> {
         return Ok(paths);
     }
 
-    let home =
-        crate::home::home_dir().ok_or_else(|| crate::cli_error("home directory is not set"))?;
-    let path = home.join(".local/share/opencode");
+    let data_home = match env::var_os(XDG_DATA_HOME_ENV).filter(|path| !path.is_empty()) {
+        Some(path) => PathBuf::from(path),
+        None => {
+            let home = crate::home::home_dir()
+                .ok_or_else(|| crate::cli_error("home directory is not set"))?;
+            home.join(".local/share")
+        }
+    };
+    let path = data_home.join("opencode");
     if path.is_dir() && seen.insert(path.clone()) {
         paths.push(path);
     }
     Ok(paths)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
+
+    use super::{OPENCODE_DATA_DIR_ENV, XDG_DATA_HOME_ENV, paths};
+
+    fn isolated_env(
+        opencode_data_dir: Option<OsString>,
+        xdg_data_home: Option<OsString>,
+        home: Option<OsString>,
+    ) -> EnvVarsGuard {
+        EnvVarsGuard::set_many([
+            (OPENCODE_DATA_DIR_ENV, opencode_data_dir),
+            (XDG_DATA_HOME_ENV, xdg_data_home),
+            ("HOME", home),
+            ("USERPROFILE", None),
+            ("HOMEDRIVE", None),
+            ("HOMEPATH", None),
+        ])
+    }
+
+    #[test]
+    fn uses_xdg_data_home_for_default_path() {
+        let fixture = fs_fixture!({
+            "xdg/opencode/opencode.db": "",
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(
+            None,
+            Some(fixture.path("xdg").into_os_string()),
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert_eq!(paths().unwrap(), vec![fixture.path("xdg/opencode")]);
+    }
+
+    #[test]
+    fn uses_xdg_data_home_without_a_home_directory() {
+        let fixture = fs_fixture!({
+            "xdg/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(None, Some(fixture.path("xdg").into_os_string()), None);
+
+        assert_eq!(paths().unwrap(), vec![fixture.path("xdg/opencode")]);
+    }
+
+    #[test]
+    fn keeps_configured_data_dirs_before_default_paths() {
+        let fixture = fs_fixture!({
+            "configured/first/opencode.db": "",
+            "configured/second/opencode.db": "",
+            "xdg/opencode/opencode.db": "",
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let first = fixture.path("configured/first");
+        let second = fixture.path("configured/second");
+        let raw = format!(
+            " {}, {}, {}, {} ",
+            first.display(),
+            second.display(),
+            first.display(),
+            fixture.path("missing").display()
+        );
+        let _guard = isolated_env(
+            Some(OsString::from(raw)),
+            Some(fixture.path("xdg").into_os_string()),
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert_eq!(paths().unwrap(), vec![first, second]);
+    }
+
+    #[test]
+    fn falls_back_to_home_data_directory_when_xdg_data_home_is_empty() {
+        let fixture = fs_fixture!({
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let _guard = isolated_env(
+            None,
+            Some(OsString::new()),
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert_eq!(
+            paths().unwrap(),
+            vec![fixture.path("home/.local/share/opencode")]
+        );
+    }
+
+    #[test]
+    fn does_not_fall_back_to_home_when_xdg_data_home_is_set() {
+        let fixture = fs_fixture!({
+            "home/.local/share/opencode/opencode.db": "",
+        });
+        let xdg_data_home = fixture.create_dir_all("xdg");
+        let _guard = isolated_env(
+            None,
+            Some(xdg_data_home.into_os_string()),
+            Some(fixture.path("home").into_os_string()),
+        );
+
+        assert!(paths().unwrap().is_empty());
+    }
 }


### PR DESCRIPTION
## Summary

- Discover OpenCode data under `XDG_DATA_HOME/opencode` when `OPENCODE_DATA_DIR` is unset.
- Preserve explicit `OPENCODE_DATA_DIR`, including an empty value disabling default discovery.
- Document the precedence and add regression coverage.

## Validation

- `cargo test --manifest-path rust/Cargo.toml -p ccusage-adapter-opencode`
- `rustfmt --edition 2024 --check rust/adapters/opencode/src/paths.rs`
- `pnpm --dir docs run build`

Fixes #1286

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OpenCode now supports `XDG_DATA_HOME` when determining its default data directory.
  * Setting `OPENCODE_DATA_DIR` overrides the default location; leaving it empty disables fallback discovery.
  * Unset, empty, relative, or invalid `XDG_DATA_HOME` values fall back to the standard data directory.

* **Documentation**
  * Updated setup, troubleshooting, and adapter documentation to explain data-directory resolution and supported environment variables.

* **Tests**
  * Added coverage for default, custom, XDG-based, and fallback data-directory resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->