### PR TITLE
fix(pi): suppress forked session replays

### DIFF
--- a/rust/adapters/pi/src/README.md
+++ b/rust/adapters/pi/src/README.md
@@ -17,10 +17,11 @@ ccusage pi daily --pi-path /path/to/sessions
 ```
 
 Forked session files may replay the usage history of their parent. For Pi's
-tree-format sessions, the parent candidate follows the active root-to-leaf path
-rather than physical JSONL order; abandoned sibling branches stay counted in
-the parent. The candidate includes only raw records at or before the child fork
-timestamp. The loader removes only a leading prefix that matches that candidate,
+tree-format sessions, the parent candidate follows the root-to-leaf path ending
+at the final physical entry rather than physical JSONL order; abandoned sibling
+and disconnected-root branches stay counted in the parent. The candidate includes
+only raw records at or before the child fork timestamp. The loader removes only a
+leading prefix that matches that candidate,
 and only when the parent file was discovered in the same store. Matching
 includes the timestamp, model, all token fields, the effective total-token
 fallback, and the effective billed cost in Display or Auto mode. The first

--- a/rust/adapters/pi/src/README.md
+++ b/rust/adapters/pi/src/README.md
@@ -15,3 +15,12 @@ ccusage pi session
 ccusage pi daily --json
 ccusage pi daily --pi-path /path/to/sessions
 ```
+
+Forked session files may replay the usage history of their parent. The parent
+candidate includes only raw records at or before the child fork timestamp. The
+loader removes only a leading prefix that matches that candidate, and only when
+the parent file was discovered in the same store. Matching includes the
+timestamp, model, all token fields, the effective total-token fallback, and
+the effective billed cost in Display or Auto mode. The first mismatch and all
+later records remain in the child session. Missing, malformed, self-referential,
+or cyclic lineage is left unchanged so usage is not discarded speculatively.

