### PR TITLE
fix(claude): scope message dedupe by session

### DIFF
--- a/rust/adapters/claude/src/README.md
+++ b/rust/adapters/claude/src/README.md
@@ -29,12 +29,13 @@ Sidechain entries:
   with their own message IDs are still counted.
 - Daily summary sidechain replay matching is scoped to the effective session ID
   and does not require matching timestamps. The regular usage loader requires
-  matching timestamps.
+  matching timestamps for sidechain replays with different request IDs.
 - This behavior fixes the overcounting reported in
   [#913](https://github.com/ccusage/ccusage/issues/913).
-- When `requestId` is missing, deduplication also uses the effective session ID
-  and timestamp. This keeps distinct gateway responses that reuse a message ID
-  separate while still collapsing same-session duplicate writes.
+- When `requestId` is missing, the regular usage loader deduplicates by message
+  ID and effective session ID. Daily summary matching also includes timestamps,
+  except for sidechain replays. Both keep gateway responses that reuse a message
+  ID in different sessions separate.
 
 The term `session` has two meanings in this codebase:
 

--- a/rust/adapters/claude/src/README.md
+++ b/rust/adapters/claude/src/README.md
@@ -29,6 +29,9 @@ Sidechain entries:
   with their own message IDs are still counted.
 - This behavior fixes the overcounting reported in
   [#913](https://github.com/ccusage/ccusage/issues/913).
+- When `requestId` is missing, deduplication also uses the effective session ID
+  and timestamp. This keeps distinct gateway responses that reuse a message ID
+  separate while still collapsing same-session duplicate writes.
 
 The term `session` has two meanings in this codebase:
 

--- a/rust/adapters/claude/src/README.md
+++ b/rust/adapters/claude/src/README.md
@@ -27,6 +27,9 @@ Sidechain entries:
 - ccusage keeps the parent entry and drops the replayed sidechain copy when at
   least one duplicate carries `isSidechain: true`. Distinct sidechain responses
   with their own message IDs are still counted.
+- Daily summary sidechain replay matching is scoped to the effective session ID
+  and does not require matching timestamps. The regular usage loader requires
+  matching timestamps.
 - This behavior fixes the overcounting reported in
   [#913](https://github.com/ccusage/ccusage/issues/913).
 - When `requestId` is missing, deduplication also uses the effective session ID

--- a/rust/adapters/claude/src/daily.rs
+++ b/rust/adapters/claude/src/daily.rs
@@ -19,10 +19,10 @@ use crate::{
 };
 
 use super::{
-    advisor_usages_from_line, chunk_file_indexes_by_size, has_unsupported_null_field,
-    is_semver_prefix,
+    advisor_usages_from_line, chunk_file_indexes_by_size, daily_usage_dedupe_hash,
+    has_unsupported_null_field, is_semver_prefix,
     paths::{claude_paths, extract_project, usage_files},
-    sidechain_replay_dedupe_hash, usage_dedupe_hash,
+    sidechain_replay_dedupe_hash,
 };
 
 pub(super) fn load_daily_summaries_inner(
@@ -415,7 +415,7 @@ fn push_deduped_daily_entry(
 ) {
     let dedupe_lookup = entry.message_id.as_deref().map(|message_id| {
         let request_id = entry.request_id.as_deref();
-        let exact_hash = usage_dedupe_hash(
+        let exact_hash = daily_usage_dedupe_hash(
             message_id,
             request_id,
             entry.session_id.as_ref(),

--- a/rust/adapters/claude/src/daily.rs
+++ b/rust/adapters/claude/src/daily.rs
@@ -113,8 +113,10 @@ struct DailyLoadedFile {
 
 #[derive(Debug)]
 struct DailyLoadedEntry {
+    timestamp: TimestampMs,
     date: String,
     project: Arc<str>,
+    session_id: Arc<str>,
     usage: TokenUsageRaw,
     cost: f64,
     model: Option<String>,
@@ -152,7 +154,7 @@ impl DailyUsageLine {
                 timestamp: entry.data.message.timestamp,
                 message: entry.data.message.message,
                 version: None,
-                session_id: None,
+                session_id: entry.session_id,
                 cost_usd: entry.data.message.cost_usd,
                 request_id: entry.data.message.request_id,
                 is_sidechain: entry.data.message.is_sidechain,
@@ -163,6 +165,8 @@ impl DailyUsageLine {
 
 #[derive(Debug, Deserialize)]
 struct DailyAgentProgressEntry {
+    #[serde(rename = "sessionId")]
+    session_id: Option<String>,
     data: DailyAgentProgressData,
 }
 
@@ -245,6 +249,8 @@ fn read_daily_usage_file(
     pricing: Option<&PricingMap>,
 ) -> DailyLoadedFile {
     let project: Arc<str> = Arc::from(extract_project(path));
+    let (path_session_id, _) = super::paths::extract_session_parts(path);
+    let path_session_id: Arc<str> = Arc::from(path_session_id);
     let mut loaded_file = DailyLoadedFile {
         timestamp: None,
         entries: Vec::new(),
@@ -301,11 +307,18 @@ fn read_daily_usage_file(
             }
         });
         let date = format_date_tz(timestamp, tz);
+        let session_id: Arc<str> = data
+            .session_id
+            .as_deref()
+            .map(Arc::from)
+            .unwrap_or_else(|| Arc::clone(&path_session_id));
         let message_id = data.message.id.clone();
         let request_id = data.request_id.clone();
         loaded_file.entries.push(DailyLoadedEntry {
+            timestamp,
             date: date.clone(),
             project: Arc::clone(&project),
+            session_id: Arc::clone(&session_id),
             usage,
             cost,
             model,
@@ -323,8 +336,10 @@ fn read_daily_usage_file(
                 pricing,
             );
             loaded_file.entries.push(DailyLoadedEntry {
+                timestamp,
                 date: date.clone(),
                 project: Arc::clone(&project),
+                session_id: Arc::clone(&session_id),
                 usage: advisor.usage,
                 cost: calculate_cost_for_usage(
                     Some(&advisor.model),
@@ -400,22 +415,32 @@ fn push_deduped_daily_entry(
 ) {
     let dedupe_lookup = entry.message_id.as_deref().map(|message_id| {
         let request_id = entry.request_id.as_deref();
-        let exact_hash = usage_dedupe_hash(message_id, request_id);
+        let exact_hash = usage_dedupe_hash(
+            message_id,
+            request_id,
+            entry.session_id.as_ref(),
+            entry.timestamp,
+        );
         let existing_index = deduped_indexes
             .get(&exact_hash)
             .and_then(|indexes| {
                 indexes.iter().copied().find(|&index| {
                     deduped[index].message_id.as_deref() == Some(message_id)
                         && deduped[index].request_id.as_deref() == request_id
+                        && deduped[index].session_id == entry.session_id
+                        && (request_id.is_some() || deduped[index].timestamp == entry.timestamp)
                 })
             })
             .or_else(|| {
                 // /btw sidechain logs can replay parent messages with new request IDs.
-                let message_hash = usage_dedupe_hash(message_id, None);
+                let message_hash =
+                    usage_dedupe_hash(message_id, None, entry.session_id.as_ref(), entry.timestamp);
                 let candidate_is_sidechain = is_sidechain_daily_entry(&entry);
                 deduped_indexes.get(&message_hash).and_then(|indexes| {
                     indexes.iter().copied().find(|&index| {
                         deduped[index].message_id.as_deref() == Some(message_id)
+                            && deduped[index].session_id == entry.session_id
+                            && deduped[index].timestamp == entry.timestamp
                             && (candidate_is_sidechain || is_sidechain_daily_entry(&deduped[index]))
                     })
                 })
@@ -423,9 +448,22 @@ fn push_deduped_daily_entry(
         (exact_hash, existing_index)
     });
 
-    if let Some((_, Some(index))) = dedupe_lookup {
+    if let Some((hash, Some(index))) = dedupe_lookup {
         if should_replace_deduped_daily_entry(&entry, &deduped[index]) {
             deduped[index] = entry;
+            push_deduped_daily_index(deduped_indexes, hash, index);
+            if let Some(message_id) = deduped[index].message_id.as_deref() {
+                push_deduped_daily_index(
+                    deduped_indexes,
+                    usage_dedupe_hash(
+                        message_id,
+                        None,
+                        deduped[index].session_id.as_ref(),
+                        deduped[index].timestamp,
+                    ),
+                    index,
+                );
+            }
         }
         return;
     }
@@ -435,7 +473,16 @@ fn push_deduped_daily_entry(
     if let Some((hash, None)) = dedupe_lookup {
         push_deduped_daily_index(deduped_indexes, hash, index);
         if let Some(message_id) = deduped[index].message_id.as_deref() {
-            push_deduped_daily_index(deduped_indexes, usage_dedupe_hash(message_id, None), index);
+            push_deduped_daily_index(
+                deduped_indexes,
+                usage_dedupe_hash(
+                    message_id,
+                    None,
+                    deduped[index].session_id.as_ref(),
+                    deduped[index].timestamp,
+                ),
+                index,
+            );
         }
     }
 }
@@ -545,8 +592,9 @@ impl DailyAccumulator {
 mod tests {
     use std::sync::Arc;
 
-    use super::{DailyLoadedEntry, push_deduped_daily_entry};
-    use crate::TokenUsageRaw;
+    use super::{DailyLoadedEntry, push_deduped_daily_entry, read_daily_usage_file};
+    use crate::{TimestampMs, TokenUsageRaw, cli::CostMode};
+    use ccusage_test_support::fs_fixture;
 
     #[test]
     fn keeps_parent_daily_usage_when_sidechain_replays_message_with_new_request_id() {
@@ -599,14 +647,111 @@ mod tests {
     }
 
     #[test]
+    fn refreshes_daily_dedupe_indexes_when_parent_replaces_sidechain_replay() {
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        push_deduped_daily_entry(
+            daily_loaded_entry(DailyEntryFixture {
+                message_id: "msg-parent",
+                request_id: "req-sidechain-replay",
+                is_sidechain: true,
+                cache_read_tokens: 50_000,
+                output_tokens: 10,
+            }),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+        push_deduped_daily_entry(
+            daily_loaded_entry(DailyEntryFixture {
+                message_id: "msg-parent",
+                request_id: "req-parent",
+                is_sidechain: false,
+                cache_read_tokens: 20,
+                output_tokens: 10,
+            }),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+        push_deduped_daily_entry(
+            daily_loaded_entry(DailyEntryFixture {
+                message_id: "msg-parent",
+                request_id: "req-parent",
+                is_sidechain: false,
+                cache_read_tokens: 5,
+                output_tokens: 5,
+            }),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].request_id.as_deref(), Some("req-parent"));
+        assert_eq!(deduped[0].usage.cache_read_input_tokens, 20);
+    }
+
+    #[test]
     fn propagates_sidechain_metadata_from_agent_progress_lines() {
         let data = serde_json::from_str::<super::DailyUsageLine>(
-            r#"{"data":{"message":{"timestamp":"2026-03-29T07:00:00.000Z","requestId":"req-sidechain","isSidechain":true,"message":{"usage":{"input_tokens":0,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":20},"model":"claude-sonnet-4-20250514","id":"msg-sidechain"}}}}"#,
+            r#"{"sessionId":"session-a","data":{"message":{"timestamp":"2026-03-29T07:00:00.000Z","requestId":"req-sidechain","isSidechain":true,"message":{"usage":{"input_tokens":0,"output_tokens":10,"cache_creation_input_tokens":0,"cache_read_input_tokens":20},"model":"claude-sonnet-4-20250514","id":"msg-sidechain"}}}}"#,
         )
         .unwrap()
         .into_entry();
 
+        assert_eq!(data.session_id.as_deref(), Some("session-a"));
         assert_eq!(data.is_sidechain, Some(true));
+    }
+
+    #[test]
+    fn keeps_gateway_daily_usage_from_distinct_sessions_with_reused_message_id() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":1}}}"#,
+            "projects/project-a/session-b/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":300,"output_tokens":1}}}"#,
+        });
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        for path in [
+            fixture.path("projects/project-a/session-a/chat.jsonl"),
+            fixture.path("projects/project-a/session-b/chat.jsonl"),
+        ] {
+            let loaded = read_daily_usage_file(&path, None, CostMode::Display, None);
+            for entry in loaded.entries {
+                push_deduped_daily_entry(entry, &mut deduped_indexes, &mut deduped);
+            }
+        }
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(
+            deduped
+                .iter()
+                .map(|entry| entry.usage.input_tokens)
+                .sum::<u64>(),
+            400
+        );
+    }
+
+    #[test]
+    fn dedupes_copied_daily_transcripts_with_the_same_serialized_session_id() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","sessionId":"session-a","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":1}}}"#,
+            "projects/project-a/session-b/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","sessionId":"session-a","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":200,"output_tokens":1}}}"#,
+        });
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        for path in [
+            fixture.path("projects/project-a/session-a/chat.jsonl"),
+            fixture.path("projects/project-a/session-b/chat.jsonl"),
+        ] {
+            let loaded = read_daily_usage_file(&path, None, CostMode::Display, None);
+            for entry in loaded.entries {
+                push_deduped_daily_entry(entry, &mut deduped_indexes, &mut deduped);
+            }
+        }
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].usage.input_tokens, 200);
     }
 
     struct DailyEntryFixture {
@@ -619,8 +764,10 @@ mod tests {
 
     fn daily_loaded_entry(fixture: DailyEntryFixture) -> DailyLoadedEntry {
         DailyLoadedEntry {
+            timestamp: TimestampMs::from_millis(1_774_000_000_000),
             date: "2026-03-29".to_string(),
             project: Arc::from("project-a"),
+            session_id: Arc::from("session-a"),
             usage: TokenUsageRaw {
                 input_tokens: 0,
                 output_tokens: fixture.output_tokens,

--- a/rust/adapters/claude/src/daily.rs
+++ b/rust/adapters/claude/src/daily.rs
@@ -22,7 +22,7 @@ use super::{
     advisor_usages_from_line, chunk_file_indexes_by_size, has_unsupported_null_field,
     is_semver_prefix,
     paths::{claude_paths, extract_project, usage_files},
-    usage_dedupe_hash,
+    sidechain_replay_dedupe_hash, usage_dedupe_hash,
 };
 
 pub(super) fn load_daily_summaries_inner(
@@ -434,13 +434,12 @@ fn push_deduped_daily_entry(
             .or_else(|| {
                 // /btw sidechain logs can replay parent messages with new request IDs.
                 let message_hash =
-                    usage_dedupe_hash(message_id, None, entry.session_id.as_ref(), entry.timestamp);
+                    sidechain_replay_dedupe_hash(message_id, entry.session_id.as_ref());
                 let candidate_is_sidechain = is_sidechain_daily_entry(&entry);
                 deduped_indexes.get(&message_hash).and_then(|indexes| {
                     indexes.iter().copied().find(|&index| {
                         deduped[index].message_id.as_deref() == Some(message_id)
                             && deduped[index].session_id == entry.session_id
-                            && deduped[index].timestamp == entry.timestamp
                             && (candidate_is_sidechain || is_sidechain_daily_entry(&deduped[index]))
                     })
                 })
@@ -455,12 +454,7 @@ fn push_deduped_daily_entry(
             if let Some(message_id) = deduped[index].message_id.as_deref() {
                 push_deduped_daily_index(
                     deduped_indexes,
-                    usage_dedupe_hash(
-                        message_id,
-                        None,
-                        deduped[index].session_id.as_ref(),
-                        deduped[index].timestamp,
-                    ),
+                    sidechain_replay_dedupe_hash(message_id, deduped[index].session_id.as_ref()),
                     index,
                 );
             }
@@ -475,12 +469,7 @@ fn push_deduped_daily_entry(
         if let Some(message_id) = deduped[index].message_id.as_deref() {
             push_deduped_daily_index(
                 deduped_indexes,
-                usage_dedupe_hash(
-                    message_id,
-                    None,
-                    deduped[index].session_id.as_ref(),
-                    deduped[index].timestamp,
-                ),
+                sidechain_replay_dedupe_hash(message_id, deduped[index].session_id.as_ref()),
                 index,
             );
         }
@@ -647,6 +636,47 @@ mod tests {
     }
 
     #[test]
+    fn dedupes_timestamp_different_daily_sidechain_replay_with_parent() {
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        push_deduped_daily_entry(
+            daily_loaded_entry_at(
+                DailyEntryFixture {
+                    message_id: "msg-parent",
+                    request_id: "req-parent",
+                    is_sidechain: false,
+                    cache_read_tokens: 20,
+                    output_tokens: 10,
+                },
+                "session-a",
+                TimestampMs::from_millis(1_774_000_000_000),
+            ),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+        push_deduped_daily_entry(
+            daily_loaded_entry_at(
+                DailyEntryFixture {
+                    message_id: "msg-parent",
+                    request_id: "req-sidechain-replay",
+                    is_sidechain: true,
+                    cache_read_tokens: 50_000,
+                    output_tokens: 10,
+                },
+                "session-a",
+                TimestampMs::from_millis(1_774_000_001_000),
+            ),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].request_id.as_deref(), Some("req-parent"));
+        assert_eq!(deduped[0].usage.cache_read_input_tokens, 20);
+    }
+
+    #[test]
     fn refreshes_daily_dedupe_indexes_when_parent_replaces_sidechain_replay() {
         let mut deduped_indexes = Default::default();
         let mut deduped = Vec::new();
@@ -732,6 +762,95 @@ mod tests {
     }
 
     #[test]
+    fn keeps_timestamp_different_requestless_daily_entries_without_sidechain() {
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        let mut first = daily_loaded_entry_at(
+            DailyEntryFixture {
+                message_id: "ocgo",
+                request_id: "unused",
+                is_sidechain: false,
+                cache_read_tokens: 0,
+                output_tokens: 10,
+            },
+            "session-a",
+            TimestampMs::from_millis(1_774_000_000_000),
+        );
+        first.request_id = None;
+        push_deduped_daily_entry(first, &mut deduped_indexes, &mut deduped);
+
+        let mut second = daily_loaded_entry_at(
+            DailyEntryFixture {
+                message_id: "ocgo",
+                request_id: "unused",
+                is_sidechain: false,
+                cache_read_tokens: 0,
+                output_tokens: 20,
+            },
+            "session-a",
+            TimestampMs::from_millis(1_774_000_001_000),
+        );
+        second.request_id = None;
+        push_deduped_daily_entry(second, &mut deduped_indexes, &mut deduped);
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(
+            deduped
+                .iter()
+                .map(|entry| entry.usage.output_tokens)
+                .sum::<u64>(),
+            30
+        );
+    }
+
+    #[test]
+    fn keeps_daily_sidechain_replay_from_distinct_session() {
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        push_deduped_daily_entry(
+            daily_loaded_entry_at(
+                DailyEntryFixture {
+                    message_id: "msg-parent",
+                    request_id: "req-parent",
+                    is_sidechain: false,
+                    cache_read_tokens: 20,
+                    output_tokens: 10,
+                },
+                "session-a",
+                TimestampMs::from_millis(1_774_000_000_000),
+            ),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+        push_deduped_daily_entry(
+            daily_loaded_entry_at(
+                DailyEntryFixture {
+                    message_id: "msg-parent",
+                    request_id: "req-sidechain-replay",
+                    is_sidechain: true,
+                    cache_read_tokens: 50_000,
+                    output_tokens: 10,
+                },
+                "session-b",
+                TimestampMs::from_millis(1_774_000_001_000),
+            ),
+            &mut deduped_indexes,
+            &mut deduped,
+        );
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(
+            deduped
+                .iter()
+                .map(|entry| entry.usage.cache_read_input_tokens)
+                .sum::<u64>(),
+            50_020
+        );
+    }
+
+    #[test]
     fn dedupes_copied_daily_transcripts_with_the_same_serialized_session_id() {
         let fixture = fs_fixture!({
             "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","sessionId":"session-a","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":1}}}"#,
@@ -783,5 +902,16 @@ mod tests {
             request_id: Some(fixture.request_id.to_string()),
             is_sidechain: Some(fixture.is_sidechain),
         }
+    }
+
+    fn daily_loaded_entry_at(
+        fixture: DailyEntryFixture,
+        session_id: &str,
+        timestamp: TimestampMs,
+    ) -> DailyLoadedEntry {
+        let mut entry = daily_loaded_entry(fixture);
+        entry.session_id = Arc::from(session_id);
+        entry.timestamp = timestamp;
+        entry
     }
 }

--- a/rust/adapters/claude/src/lib.rs
+++ b/rust/adapters/claude/src/lib.rs
@@ -227,6 +227,14 @@ fn usage_dedupe_hash(
     hasher.finish()
 }
 
+fn sidechain_replay_dedupe_hash(message_id: &str, session_id: &str) -> u64 {
+    let mut hasher = FxHasher::default();
+    "sidechain-replay".hash(&mut hasher);
+    message_id.hash(&mut hasher);
+    session_id.hash(&mut hasher);
+    hasher.finish()
+}
+
 fn loaded_entry_session_id(entry: &LoadedEntry) -> &str {
     entry
         .data

--- a/rust/adapters/claude/src/lib.rs
+++ b/rust/adapters/claude/src/lib.rs
@@ -147,7 +147,7 @@ fn push_deduped_entry(
     let dedupe_lookup = entry.data.message.id.as_deref().map(|message_id| {
         let request_id = entry.data.request_id.as_deref();
         let session_id = loaded_entry_session_id(&entry);
-        let exact_hash = usage_dedupe_hash(message_id, request_id, session_id, entry.timestamp);
+        let exact_hash = usage_dedupe_hash(message_id, request_id, session_id);
         let existing_index = deduped_indexes
             .get(&exact_hash)
             .and_then(|indexes| {
@@ -157,13 +157,12 @@ fn push_deduped_entry(
                         message_id,
                         request_id,
                         session_id,
-                        entry.timestamp,
                     )
                 })
             })
             .or_else(|| {
                 // /btw sidechain logs can replay parent messages with new request IDs.
-                let message_hash = usage_dedupe_hash(message_id, None, session_id, entry.timestamp);
+                let message_hash = usage_dedupe_hash(message_id, None, session_id);
                 let candidate_is_sidechain = is_sidechain_usage_entry(&entry.data);
                 deduped_indexes.get(&message_hash).and_then(|indexes| {
                     indexes.iter().copied().find(|&index| {
@@ -188,7 +187,7 @@ fn push_deduped_entry(
                 let session_id = loaded_entry_session_id(&deduped[index]);
                 push_deduped_index(
                     deduped_indexes,
-                    usage_dedupe_hash(message_id, None, session_id, deduped[index].timestamp),
+                    usage_dedupe_hash(message_id, None, session_id),
                     index,
                 );
             }
@@ -204,14 +203,22 @@ fn push_deduped_entry(
             let session_id = loaded_entry_session_id(&deduped[index]);
             push_deduped_index(
                 deduped_indexes,
-                usage_dedupe_hash(message_id, None, session_id, deduped[index].timestamp),
+                usage_dedupe_hash(message_id, None, session_id),
                 index,
             );
         }
     }
 }
 
-fn usage_dedupe_hash(
+fn usage_dedupe_hash(message_id: &str, request_id: Option<&str>, session_id: &str) -> u64 {
+    let mut hasher = FxHasher::default();
+    message_id.hash(&mut hasher);
+    request_id.hash(&mut hasher);
+    session_id.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn daily_usage_dedupe_hash(
     message_id: &str,
     request_id: Option<&str>,
     session_id: &str,
@@ -248,12 +255,10 @@ fn loaded_entry_matches_dedupe_key(
     message_id: &str,
     request_id: Option<&str>,
     session_id: &str,
-    timestamp: TimestampMs,
 ) -> bool {
     entry.data.message.id.as_deref() == Some(message_id)
         && entry.data.request_id.as_deref() == request_id
         && loaded_entry_session_id(entry) == session_id
-        && (request_id.is_some() || entry.timestamp == timestamp)
 }
 
 fn loaded_entry_matches_sidechain_dedupe_key(
@@ -766,6 +771,32 @@ mod tests {
                 .sum::<u64>(),
             400
         );
+    }
+
+    #[test]
+    fn dedupes_requestless_usage_from_same_session_at_distinct_timestamps() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": [
+                r#"{"timestamp":"2026-05-22T02:34:40.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":25}}}"#,
+                r#"{"timestamp":"2026-05-22T02:34:41.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":250,"speed":"standard"}}}"#,
+            ]
+            .join("\n"),
+        });
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        let loaded = read_usage_file(
+            &fixture.path("projects/project-a/session-a/chat.jsonl"),
+            None,
+            CostMode::Display,
+            None,
+        );
+        for entry in loaded.entries {
+            push_deduped_entry(entry, &mut deduped_indexes, &mut deduped);
+        }
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].data.message.usage.output_tokens, 250);
     }
 
     #[test]

--- a/rust/adapters/claude/src/lib.rs
+++ b/rust/adapters/claude/src/lib.rs
@@ -146,23 +146,32 @@ fn push_deduped_entry(
 ) {
     let dedupe_lookup = entry.data.message.id.as_deref().map(|message_id| {
         let request_id = entry.data.request_id.as_deref();
-        let exact_hash = usage_dedupe_hash(message_id, request_id);
+        let session_id = loaded_entry_session_id(&entry);
+        let exact_hash = usage_dedupe_hash(message_id, request_id, session_id, entry.timestamp);
         let existing_index = deduped_indexes
             .get(&exact_hash)
             .and_then(|indexes| {
                 indexes.iter().copied().find(|&index| {
-                    loaded_entry_matches_dedupe_key(&deduped[index], message_id, request_id)
+                    loaded_entry_matches_dedupe_key(
+                        &deduped[index],
+                        message_id,
+                        request_id,
+                        session_id,
+                        entry.timestamp,
+                    )
                 })
             })
             .or_else(|| {
                 // /btw sidechain logs can replay parent messages with new request IDs.
-                let message_hash = usage_dedupe_hash(message_id, None);
+                let message_hash = usage_dedupe_hash(message_id, None, session_id, entry.timestamp);
                 let candidate_is_sidechain = is_sidechain_usage_entry(&entry.data);
                 deduped_indexes.get(&message_hash).and_then(|indexes| {
                     indexes.iter().copied().find(|&index| {
                         loaded_entry_matches_sidechain_dedupe_key(
                             &deduped[index],
                             message_id,
+                            session_id,
+                            entry.timestamp,
                             candidate_is_sidechain,
                         )
                     })
@@ -176,7 +185,12 @@ fn push_deduped_entry(
             deduped[index] = entry;
             push_deduped_index(deduped_indexes, hash, index);
             if let Some(message_id) = deduped[index].data.message.id.as_deref() {
-                push_deduped_index(deduped_indexes, usage_dedupe_hash(message_id, None), index);
+                let session_id = loaded_entry_session_id(&deduped[index]);
+                push_deduped_index(
+                    deduped_indexes,
+                    usage_dedupe_hash(message_id, None, session_id, deduped[index].timestamp),
+                    index,
+                );
             }
         }
         return;
@@ -187,33 +201,63 @@ fn push_deduped_entry(
     if let Some((hash, None)) = dedupe_lookup {
         push_deduped_index(deduped_indexes, hash, index);
         if let Some(message_id) = deduped[index].data.message.id.as_deref() {
-            push_deduped_index(deduped_indexes, usage_dedupe_hash(message_id, None), index);
+            let session_id = loaded_entry_session_id(&deduped[index]);
+            push_deduped_index(
+                deduped_indexes,
+                usage_dedupe_hash(message_id, None, session_id, deduped[index].timestamp),
+                index,
+            );
         }
     }
 }
 
-fn usage_dedupe_hash(message_id: &str, request_id: Option<&str>) -> u64 {
+fn usage_dedupe_hash(
+    message_id: &str,
+    request_id: Option<&str>,
+    session_id: &str,
+    timestamp: TimestampMs,
+) -> u64 {
     let mut hasher = FxHasher::default();
     message_id.hash(&mut hasher);
     request_id.hash(&mut hasher);
+    session_id.hash(&mut hasher);
+    if request_id.is_none() {
+        timestamp.hash(&mut hasher);
+    }
     hasher.finish()
+}
+
+fn loaded_entry_session_id(entry: &LoadedEntry) -> &str {
+    entry
+        .data
+        .session_id
+        .as_deref()
+        .unwrap_or(entry.session_id.as_ref())
 }
 
 fn loaded_entry_matches_dedupe_key(
     entry: &LoadedEntry,
     message_id: &str,
     request_id: Option<&str>,
+    session_id: &str,
+    timestamp: TimestampMs,
 ) -> bool {
     entry.data.message.id.as_deref() == Some(message_id)
         && entry.data.request_id.as_deref() == request_id
+        && loaded_entry_session_id(entry) == session_id
+        && (request_id.is_some() || entry.timestamp == timestamp)
 }
 
 fn loaded_entry_matches_sidechain_dedupe_key(
     entry: &LoadedEntry,
     message_id: &str,
+    session_id: &str,
+    timestamp: TimestampMs,
     candidate_is_sidechain: bool,
 ) -> bool {
     entry.data.message.id.as_deref() == Some(message_id)
+        && loaded_entry_session_id(entry) == session_id
+        && entry.timestamp == timestamp
         && (candidate_is_sidechain || is_sidechain_usage_entry(&entry.data))
 }
 
@@ -685,6 +729,58 @@ mod tests {
         assert_eq!(loaded.entries[0].cost, 1.23);
         assert_eq!(loaded.entries[1].model.as_deref(), Some("advisor-model"));
         assert_eq!(loaded.entries[1].cost, 26.0);
+    }
+
+    #[test]
+    fn keeps_gateway_usage_from_distinct_sessions_with_reused_message_id() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":1}}}"#,
+            "projects/project-a/session-b/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":300,"output_tokens":1}}}"#,
+        });
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        for path in [
+            fixture.path("projects/project-a/session-a/chat.jsonl"),
+            fixture.path("projects/project-a/session-b/chat.jsonl"),
+        ] {
+            let loaded = read_usage_file(&path, None, CostMode::Display, None);
+            for entry in loaded.entries {
+                push_deduped_entry(entry, &mut deduped_indexes, &mut deduped);
+            }
+        }
+
+        assert_eq!(deduped.len(), 2);
+        assert_eq!(
+            deduped
+                .iter()
+                .map(|entry| entry.data.message.usage.input_tokens)
+                .sum::<u64>(),
+            400
+        );
+    }
+
+    #[test]
+    fn dedupes_copied_transcripts_with_the_same_serialized_session_id() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","sessionId":"session-a","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":100,"output_tokens":1}}}"#,
+            "projects/project-a/session-b/chat.jsonl": r#"{"timestamp":"2026-05-22T02:34:40.000Z","sessionId":"session-a","message":{"id":"ocgo","model":"claude-sonnet-4-20250514","usage":{"input_tokens":200,"output_tokens":1}}}"#,
+        });
+        let mut deduped_indexes = Default::default();
+        let mut deduped = Vec::new();
+
+        for path in [
+            fixture.path("projects/project-a/session-a/chat.jsonl"),
+            fixture.path("projects/project-a/session-b/chat.jsonl"),
+        ] {
+            let loaded = read_usage_file(&path, None, CostMode::Display, None);
+            for entry in loaded.entries {
+                push_deduped_entry(entry, &mut deduped_indexes, &mut deduped);
+            }
+        }
+
+        assert_eq!(deduped.len(), 1);
+        assert_eq!(deduped[0].data.message.usage.input_tokens, 200);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -302,6 +302,28 @@ mod tests {
     }
 
     #[test]
+    fn dedupes_reused_message_id_from_same_session_without_request_id() {
+        let fixture = fs_fixture!({
+            "projects/project1/session1/chat.jsonl": [
+                r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,
+                r#"{"timestamp":"2025-01-10T10:00:01.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":250,"cache_creation_input_tokens":10,"cache_read_input_tokens":5,"speed":"standard"}},"costUSD":0.01}"#,
+            ]
+            .join("\n"),
+        });
+
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, None).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 250);
+        assert_eq!(entries[0].cost, 0.01);
+    }
+
+    #[test]
     fn accepts_projects_directory_in_claude_config_dir() {
         let fixture = fs_fixture!({
             "projects/project1/session1/chat.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,

--- a/rust/crates/ccusage/src/main.rs
+++ b/rust/crates/ccusage/src/main.rs
@@ -278,13 +278,10 @@ mod tests {
     }
 
     #[test]
-    fn dedupes_usage_entries_by_message_id_without_request_id() {
+    fn keeps_reused_message_id_from_distinct_sessions_at_same_timestamp() {
         let fixture = fs_fixture!({
-            "projects/project1/session1/chat.jsonl": [
-                r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,
-                r#"{"timestamp":"2025-01-10T10:00:01.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":250,"cache_creation_input_tokens":10,"cache_read_input_tokens":5,"speed":"standard"}},"costUSD":0.01}"#,
-            ]
-            .join("\n"),
+            "projects/project1/session1/chat.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":25,"cache_creation_input_tokens":10,"cache_read_input_tokens":5}},"costUSD":0.001}"#,
+            "projects/project1/session2/chat.jsonl": r#"{"timestamp":"2025-01-10T10:00:00.000Z","message":{"id":"msg_123","model":"claude-opus-4-6","usage":{"input_tokens":100,"output_tokens":250,"cache_creation_input_tokens":10,"cache_read_input_tokens":5,"speed":"standard"}},"costUSD":0.01}"#,
         });
 
         let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
@@ -294,9 +291,14 @@ mod tests {
         };
         let entries = load_entries(&shared, None).unwrap();
 
-        assert_eq!(entries.len(), 1);
-        assert_eq!(entries[0].data.message.usage.output_tokens, 250);
-        assert_eq!(entries[0].cost, 0.01);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|entry| entry.data.message.usage.output_tokens)
+                .sum::<u64>(),
+            275
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- scope Claude Gateway fallback message-ID deduplication by session
- retain canonical parent records when daily sidechain entries are replaced
- add regressions for cross-session gateway events and daily replacement

## Validation

- cargo test -p ccusage-adapter-claude
- cargo test -p ccusage-adapter-all claude
- cargo fmt --check

Fixes #1635

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes Claude Gateway message deduplication by session so distinct sessions that reuse a message ID are no longer collapsed, fixing cross-session usage undercounting.

- Message dedupe now includes the session ID; without a `requestId`, the daily loader also includes the timestamp, while the regular loader still collapses same-session duplicates across timestamps.
- Daily sidechain replay matching uses the effective session ID and no longer requires matching timestamps; the regular loader still requires them.
- Canonical parent records are retained when daily sidechain entries are replaced, and agent progress entries preserve session info.
- Fixes #1635.

<sup>Written for commit 4cfa01910b2d1209638fb8594a0b9aa9dca5874d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Claude usage deduplication to distinguish entries from separate sessions, even when message IDs or timestamps are reused.
  - Continued removing duplicate records from copied transcripts within the same session.
  - Enabled sidechain replay matching across differing timestamps while preserving session boundaries.
  - Improved handling of requestless entries with different timestamps.
- **Tests**
  - Added coverage for session-aware and timestamp-independent deduplication.
- **Documentation**
  - Documented the updated deduplication behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->