### PR TITLE
fix(statusline): apply pricing overrides

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -1435,6 +1435,58 @@
 											"markdownDescription": "Use cached pricing data where supported.",
 											"type": "boolean"
 										},
+										"pricingOverrides": {
+											"additionalProperties": {
+												"additionalProperties": false,
+												"properties": {
+													"cacheCreationInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheCreationInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCost": {
+														"format": "double",
+														"type": "number"
+													},
+													"cacheReadInputTokenCostAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"fastMultiplier": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"inputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													},
+													"maxInputTokens": {
+														"format": "uint64",
+														"minimum": 0.0,
+														"type": "integer"
+													},
+													"outputCostPerToken": {
+														"format": "double",
+														"type": "number"
+													},
+													"outputCostPerTokenAbove200kTokens": {
+														"format": "double",
+														"type": "number"
+													}
+												},
+												"type": "object"
+											},
+											"description": "Runtime pricing overrides keyed by raw model name.",
+											"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+											"type": "object"
+										},
 										"refreshInterval": {
 											"default": 1,
 											"description": "Statusline refresh interval in seconds.",
@@ -3953,6 +4005,58 @@
 									"description": "Use cached pricing data where supported.",
 									"markdownDescription": "Use cached pricing data where supported.",
 									"type": "boolean"
+								},
+								"pricingOverrides": {
+									"additionalProperties": {
+										"additionalProperties": false,
+										"properties": {
+											"cacheCreationInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheCreationInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCost": {
+												"format": "double",
+												"type": "number"
+											},
+											"cacheReadInputTokenCostAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"fastMultiplier": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"inputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											},
+											"maxInputTokens": {
+												"format": "uint64",
+												"minimum": 0.0,
+												"type": "integer"
+											},
+											"outputCostPerToken": {
+												"format": "double",
+												"type": "number"
+											},
+											"outputCostPerTokenAbove200kTokens": {
+												"format": "double",
+												"type": "number"
+											}
+										},
+										"type": "object"
+									},
+									"description": "Runtime pricing overrides keyed by raw model name.",
+									"markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+									"type": "object"
 								},
 								"refreshInterval": {
 									"default": 1,

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -163,6 +163,7 @@ pub struct StatuslineArgs {
     pub config: Option<PathBuf>,
     pub debug: bool,
     pub model_label_aliases: HashMap<String, String>,
+    pub pricing_overrides: BTreeMap<String, PricingOverride>,
 }
 
 #[derive(Clone)]
@@ -227,6 +228,7 @@ impl Default for StatuslineArgs {
             config: None,
             debug: false,
             model_label_aliases: HashMap::new(),
+            pricing_overrides: BTreeMap::new(),
         }
     }
 }

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -498,6 +498,9 @@ fn apply_config_to_statusline_args(args: &mut StatuslineArgs, config: &ConfigCon
         if let Some(aliases) = options.model_label_aliases {
             args.model_label_aliases = aliases;
         }
+        if let Some(pricing_overrides) = options.pricing_overrides {
+            merge_pricing_overrides(&mut args.pricing_overrides, pricing_overrides);
+        }
     }
 }
 

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -471,6 +471,8 @@ pub struct StatuslineSpecificOptions {
     pub debug: Option<bool>,
     /// Map model identifiers to short display labels.
     pub model_label_aliases: Option<HashMap<String, String>>,
+    /// Runtime pricing overrides keyed by raw model name.
+    pub pricing_overrides: Option<BTreeMap<String, ConfigPricingOverride>>,
 }
 
 #[derive(Debug, Default, Deserialize, JsonSchema)]
@@ -638,6 +640,7 @@ impl StatuslineSpecificOptions {
             timezone: string_option(map, "timezone"),
             debug: bool_option(map, "debug"),
             model_label_aliases: hashmap_option(map, "modelLabelAliases"),
+            pricing_overrides: pricing_override_map_option(map, "pricingOverrides"),
         }
     }
 }
@@ -1071,6 +1074,7 @@ mod tests {
                 "noCache",
                 "noOffline",
                 "offline",
+                "pricingOverrides",
                 "refreshInterval",
                 "timezone",
                 "visualBurnRate",

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -72,6 +72,58 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
         "markdownDescription": "Use cached pricing data where supported.",
         "type": "boolean"
       },
+      "pricingOverrides": {
+        "additionalProperties": {
+          "additionalProperties": false,
+          "properties": {
+            "cacheCreationInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheCreationInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCost": {
+              "format": "double",
+              "type": "number"
+            },
+            "cacheReadInputTokenCostAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "fastMultiplier": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "inputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            },
+            "maxInputTokens": {
+              "format": "uint64",
+              "minimum": 0.0,
+              "type": "integer"
+            },
+            "outputCostPerToken": {
+              "format": "double",
+              "type": "number"
+            },
+            "outputCostPerTokenAbove200kTokens": {
+              "format": "double",
+              "type": "number"
+            }
+          },
+          "type": "object"
+        },
+        "description": "Runtime pricing overrides keyed by raw model name.",
+        "markdownDescription": "Runtime pricing overrides keyed by raw model name.",
+        "type": "object"
+      },
       "refreshInterval": {
         "default": 1,
         "description": "Statusline refresh interval in seconds.",

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -331,10 +331,7 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
 
     let hook: StatuslineHook =
         serde_json::from_str(stdin.trim()).context("Invalid input format")?;
-    let shared = SharedArgs {
-        offline: args.offline && !args.no_offline,
-        ..SharedArgs::default()
-    };
+    let shared = statusline_shared(&args);
     let cache_enabled = args.cache && !args.no_cache;
     let cache_path = statusline_cache_path(&hook.session_id);
     let transcript_path = Path::new(&hook.transcript_path);
@@ -384,6 +381,14 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
         }
     }
     Ok(())