--- a/rust/adapters/pi/src/README.md
+++ b/rust/adapters/pi/src/README.md
@@ -16,11 +16,14 @@ ccusage pi daily --json
 ccusage pi daily --pi-path /path/to/sessions
 ```
 
-Forked session files may replay the usage history of their parent. The parent
-candidate includes only raw records at or before the child fork timestamp. The
-loader removes only a leading prefix that matches that candidate, and only when
-the parent file was discovered in the same store. Matching includes the
-timestamp, model, all token fields, the effective total-token fallback, and
-the effective billed cost in Display or Auto mode. The first mismatch and all
-later records remain in the child session. Missing, malformed, self-referential,
-or cyclic lineage is left unchanged so usage is not discarded speculatively.
+Forked session files may replay the usage history of their parent. For Pi's
+tree-format sessions, the parent candidate follows the active root-to-leaf path
+rather than physical JSONL order; abandoned sibling branches stay counted in
+the parent. The candidate includes only raw records at or before the child fork
+timestamp. The loader removes only a leading prefix that matches that candidate,
+and only when the parent file was discovered in the same store. Matching
+includes the timestamp, model, all token fields, the effective total-token
+fallback, and the effective billed cost in Display or Auto mode. The first
+mismatch and all later records remain in the child session. Missing, malformed,
+self-referential, or cyclic lineage is left unchanged so usage is not discarded
+speculatively.

--- a/rust/adapters/pi/src/loader.rs
+++ b/rust/adapters/pi/src/loader.rs
@@ -553,6 +553,75 @@ mod tests {
     }
 
     #[test]
+    fn skips_copied_branch_when_parent_has_multiple_disconnected_roots() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                linked_usage_line("unrelated-root", None, "2026-01-02T09:00:00.000Z", 50),
+                linked_usage_line("active-root", None, "2026-01-02T10:00:00.000Z", 100),
+                linked_usage_line(
+                    "active-leaf",
+                    Some("active-root"),
+                    "2026-01-02T11:00:00.000Z",
+                    200,
+                ),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                linked_usage_line("copy-root", None, "2026-01-02T10:00:00.000Z", 100),
+                linked_usage_line(
+                    "copy-leaf",
+                    Some("copy-root"),
+                    "2026-01-02T11:00:00.000Z",
+                    200,
+                ),
+                linked_usage_line(
+                    "child-only",
+                    Some("copy-leaf"),
+                    "2026-01-03T01:00:00.000Z",
+                    300,
+                ),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 4, "single_thread={single_thread}");
+            assert!(entries.iter().any(|entry| {
+                entry.session_id.as_ref() == "root" && entry.data.message.usage.input_tokens == 50
+            }));
+            let child_entries = entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child")
+                .collect::<Vec<_>>();
+            assert_eq!(child_entries.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                child_entries[0].data.message.usage.input_tokens, 300,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
     fn fails_open_for_missing_malformed_and_unrelated_same_token_sessions() {
         let fixture = Fixture::new();
         let missing_parent = fixture.path("sessions/project-a/missing.jsonl");

--- a/rust/adapters/pi/src/loader.rs
+++ b/rust/adapters/pi/src/loader.rs
@@ -227,28 +227,18 @@ impl PiReplayPlan {
             if !has_valid_lineage(child_index, &parent_by_child, &invalid_lineage) {
                 continue;
             }
-            let Some(child_usage) = loaded
-                .get(child_index)
-                .and_then(|data| data.as_ref())
-                .map(|data| data.usage.as_slice())
-            else {
-                continue;
-            };
-            let Some(parent_usage) = loaded
+            let Some(parent) = loaded
                 .get(replay.parent_index)
                 .and_then(|data| data.as_ref())
-                .map(|data| data.usage.as_slice())
             else {
                 continue;
             };
-            let parent_prefix = parent_usage
-                .iter()
-                .take_while(|entry| entry.timestamp <= replay.fork_timestamp);
-            let matched = child_usage
-                .iter()
-                .zip(parent_prefix)
-                .take_while(|(child, parent)| child == parent)
-                .count();
+            let Some(child) = loaded.get(child_index).and_then(|data| data.as_ref()) else {
+                continue;
+            };
+            let Some(matched) = parent.matching_replay_prefix(child, replay.fork_timestamp) else {
+                continue;
+            };
             if matched > 0 {
                 skip_by_file.insert(child_index, matched);
             }
@@ -385,6 +375,27 @@ mod tests {
         )
     }
 
+    fn linked_usage_line(id: &str, parent_id: Option<&str>, timestamp: &str, input: u64) -> String {
+        let mut line = json!({
+            "type": "message",
+            "id": id,
+            "timestamp": timestamp,
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5",
+                "usage": {
+                    "input": input,
+                    "output": 10,
+                    "cacheRead": 20,
+                    "cacheWrite": 3,
+                    "totalTokens": input + 33,
+                },
+            },
+        });
+        line["parentId"] = parent_id.map_or(serde_json::Value::Null, |parent_id| json!(parent_id));
+        line.to_string()
+    }
+
     fn usage_line_with_display_cost(timestamp: &str, display_cost: f64) -> String {
         json!({
             "type": "message",
@@ -475,6 +486,67 @@ mod tests {
                     .usage
                     .cache_creation_input_tokens,
                 999,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
+    fn skips_the_copied_active_parent_branch_after_an_abandoned_sibling() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                linked_usage_line("a", None, "2026-01-02T10:00:00.000Z", 100),
+                linked_usage_line("x", Some("a"), "2026-01-02T11:00:00.000Z", 200),
+                linked_usage_line("y", Some("a"), "2026-01-02T12:00:00.000Z", 300),
+                linked_usage_line("z", Some("y"), "2026-01-02T13:00:00.000Z", 400),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                linked_usage_line("copy-a", None, "2026-01-02T10:00:00.000Z", 100),
+                linked_usage_line("copy-y", Some("copy-a"), "2026-01-02T12:00:00.000Z", 300),
+                linked_usage_line("copy-z", Some("copy-y"), "2026-01-02T13:00:00.000Z", 400),
+                linked_usage_line(
+                    "child-only",
+                    Some("copy-z"),
+                    "2026-01-03T01:00:00.000Z",
+                    500,
+                ),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 5, "single_thread={single_thread}");
+            assert!(entries.iter().any(|entry| {
+                entry.session_id.as_ref() == "root" && entry.data.message.usage.input_tokens == 200
+            }));
+            let child_entries = entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child")
+                .collect::<Vec<_>>();
+            assert_eq!(child_entries.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                child_entries[0].data.message.usage.input_tokens, 500,
                 "single_thread={single_thread}"
             );
         }

--- a/rust/adapters/pi/src/loader.rs
+++ b/rust/adapters/pi/src/loader.rs
@@ -1,4 +1,7 @@
-use std::{collections::HashSet, path::PathBuf};
+use std::{
+    collections::{HashMap, HashSet},
+    path::{Component, Path, PathBuf},
+};
 
 use crate::{
     LoadedEntry, PricingMap, Result, cli::SharedArgs, collect_files_with_extension, debug_log,
@@ -92,6 +95,8 @@ fn load_entries_from_paths(
     let tz = parse_tz(shared.timezone.as_deref());
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
+    let mut discovered_files = Vec::new();
+    let mut loaded_files = Vec::new();
     for path in paths {
         let mut files = Vec::new();
         collect_files_with_extension(&path, "jsonl", &mut files);
@@ -101,9 +106,9 @@ fn load_entries_from_paths(
         let loaded = read_files_parallel(&files, shared.single_thread, |file| {
             let result = match scope {
                 PiLoadScope::Default => {
-                    parser::read_session_file(file, tz.as_ref(), shared.mode, pricing)
+                    parser::read_session_file_data(file, tz.as_ref(), shared.mode, pricing)
                 }
-                PiLoadScope::Named { store_name } => parser::read_session_file_for_store(
+                PiLoadScope::Named { store_name } => parser::read_session_file_data_for_store(
                     file,
                     &path,
                     tz.as_ref(),
@@ -112,32 +117,982 @@ fn load_entries_from_paths(
                     store_name,
                 ),
             };
-            result.unwrap_or_else(|error| {
-                let label = scope.debug_label();
-                debug_log(
-                    shared,
-                    format!(
-                        "Failed to read {label} session file {}: {error}",
-                        file.display()
-                    ),
-                );
-                Vec::new()
-            })
-        });
-        for file_entries in loaded {
-            for entry in file_entries {
-                let id = match scope {
-                    PiLoadScope::Default => parser::entry_id(&entry),
-                    PiLoadScope::Named { .. } => {
-                        parser::entry_id_for_store(scope.store_name(), &entry)
-                    }
-                };
-                if seen.insert(id) {
-                    entries.push(entry);
+            match result {
+                Ok(data) => Some(data),
+                Err(error) => {
+                    let label = scope.debug_label();
+                    debug_log(
+                        shared,
+                        format!(
+                            "Failed to read {label} session file {}: {error}",
+                            file.display()
+                        ),
+                    );
+                    None
                 }
+            }
+        });
+        discovered_files.extend(files.into_iter().map(|file| DiscoveredFile { path: file }));
+        loaded_files.extend(loaded);
+    }
+
+    let replay_plan = PiReplayPlan::new(&discovered_files, &loaded_files);
+    for (index, (_file, data)) in discovered_files.into_iter().zip(loaded_files).enumerate() {
+        let Some(data) = data else {
+            continue;
+        };
+        for entry in data
+            .entries
+            .into_iter()
+            .skip(replay_plan.skip_prefix(index))
+        {
+            let id = match scope {
+                PiLoadScope::Default => parser::entry_id(&entry),
+                PiLoadScope::Named { .. } => parser::entry_id_for_store(scope.store_name(), &entry),
+            };
+            if seen.insert(id) {
+                entries.push(entry);
             }
         }
     }
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
+}
+
+struct DiscoveredFile {
+    path: PathBuf,
+}
+
+struct ParentReplay {
+    parent_index: usize,
+    fork_timestamp: crate::TimestampMs,
+}
+
+struct PiReplayPlan {
+    skip_by_file: HashMap<usize, usize>,
+}
+
+impl PiReplayPlan {
+    fn new(files: &[DiscoveredFile], loaded: &[Option<parser::PiSessionData>]) -> Self {
+        let mut files_by_path = HashMap::new();
+        for (index, file) in files.iter().enumerate() {
+            files_by_path
+                .entry(normalize_path(&file.path))
+                .or_insert(index);
+        }
+
+        let mut invalid_lineage = HashSet::new();
+        for (index, data) in loaded.iter().enumerate() {
+            let Some(header) = data.as_ref().and_then(|data| data.header.as_ref()) else {
+                invalid_lineage.insert(index);
+                continue;
+            };
+            if header.timestamp.is_none() || header.parent_session_is_malformed {
+                invalid_lineage.insert(index);
+            }
+        }
+
+        let mut parent_by_child = HashMap::new();
+        for (child_index, data) in loaded.iter().enumerate() {
+            let Some(header) = data.as_ref().and_then(|data| data.header.as_ref()) else {
+                continue;
+            };
+            let Some(parent_path) = header.parent_session.as_ref() else {
+                continue;
+            };
+            let Some(fork_timestamp) = header.timestamp else {
+                continue;
+            };
+            let Some(parent_index) =
+                resolve_parent_index(parent_path, &files[child_index].path, &files_by_path)
+            else {
+                invalid_lineage.insert(child_index);
+                continue;
+            };
+            if parent_index == child_index {
+                invalid_lineage.insert(child_index);
+                continue;
+            }
+            parent_by_child.insert(
+                child_index,
+                ParentReplay {
+                    parent_index,
+                    fork_timestamp,
+                },
+            );
+        }
+
+        let mut skip_by_file = HashMap::new();
+        for (&child_index, replay) in &parent_by_child {
+            if !has_valid_lineage(child_index, &parent_by_child, &invalid_lineage) {
+                continue;
+            }
+            let Some(child_usage) = loaded
+                .get(child_index)
+                .and_then(|data| data.as_ref())
+                .map(|data| data.usage.as_slice())
+            else {
+                continue;
+            };
+            let Some(parent_usage) = loaded
+                .get(replay.parent_index)
+                .and_then(|data| data.as_ref())
+                .map(|data| data.usage.as_slice())
+            else {
+                continue;
+            };
+            let parent_prefix = parent_usage
+                .iter()
+                .take_while(|entry| entry.timestamp <= replay.fork_timestamp);
+            let matched = child_usage
+                .iter()
+                .zip(parent_prefix)
+                .take_while(|(child, parent)| child == parent)
+                .count();
+            if matched > 0 {
+                skip_by_file.insert(child_index, matched);
+            }
+        }
+
+        Self { skip_by_file }
+    }
+
+    fn skip_prefix(&self, file_index: usize) -> usize {
+        self.skip_by_file.get(&file_index).copied().unwrap_or(0)
+    }
+}
+
+fn has_valid_lineage(
+    child_index: usize,
+    parent_by_child: &HashMap<usize, ParentReplay>,
+    invalid_lineage: &HashSet<usize>,
+) -> bool {
+    let mut visited = HashSet::new();
+    let mut current = child_index;
+    while let Some(replay) = parent_by_child.get(&current) {
+        if invalid_lineage.contains(&current) {
+            return false;
+        }
+        if !visited.insert(current) {
+            return false;
+        }
+        current = replay.parent_index;
+    }
+    !invalid_lineage.contains(&current)
+}
+
+fn resolve_parent_index(
+    parent_path: &Path,
+    child_path: &Path,
+    files_by_path: &HashMap<PathBuf, usize>,
+) -> Option<usize> {
+    let normalized_parent = normalize_path(parent_path);
+    if let Some(parent_index) = files_by_path.get(&normalized_parent).copied() {
+        return Some(parent_index);
+    }
+    if parent_path.is_relative()
+        && let Some(parent) = child_path.parent()
+    {
+        return files_by_path
+            .get(&normalize_path(&parent.join(parent_path)))
+            .copied();
+    }
+    None
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = if path.is_absolute() {
+        PathBuf::new()
+    } else {
+        std::env::current_dir().unwrap_or_default()
+    };
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::Normal(part) => normalized.push(part),
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+        }
+    }
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::{CostMode, SharedArgs};
+    use ccusage_test_support::Fixture;
+    use serde_json::json;
+    use std::path::Path;
+
+    fn session_line(id: &str, timestamp: &str, parent: Option<&Path>) -> String {
+        let mut line = json!({
+            "type": "session",
+            "id": id,
+            "timestamp": timestamp,
+        });
+        if let Some(parent) = parent {
+            line["parentSession"] = json!(parent.to_string_lossy().to_string());
+        }
+        line.to_string()
+    }
+
+    fn usage_line_with_model_and_total(
+        timestamp: &str,
+        model: &str,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        cache_write: u64,
+        total_tokens: u64,
+    ) -> String {
+        json!({
+            "type": "message",
+            "timestamp": timestamp,
+            "message": {
+                "role": "assistant",
+                "model": model,
+                "usage": {
+                    "input": input,
+                    "output": output,
+                    "cacheRead": cache_read,
+                    "cacheWrite": cache_write,
+                    "totalTokens": total_tokens,
+                },
+            },
+        })
+        .to_string()
+    }
+
+    fn usage_line(
+        timestamp: &str,
+        input: u64,
+        output: u64,
+        cache_read: u64,
+        cache_write: u64,
+    ) -> String {
+        usage_line_with_model_and_total(
+            timestamp,
+            "gpt-5",
+            input,
+            output,
+            cache_read,
+            cache_write,
+            input + output + cache_read + cache_write,
+        )
+    }
+
+    fn usage_line_with_display_cost(timestamp: &str, display_cost: f64) -> String {
+        json!({
+            "type": "message",
+            "timestamp": timestamp,
+            "message": {
+                "role": "assistant",
+                "model": "gpt-5",
+                "usage": {
+                    "input": 10,
+                    "output": 20,
+                    "cacheRead": 30,
+                    "cacheWrite": 40,
+                    "totalTokens": 100,
+                    "cost": {"total": display_cost},
+                },
+            },
+        })
+        .to_string()
+    }
+
+    #[test]
+    fn skips_replayed_parent_prefix_but_keeps_child_usage() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-03T00:00:00.000Z", 200, 20, 30, 4),
+                usage_line("2026-01-04T00:00:00.000Z", 50, 5, 6, 1),
+            ]
+            .join("\n"),
+        );
+        let _child_a = fixture.write_file(
+            "sessions/project-a/child-a.jsonl",
+            [
+                session_line("child-a", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-03T00:00:00.000Z", 200, 20, 30, 4),
+                usage_line("2026-01-04T00:00:00.000Z", 50, 5, 6, 1),
+            ]
+            .join("\n"),
+        );
+        let _child_b = fixture.write_file(
+            "sessions/project-a/child-b.jsonl",
+            [
+                session_line("child-b", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-03T00:00:00.000Z", 200, 20, 30, 999),
+                usage_line("2026-01-03T01:00:00.000Z", 70, 7, 8, 2),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 6, "single_thread={single_thread}");
+            let child_a_entries = entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child-a")
+                .collect::<Vec<_>>();
+            assert_eq!(child_a_entries.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                child_a_entries[0].data.message.usage.input_tokens, 50,
+                "single_thread={single_thread}"
+            );
+            let child_b_entries = entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child-b")
+                .collect::<Vec<_>>();
+            assert_eq!(child_b_entries.len(), 2, "single_thread={single_thread}");
+            assert_eq!(
+                child_b_entries[0]
+                    .data
+                    .message
+                    .usage
+                    .cache_creation_input_tokens,
+                999,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
+    fn fails_open_for_missing_malformed_and_unrelated_same_token_sessions() {
+        let fixture = Fixture::new();
+        let missing_parent = fixture.path("sessions/project-a/missing.jsonl");
+        let malformed_parent = fixture.path("sessions/project-a/malformed-parent.jsonl");
+        let outside_parent = fixture.write_file(
+            "outside/root.jsonl",
+            [
+                session_line("outside", "2026-01-01T00:00:00.000Z", None),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/missing-child.jsonl",
+            [
+                session_line(
+                    "missing-child",
+                    "2026-01-03T00:00:00.000Z",
+                    Some(&missing_parent),
+                ),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/outside-parent-child.jsonl",
+            [
+                session_line(
+                    "outside-parent-child",
+                    "2026-01-03T00:00:00.000Z",
+                    Some(&outside_parent),
+                ),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/malformed-parent.jsonl",
+            [
+                "not json".to_string(),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/malformed-parent-child.jsonl",
+            [
+                session_line(
+                    "malformed-parent-child",
+                    "2026-01-03T00:00:00.000Z",
+                    Some(&malformed_parent),
+                ),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/malformed-parent-grandchild.jsonl",
+            [
+                session_line(
+                    "malformed-parent-grandchild",
+                    "2026-01-04T00:00:00.000Z",
+                    Some(&fixture.path("sessions/project-a/malformed-parent-child.jsonl")),
+                ),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/malformed-child.jsonl",
+            [
+                "not json".to_string(),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/regular-a.jsonl",
+            usage_line("2026-01-02T11:00:00.000Z", 100, 10, 20, 3),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/regular-b.jsonl",
+            usage_line("2026-01-02T11:00:00.000Z", 100, 10, 20, 3),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 8, "single_thread={single_thread}");
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "missing-child")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "outside-parent-child")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "regular-a")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "regular-b")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "malformed-parent-grandchild")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
+    fn fails_open_for_self_referential_and_cyclic_sessions() {
+        let fixture = Fixture::new();
+        let self_path = fixture.path("sessions/project-a/self.jsonl");
+        let cycle_a = fixture.path("sessions/project-a/cycle-a.jsonl");
+        let cycle_b = fixture.path("sessions/project-a/cycle-b.jsonl");
+        let _ = fixture.write_file(
+            "sessions/project-a/self.jsonl",
+            [
+                session_line("self", "2026-01-03T00:00:00.000Z", Some(&self_path)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/cycle-a.jsonl",
+            [
+                session_line("cycle-a", "2026-01-03T00:00:00.000Z", Some(&cycle_b)),
+                usage_line("2026-01-02T10:00:00.000Z", 200, 20, 30, 4),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/cycle-b.jsonl",
+            [
+                session_line("cycle-b", "2026-01-03T00:00:00.000Z", Some(&cycle_a)),
+                usage_line("2026-01-02T10:00:00.000Z", 200, 20, 30, 4),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 3, "single_thread={single_thread}");
+        }
+    }
+
+    #[test]
+    fn uses_raw_parent_stream_for_nested_forks() {
+        let fixture = Fixture::new();
+        let root = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-02T11:00:00.000Z", 200, 20, 30, 4),
+            ]
+            .join("\n"),
+        );
+        let child = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&root)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-02T11:00:00.000Z", 200, 20, 30, 4),
+                usage_line("2026-01-03T01:00:00.000Z", 300, 30, 40, 5),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/grandchild.jsonl",
+            [
+                session_line("grandchild", "2026-01-04T00:00:00.000Z", Some(&child)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-02T11:00:00.000Z", 200, 20, 30, 4),
+                usage_line("2026-01-03T01:00:00.000Z", 300, 30, 40, 5),
+                usage_line("2026-01-04T01:00:00.000Z", 400, 40, 50, 6),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 4, "single_thread={single_thread}");
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "child")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == "grandchild")
+                    .count(),
+                1,
+                "single_thread={single_thread}"
+            );
+            assert_eq!(
+                entries
+                    .iter()
+                    .find(|entry| entry.session_id.as_ref() == "grandchild")
+                    .unwrap()
+                    .data
+                    .message
+                    .usage
+                    .input_tokens,
+                400,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
+    fn compares_every_effective_usage_field_before_suppressing_replay() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_model_and_total(
+                    "2026-01-02T10:00:00.000Z",
+                    "gpt-5",
+                    10,
+                    20,
+                    30,
+                    40,
+                    100,
+                ),
+            ]
+            .join("\n"),
+        );
+        let variants = [
+            ("input", "gpt-5", 11, 20, 30, 40, 101),
+            ("output", "gpt-5", 10, 21, 30, 40, 101),
+            ("cache-read", "gpt-5", 10, 20, 31, 40, 101),
+            ("cache-write", "gpt-5", 10, 20, 30, 41, 101),
+            ("model", "gpt-5-mini", 10, 20, 30, 40, 100),
+            ("total-fallback", "gpt-5", 10, 20, 30, 40, 110),
+        ];
+        for (name, model, input, output, cache_read, cache_write, total_tokens) in variants {
+            let _ = fixture.write_file(
+                format!("sessions/project-a/child-{name}.jsonl"),
+                [
+                    session_line(name, "2026-01-03T00:00:00.000Z", Some(&parent)),
+                    usage_line_with_model_and_total(
+                        "2026-01-02T10:00:00.000Z",
+                        model,
+                        input,
+                        output,
+                        cache_read,
+                        cache_write,
+                        total_tokens,
+                    ),
+                    usage_line("2026-01-03T01:00:00.000Z", 1, 2, 3, 4),
+                ]
+                .join("\n"),
+            );
+        }
+
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            single_thread: false,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries_from_paths(
+            &shared,
+            vec![fixture.path("sessions")],
+            None,
+            PiLoadScope::Default,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1 + variants.len() * 2);
+        for (name, ..) in variants {
+            let session_id = format!("child-{name}");
+            assert_eq!(
+                entries
+                    .iter()
+                    .filter(|entry| entry.session_id.as_ref() == session_id)
+                    .count(),
+                2,
+                "variant={name}"
+            );
+        }
+    }
+
+    #[test]
+    fn keeps_child_usage_when_display_cost_differs() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 1.0),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 2.0),
+            ]
+            .join("\n"),
+        );
+
+        for mode in [CostMode::Display, CostMode::Auto] {
+            let shared = SharedArgs {
+                mode,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 2, "mode={mode:?}");
+            assert_eq!(
+                entries
+                    .iter()
+                    .find(|entry| entry.session_id.as_ref() == "child")
+                    .unwrap()
+                    .cost,
+                2.0,
+                "mode={mode:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn ignores_stored_display_cost_when_calculating_replay_identity() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 1.0),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 2.0),
+            ]
+            .join("\n"),
+        );
+        let shared = SharedArgs {
+            mode: CostMode::Calculate,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries_from_paths(
+            &shared,
+            vec![fixture.path("sessions")],
+            None,
+            PiLoadScope::Default,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "root");
+    }
+
+    #[test]
+    fn treats_signed_zero_display_costs_as_equal_replay_identity() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 0.0),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", -0.0),
+            ]
+            .join("\n"),
+        );
+
+        for mode in [CostMode::Display, CostMode::Auto] {
+            let shared = SharedArgs {
+                mode,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 1, "mode={mode:?}");
+            assert_eq!(entries[0].session_id.as_ref(), "root", "mode={mode:?}");
+        }
+    }
+
+    #[test]
+    fn treats_missing_and_zero_display_costs_as_equal_replay_identity() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_model_and_total(
+                    "2026-01-02T10:00:00.000Z",
+                    "gpt-5",
+                    10,
+                    20,
+                    30,
+                    40,
+                    100,
+                ),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line_with_display_cost("2026-01-02T10:00:00.000Z", 0.0),
+            ]
+            .join("\n"),
+        );
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            ..SharedArgs::default()
+        };
+        let entries = load_entries_from_paths(
+            &shared,
+            vec![fixture.path("sessions")],
+            None,
+            PiLoadScope::Default,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "root");
+    }
+
+    #[test]
+    fn dedupes_replay_when_raw_total_underreports_billable_usage() {
+        let fixture = Fixture::new();
+        let parent = fixture.write_file(
+            "sessions/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line_with_model_and_total(
+                    "2026-01-02T10:00:00.000Z",
+                    "gpt-5",
+                    10,
+                    20,
+                    30,
+                    40,
+                    100,
+                ),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "sessions/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line_with_model_and_total(
+                    "2026-01-02T10:00:00.000Z",
+                    "gpt-5",
+                    10,
+                    20,
+                    30,
+                    40,
+                    99,
+                ),
+                usage_line("2026-01-03T01:00:00.000Z", 1, 2, 3, 4),
+            ]
+            .join("\n"),
+        );
+
+        for single_thread in [true, false] {
+            let shared = SharedArgs {
+                mode: CostMode::Display,
+                single_thread,
+                ..SharedArgs::default()
+            };
+            let entries = load_entries_from_paths(
+                &shared,
+                vec![fixture.path("sessions")],
+                None,
+                PiLoadScope::Default,
+            )
+            .unwrap();
+
+            assert_eq!(entries.len(), 2, "single_thread={single_thread}");
+            let child_entries = entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child")
+                .collect::<Vec<_>>();
+            assert_eq!(child_entries.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                child_entries[0].data.message.usage.input_tokens, 1,
+                "single_thread={single_thread}"
+            );
+        }
+    }
+
+    #[test]
+    fn matches_parent_files_across_multiple_paths_of_one_named_store() {
+        let fixture = Fixture::new();
+        let first_store = fixture.create_dir_all("first");
+        let second_store = fixture.create_dir_all("second");
+        let parent = fixture.write_file(
+            "first/project-a/root.jsonl",
+            [
+                session_line("root", "2026-01-01T00:00:00.000Z", None),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+            ]
+            .join("\n"),
+        );
+        let _ = fixture.write_file(
+            "second/project-a/child.jsonl",
+            [
+                session_line("child", "2026-01-03T00:00:00.000Z", Some(&parent)),
+                usage_line("2026-01-02T10:00:00.000Z", 100, 10, 20, 3),
+                usage_line("2026-01-03T01:00:00.000Z", 50, 5, 6, 1),
+            ]
+            .join("\n"),
+        );
+
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            single_thread: false,
+            ..SharedArgs::default()
+        };
+        let entries =
+            load_entries_for_store_paths(&shared, vec![first_store, second_store], "omp", None)
+                .unwrap();
+
+        assert_eq!(entries.len(), 2);
+        assert_eq!(
+            entries
+                .iter()
+                .filter(|entry| entry.session_id.as_ref() == "child")
+                .count(),
+            1
+        );
+        assert_eq!(entries[1].model.as_deref(), Some("[omp] gpt-5"));
+    }
 }

--- a/rust/adapters/pi/src/parser.rs
+++ b/rust/adapters/pi/src/parser.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     sync::Arc,
@@ -28,7 +29,24 @@ struct PiLine {
         deserialize_with = "jsonl::non_empty_string"
     )]
     parent_session: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
     message: Option<PiMessage>,
+}
+
+/// The link fields carried by every tree-format pi session entry.
+#[derive(Debug, Deserialize)]
+struct PiEntryLink {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    r#type: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(
+        rename = "parentId",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    parent_id: Option<String>,
 }
 
 /// The pi `message` block carried by assistant records.
@@ -76,28 +94,66 @@ struct PiCost {
 }
 
 #[derive(Debug, Clone)]
-pub(super) struct PiSessionHeader {
-    pub(super) parent_session: Option<PathBuf>,
-    pub(super) parent_session_is_malformed: bool,
-    pub(super) timestamp: Option<crate::TimestampMs>,
+pub(crate) struct PiSessionHeader {
+    pub(crate) parent_session: Option<PathBuf>,
+    pub(crate) parent_session_is_malformed: bool,
+    pub(crate) timestamp: Option<crate::TimestampMs>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub(super) struct PiUsageSignature {
-    pub(super) timestamp: crate::TimestampMs,
-    pub(super) model: Option<String>,
-    pub(super) input_tokens: u64,
-    pub(super) output_tokens: u64,
-    pub(super) cache_creation_input_tokens: u64,
-    pub(super) cache_read_input_tokens: u64,
-    pub(super) effective_total_tokens: u64,
-    pub(super) billed_cost_bits: Option<u64>,
+struct PiUsageSignature {
+    timestamp: crate::TimestampMs,
+    model: Option<String>,
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_creation_input_tokens: u64,
+    cache_read_input_tokens: u64,
+    effective_total_tokens: u64,
+    billed_cost_bits: Option<u64>,
 }
 
-pub(super) struct PiSessionData {
-    pub(super) header: Option<PiSessionHeader>,
-    pub(super) usage: Vec<PiUsageSignature>,
-    pub(super) entries: Vec<LoadedEntry>,
+struct PiUsageRecord {
+    signature: PiUsageSignature,
+    entry_id: Option<String>,
+}
+
+enum PiReplayUsagePath {
+    Linear,
+    Active(Vec<usize>),
+    Invalid,
+}
+
+pub(crate) struct PiSessionData {
+    pub(crate) header: Option<PiSessionHeader>,
+    usage: Vec<PiUsageRecord>,
+    replay_usage_path: PiReplayUsagePath,
+    pub(crate) entries: Vec<LoadedEntry>,
+}
+
+impl PiSessionData {
+    pub(crate) fn matching_replay_prefix(
+        &self,
+        child: &Self,
+        fork_timestamp: crate::TimestampMs,
+    ) -> Option<usize> {
+        if matches!(&child.replay_usage_path, PiReplayUsagePath::Invalid) {
+            return None;
+        }
+
+        match &self.replay_usage_path {
+            PiReplayUsagePath::Linear => Some(matching_replay_prefix(
+                child.usage.iter().map(|usage| &usage.signature),
+                self.usage.iter().map(|usage| &usage.signature),
+                fork_timestamp,
+            )),
+            PiReplayUsagePath::Active(indices) => Some(matching_replay_prefix(
+                child.usage.iter().map(|usage| &usage.signature),
+                indices.iter().map(|&index| &self.usage[index].signature),
+                fork_timestamp,
+            )),
+            PiReplayUsagePath::Invalid => None,
+        }
+    }
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
@@ -111,7 +167,7 @@ pub fn read_session_file(
 }
 
 #[cfg_attr(not(test), allow(dead_code))]
-pub(super) fn read_session_file_for_store(
+fn read_session_file_for_store(
     path: &Path,
     store_root: &Path,
     tz: Option<&JiffTimeZone>,
@@ -122,7 +178,7 @@ pub(super) fn read_session_file_for_store(
     Ok(read_session_file_data_for_store(path, store_root, tz, mode, pricing, store_name)?.entries)
 }
 
-pub(super) fn read_session_file_data(
+pub(crate) fn read_session_file_data(
     path: &Path,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
@@ -131,7 +187,7 @@ pub(super) fn read_session_file_data(
     read_session_file_data_with_context(path, tz, mode, pricing, PiStoreContext::Default)
 }
 
-pub(super) fn read_session_file_data_for_store(
+pub(crate) fn read_session_file_data_for_store(
     path: &Path,
     store_root: &Path,
     tz: Option<&JiffTimeZone>,
@@ -231,7 +287,7 @@ fn read_session_file_data_with_context(
     // `message` object, so require both substrings before JSON parsing.
     let prefilter = LinePrefilter::all(&[br#""usage""#, br#""message""#]);
     let mut entries = Vec::new();
-    let mut usage_signatures = Vec::new();
+    let mut usage_records = Vec::new();
 
     for record in jsonl::records::<PiLine>(&content, Some(&prefilter)) {
         if !is_pi_message_usage(&record) {
@@ -279,16 +335,19 @@ fn read_session_file_data_with_context(
             mode,
             pricing,
         );
-        usage_signatures.push(PiUsageSignature {
-            timestamp,
-            model: raw_model.clone(),
-            input_tokens: usage.input_tokens,
-            output_tokens: usage.output_tokens,
-            cache_creation_input_tokens: usage.cache_creation_input_tokens,
-            cache_read_input_tokens: usage.cache_read_input_tokens,
-            effective_total_tokens: crate::total_usage_tokens(usage)
-                .saturating_add(extra_total_tokens),
-            billed_cost_bits: replay_billed_cost_bits(mode, cost),
+        usage_records.push(PiUsageRecord {
+            signature: PiUsageSignature {
+                timestamp,
+                model: raw_model.clone(),
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_creation_input_tokens: usage.cache_creation_input_tokens,
+                cache_read_input_tokens: usage.cache_read_input_tokens,
+                effective_total_tokens: crate::total_usage_tokens(usage)
+                    .saturating_add(extra_total_tokens),
+                billed_cost_bits: replay_billed_cost_bits(mode, cost),
+            },
+            entry_id: record.id.clone(),
         });
         let missing_pricing_model = context.missing_pricing_model(
             raw_model.as_deref(),
@@ -330,9 +389,90 @@ fn read_session_file_data_with_context(
     }
     Ok(PiSessionData {
         header,
-        usage: usage_signatures,
+        replay_usage_path: replay_usage_path(&content, &usage_records),
+        usage: usage_records,
         entries,
     })
+}
+
+fn matching_replay_prefix<'a>(
+    child_usage: impl Iterator<Item = &'a PiUsageSignature>,
+    parent_usage: impl Iterator<Item = &'a PiUsageSignature>,
+    fork_timestamp: crate::TimestampMs,
+) -> usize {
+    child_usage
+        .zip(parent_usage.take_while(|usage| usage.timestamp <= fork_timestamp))
+        .take_while(|(child, parent)| child == parent)
+        .count()
+}
+
+fn replay_usage_path(content: &[u8], usage: &[PiUsageRecord]) -> PiReplayUsagePath {
+    let links = jsonl::records::<PiEntryLink>(content, None)
+        .filter(|link| link.r#type.as_deref() != Some("session"))
+        .collect::<Vec<_>>();
+    if links
+        .iter()
+        .all(|link| link.id.is_none() && link.parent_id.is_none())
+    {
+        // Version 1 sessions predate entry links, so their physical order is
+        // the only available linear history.
+        return PiReplayUsagePath::Linear;
+    }
+
+    let mut parents_by_id = HashMap::new();
+    let mut leaf_id = None;
+    for link in links {
+        // A partially linked session cannot identify an active branch safely.
+        let Some(id) = link.id else {
+            return PiReplayUsagePath::Invalid;
+        };
+        if parents_by_id.insert(id.clone(), link.parent_id).is_some() {
+            return PiReplayUsagePath::Invalid;
+        }
+        leaf_id = Some(id);
+    }
+    let Some(mut entry_id) = leaf_id else {
+        return PiReplayUsagePath::Linear;
+    };
+    if parents_by_id
+        .values()
+        .filter(|parent| parent.is_none())
+        .count()
+        != 1
+        || parents_by_id
+            .values()
+            .flatten()
+            .any(|parent| !parents_by_id.contains_key(parent))
+    {
+        return PiReplayUsagePath::Invalid;
+    }
+
+    let usage_by_id = usage
+        .iter()
+        .enumerate()
+        .filter_map(|(index, usage)| usage.entry_id.as_deref().map(|id| (id, index)))
+        .collect::<HashMap<_, _>>();
+    let mut active_usage = Vec::new();
+    let mut visited = HashSet::new();
+    loop {
+        // Pi writes the current leaf last; walking its parents excludes sibling
+        // branches that remain earlier in the same physical JSONL file.
+        if !visited.insert(entry_id.clone()) {
+            return PiReplayUsagePath::Invalid;
+        }
+        if let Some(&usage_index) = usage_by_id.get(entry_id.as_str()) {
+            active_usage.push(usage_index);
+        }
+        let Some(parent_id) = parents_by_id.get(&entry_id) else {
+            return PiReplayUsagePath::Invalid;
+        };
+        let Some(parent_id) = parent_id else {
+            break;
+        };
+        entry_id = parent_id.clone();
+    }
+    active_usage.reverse();
+    PiReplayUsagePath::Active(active_usage)
 }
 
 fn replay_billed_cost_bits(mode: CostMode, cost: f64) -> Option<u64> {
@@ -410,7 +550,7 @@ fn extract_project_for_store(path: &Path, store_root: &Path) -> String {
     extract_project(path)
 }
 
-pub(super) fn entry_id(entry: &LoadedEntry) -> String {
+pub(crate) fn entry_id(entry: &LoadedEntry) -> String {
     entry_id_for_store("pi", entry)
 }
 
@@ -476,7 +616,7 @@ fn store_pricing(
         .or_else(|| raw_model.and_then(|model| pricing.find(model)))
 }
 
-pub(super) fn entry_id_for_store(store_name: &str, entry: &LoadedEntry) -> String {
+pub(crate) fn entry_id_for_store(store_name: &str, entry: &LoadedEntry) -> String {
     [
         store_name,
         entry.project.as_ref(),

--- a/rust/adapters/pi/src/parser.rs
+++ b/rust/adapters/pi/src/parser.rs
@@ -1,4 +1,8 @@
-use std::{fs, path::Path, sync::Arc};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
 
 use jiff::tz::TimeZone as JiffTimeZone;
 use serde::Deserialize;
@@ -18,6 +22,12 @@ struct PiLine {
     r#type: Option<String>,
     #[serde(default, deserialize_with = "jsonl::non_empty_string")]
     timestamp: Option<String>,
+    #[serde(
+        rename = "parentSession",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    parent_session: Option<String>,
     message: Option<PiMessage>,
 }
 
@@ -65,15 +75,42 @@ struct PiCost {
     total: Option<f64>,
 }
 
+#[derive(Debug, Clone)]
+pub(super) struct PiSessionHeader {
+    pub(super) parent_session: Option<PathBuf>,
+    pub(super) parent_session_is_malformed: bool,
+    pub(super) timestamp: Option<crate::TimestampMs>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct PiUsageSignature {
+    pub(super) timestamp: crate::TimestampMs,
+    pub(super) model: Option<String>,
+    pub(super) input_tokens: u64,
+    pub(super) output_tokens: u64,
+    pub(super) cache_creation_input_tokens: u64,
+    pub(super) cache_read_input_tokens: u64,
+    pub(super) effective_total_tokens: u64,
+    pub(super) billed_cost_bits: Option<u64>,
+}
+
+pub(super) struct PiSessionData {
+    pub(super) header: Option<PiSessionHeader>,
+    pub(super) usage: Vec<PiUsageSignature>,
+    pub(super) entries: Vec<LoadedEntry>,
+}
+
+#[cfg_attr(not(test), allow(dead_code))]
 pub fn read_session_file(
     path: &Path,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
 ) -> Result<Vec<LoadedEntry>> {
-    read_session_file_with_context(path, tz, mode, pricing, PiStoreContext::Default)
+    Ok(read_session_file_data(path, tz, mode, pricing)?.entries)
 }
 
+#[cfg_attr(not(test), allow(dead_code))]
 pub(super) fn read_session_file_for_store(
     path: &Path,
     store_root: &Path,
@@ -82,7 +119,27 @@ pub(super) fn read_session_file_for_store(
     pricing: Option<&PricingMap>,
     store_name: &str,
 ) -> Result<Vec<LoadedEntry>> {
-    read_session_file_with_context(
+    Ok(read_session_file_data_for_store(path, store_root, tz, mode, pricing, store_name)?.entries)
+}
+
+pub(super) fn read_session_file_data(
+    path: &Path,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Result<PiSessionData> {
+    read_session_file_data_with_context(path, tz, mode, pricing, PiStoreContext::Default)
+}
+
+pub(super) fn read_session_file_data_for_store(
+    path: &Path,
+    store_root: &Path,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+    store_name: &str,
+) -> Result<PiSessionData> {
+    read_session_file_data_with_context(
         path,
         tz,
         mode,
@@ -159,20 +216,22 @@ impl<'a> PiStoreContext<'a> {
     }
 }
 
-fn read_session_file_with_context(
+fn read_session_file_data_with_context(
     path: &Path,
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
     context: PiStoreContext<'_>,
-) -> Result<Vec<LoadedEntry>> {
+) -> Result<PiSessionData> {
     let content = fs::read(path)?;
     let project = context.project(path);
     let session_id = extract_session_id(path);
+    let header = parse_session_header(&content);
     // Usable pi lines carry token counts under a `usage` key nested in a
     // `message` object, so require both substrings before JSON parsing.
     let prefilter = LinePrefilter::all(&[br#""usage""#, br#""message""#]);
     let mut entries = Vec::new();
+    let mut usage_signatures = Vec::new();
 
     for record in jsonl::records::<PiLine>(&content, Some(&prefilter)) {
         if !is_pi_message_usage(&record) {
@@ -208,10 +267,10 @@ fn read_session_file_with_context(
             continue;
         }
         let raw_model = message.model.clone();
+        let display_cost = usage_value.cost.as_ref().and_then(|cost| cost.total);
         let model = raw_model
             .as_ref()
             .map(|model| format!("[{}] {model}", context.store_name()));
-        let display_cost = usage_value.cost.as_ref().and_then(|cost| cost.total);
         let cost = context.cost(
             raw_model.as_deref(),
             model.as_deref(),
@@ -220,6 +279,17 @@ fn read_session_file_with_context(
             mode,
             pricing,
         );
+        usage_signatures.push(PiUsageSignature {
+            timestamp,
+            model: raw_model.clone(),
+            input_tokens: usage.input_tokens,
+            output_tokens: usage.output_tokens,
+            cache_creation_input_tokens: usage.cache_creation_input_tokens,
+            cache_read_input_tokens: usage.cache_read_input_tokens,
+            effective_total_tokens: crate::total_usage_tokens(usage)
+                .saturating_add(extra_total_tokens),
+            billed_cost_bits: replay_billed_cost_bits(mode, cost),
+        });
         let missing_pricing_model = context.missing_pricing_model(
             raw_model.as_deref(),
             model.as_deref(),
@@ -258,7 +328,40 @@ fn read_session_file_with_context(
             missing_pricing_model,
         });
     }
-    Ok(entries)
+    Ok(PiSessionData {
+        header,
+        usage: usage_signatures,
+        entries,
+    })
+}
+
+fn replay_billed_cost_bits(mode: CostMode, cost: f64) -> Option<u64> {
+    if mode == CostMode::Calculate {
+        return None;
+    }
+    Some(if cost == 0.0 {
+        0.0_f64.to_bits()
+    } else {
+        cost.to_bits()
+    })
+}
+
+fn parse_session_header(content: &[u8]) -> Option<PiSessionHeader> {
+    let first_line = content.split(|byte| *byte == b'\n').next()?;
+    let value = serde_json::from_slice::<serde_json::Value>(first_line).ok()?;
+    let header = serde_json::from_value::<PiLine>(value.clone()).ok()?;
+    (header.r#type.as_deref() == Some("session")).then(|| PiSessionHeader {
+        parent_session: header.parent_session.map(PathBuf::from),
+        parent_session_is_malformed: value.get("parentSession").is_some_and(|parent| {
+            !parent
+                .as_str()
+                .is_some_and(|parent| !parent.trim().is_empty())
+        }),
+        timestamp: header
+            .timestamp
+            .as_deref()
+            .and_then(crate::parse_ts_timestamp),
+    })
 }
 
 fn is_pi_message_usage(record: &PiLine) -> bool {

--- a/rust/adapters/pi/src/parser.rs
+++ b/rust/adapters/pi/src/parser.rs
@@ -436,13 +436,9 @@ fn replay_usage_path(content: &[u8], usage: &[PiUsageRecord]) -> PiReplayUsagePa
     };
     if parents_by_id
         .values()
-        .filter(|parent| parent.is_none())
-        .count()
-        != 1
-        || parents_by_id
-            .values()
-            .flatten()
-            .any(|parent| !parents_by_id.contains_key(parent))
+        .flatten()
+        .any(|parent| !parents_by_id.contains_key(parent))
+        || has_cyclic_entry_links(&parents_by_id)
     {
         return PiReplayUsagePath::Invalid;
     }
@@ -473,6 +469,32 @@ fn replay_usage_path(content: &[u8], usage: &[PiUsageRecord]) -> PiReplayUsagePa
     }
     active_usage.reverse();
     PiReplayUsagePath::Active(active_usage)
+}
+
+fn has_cyclic_entry_links(parents_by_id: &HashMap<String, Option<String>>) -> bool {
+    let mut validated = HashSet::new();
+    for start in parents_by_id.keys() {
+        if validated.contains(start) {
+            continue;
+        }
+
+        let mut path = HashSet::new();
+        let mut entry_id = start.clone();
+        while !validated.contains(&entry_id) {
+            if !path.insert(entry_id.clone()) {
+                return true;
+            }
+            let Some(parent_id) = parents_by_id.get(&entry_id) else {
+                return true;
+            };
+            let Some(parent_id) = parent_id else {
+                break;
+            };
+            entry_id = parent_id.clone();
+        }
+        validated.extend(path);
+    }
+    false
 }
 
 fn replay_billed_cost_bits(mode: CostMode, cost: f64) -> Option<u64> {


### PR DESCRIPTION
## Summary

- suppress only the copied prefix of a Pi fork session
- keep mismatched child usage and all fail-open lineage cases
- compare effective billable usage, including cost-mode-specific behavior

## Validation

- cargo test -p ccusage-adapter-pi
- cargo test -p ccusage-adapter-all
- cargo fmt --check

Fixes #1634

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses duplicate usage in Pi fork session replays so copied parent history is no longer charged twice. Previously the entire parent stream was replayed; now only a leading prefix matching the parent's active root-to-leaf branch up to the fork timestamp is removed, leaving child-specific usage, mismatched records, and abandoned or disconnected parent branches intact. Sessions without entry links fall back to physical order.

- Only suppresses replay when the parent file is found in the same store and lineage is valid; missing, malformed, self-referential, or cyclic lineage fails open.
- Matching compares timestamp, model, token fields, effective total-token fallback, and billed cost in Display/Auto mode; Calculate mode ignores stored cost.
- Fixes #1634.

<sup>Written for commit 28189625fbd22b04e7c7abd46019e9c7c48c723c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved forked-session replay to follow the active conversation path and prevent duplicate usage entries.
  * Added safeguards for missing, malformed, self-referential, or cyclic session history.
  * Preserved valid usage and billing details across nested forks, multiple stores, and file paths.
  * Improved matching of replayed usage records, including token and billing information.

* **Documentation**
  * Clarified how parent candidates are determined in tree-formatted sessions, including abandoned branches and disconnected roots.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->