+}
+
+fn statusline_shared(args: &StatuslineArgs) -> SharedArgs {
+    SharedArgs {
+        offline: args.offline && !args.no_offline,
+        pricing_overrides: args.pricing_overrides.clone(),
+        ..SharedArgs::default()
+    }
 }
 
 /// Resolve the model label shown in the statusline.
@@ -842,9 +847,92 @@ struct HookContext {
 
 #[cfg(test)]
 mod tests {
-    use ccusage_test_support::fs_fixture;
+    use std::ffi::OsString;
+
+    use ccusage_config::ConfigContext;
+    use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     use super::*;
+    use crate::cli::{Cli, Command};
+
+    #[test]
+    fn statusline_invocation_passes_config_pricing_overrides_to_cost_loading() {
+        let fixture = fs_fixture!({
+            "ccusage.json": r#"{
+                "defaults": {
+                    "pricingOverrides": {
+                        "third-party-model": {
+                            "inputCostPerToken": 0.000001,
+                            "outputCostPerToken": 0.000002
+                        }
+                    }
+                },
+                "commands": {
+                    "statusline": {
+                        "pricingOverrides": {
+                            "third-party-model": {
+                                "outputCostPerToken": 0.000003
+                            }
+                        }
+                    }
+                }
+            }"#,
+            "projects/project/session.jsonl": r#"{"timestamp":"2020-01-01T00:00:00.000Z","sessionId":"session","message":{"id":"message","model":"third-party-model","usage":{"input_tokens":100000,"output_tokens":100000}}}"#,
+        });
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        let config_path = fixture.path("ccusage.json");
+        let config_path = config_path.to_string_lossy().into_owned();
+        let config_args = vec![
+            "statusline".to_string(),
+            "--config".to_string(),
+            config_path.clone(),
+        ];
+        let config = ConfigContext::from_args(&config_args);
+        let cli = Cli::parse_from_with_config(
+            [
+                "ccusage",
+                "statusline",
+                "--config",
+                config_path.as_str(),
+                "--cost-source",
+                "ccusage",
+            ]
+            .into_iter()
+            .map(OsString::from),
+            &config,
+            DEFAULT_SESSION_DURATION_HOURS,
+            env!("CCUSAGE_VERSION"),
+        )
+        .unwrap();
+        let Some(Command::Statusline(args)) = cli.command else {
+            panic!("expected statusline command");
+        };
+
+        let shared = statusline_shared(&args);
+        let pricing = &shared.pricing_overrides["third-party-model"];
+        assert_eq!(pricing.input_cost_per_token, Some(0.000001));
+        assert_eq!(pricing.output_cost_per_token, Some(0.000003));
+
+        let hook = StatuslineHook {
+            session_id: "session".to_string(),
+            transcript_path: fixture
+                .path("transcript.jsonl")
+                .to_string_lossy()
+                .into_owned(),
+            model: HookModel {
+                id: Some("third-party-model".to_string()),
+                display_name: "Third-party model".to_string(),
+            },
+            cost: None,
+            context_window: Some(HookContext {
+                total_input_tokens: 100_000,
+                context_window_size: 200_000,
+            }),
+            effort: None,
+        };
+        let output = render_statusline(&hook, &args, &shared).unwrap();
+        assert!(output.contains("💰 $0.40 session"), "{output}");
+    }
 
     #[test]
     fn calculates_context_tokens_from_latest_assistant_transcript_line() {


### PR DESCRIPTION
## Summary

- pass configured `pricingOverrides` into statusline cost loading
- preserve defaults and `commands.statusline` field-level precedence
- regenerate the configuration schema and add regression coverage

## Validation

- `cargo test --manifest-path rust/Cargo.toml -p ccusage`
- `cargo test --manifest-path rust/Cargo.toml -p ccusage-cli-parser`
- `cargo test --manifest-path rust/Cargo.toml -p ccusage-config`
- `cargo fmt --all -- --check`

Fixes #1591

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes statusline cost loading so configured `pricingOverrides` are applied instead of using default rates. Third-party model costs now respect the merged defaults and `commands.statusline` settings, fixing #1591.

- Updates the config schema and snapshot to include the new `pricingOverrides` field.
- Adds regression coverage for default and command-level precedence.

<sup>Written for commit bb46049163fc9d0a3bc0b9da53886e707390860b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional pricing overrides for the statusline command.
  - Configure model-specific token pricing, cache costs, fast-mode multipliers, and input-token limits.
  - Pricing overrides now apply to statusline cost calculations, including command-specific settings and offline usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->