### PR TITLE
fix(claude): scope session totals to date window

### DIFF
--- a/docs/guide/session-reports.md
+++ b/docs/guide/session-reports.md
@@ -87,8 +87,8 @@ Sessions are displayed using the last two segments of their full identifier:
 
 - **Input/Output Tokens**: Total tokens exchanged in the conversation
 - **Cache Tokens**: Cache creation and read tokens for context efficiency
-- **Cost**: Estimated USD cost for the entire conversation
-- **Last Activity**: Date of the most recent message in the session
+- **Cost**: Estimated USD cost for the usage shown; without a date filter, the entire conversation
+- **Last Activity**: Date of the most recent message included in the report
 
 ### Sorting
 
@@ -120,18 +120,20 @@ ccusage session -i <session-id>
 
 ### Date Filtering
 
-Filter sessions by their last activity date:
+For Claude Code, filter session usage by the local date of each entry:
 
 ```bash
 # Show sessions active since May 10th
-ccusage session --since 20260510
+ccusage claude session --since 20260510
 
 # Show sessions active in a specific date range
-ccusage session --since 20260501 --until 20260516
+ccusage claude session --since 20260501 --until 20260516
 
 # Show only recent sessions (last week)
-ccusage session --since $(date -d '7 days ago' +%Y%m%d)
+ccusage claude session --since $(date -d '7 days ago' +%Y%m%d)
 ```
+
+For `ccusage claude session`, date filters are applied before session totals are calculated, so token and cost totals represent only the entries inside the selected window. Both bounds are inclusive, and `--timezone` determines the local date used for filtering.
 
 ### Cost Calculation Modes
 

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -6,14 +6,15 @@ use std::{
     time::{SystemTime, UNIX_EPOCH},
 };
 
+use ccusage_adapter_common::filter_loaded_entries_by_date;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
 use crate::pricing::PricingMap;
 use crate::{
     BucketKind, Color, Context, DEFAULT_RECENT_DAYS, DEFAULT_SESSION_DURATION_HOURS,
-    MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, block_json,
-    calculate_burn_rate,
+    MILLIS_PER_DAY, MILLIS_PER_MINUTE, Result, SessionAccumulator, TimestampMs, UsageSummary,
+    block_json, calculate_burn_rate,
     cli::{
         BlocksArgs, CostSource, DailyArgs, SessionArgs, SharedArgs, SortOrder, StatuslineArgs,
         VisualBurnRate, WeekDay, WeeklyArgs,
@@ -149,43 +150,7 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
 
     let mut session_shared = shared.clone();
     session_shared.order = SortOrder::Desc;
-    let entries = load_entries(&session_shared, None)?;
-    let mut grouped = Vec::<SessionAccumulator>::new();
-    let mut group_indexes = FxHashMap::<(Arc<str>, Arc<str>), usize>::default();
-    for entry in &entries {
-        let key = (
-            Arc::clone(&entry.project_path),
-            Arc::clone(&entry.session_id),
-        );
-        let index = *group_indexes.entry(key).or_insert_with(|| {
-            let index = grouped.len();
-            grouped.push(SessionAccumulator::default());
-            index
-        });
-        grouped[index].add_entry(entry);
-    }
-
-    let mut rows = Vec::with_capacity(grouped.len());
-    for group in grouped {
-        rows.push(group.into_summary()?);
-    }
-    if session_shared.since.is_some() || session_shared.until.is_some() {
-        rows.retain(|row| {
-            let date = row
-                .last_activity
-                .as_deref()
-                .unwrap_or_default()
-                .replace('-', "");
-            session_shared
-                .since
-                .as_ref()
-                .is_none_or(|since| &date >= since)
-                && session_shared
-                    .until
-                    .as_ref()
-                    .is_none_or(|until| &date <= until)
-        });
-    }
+    let mut rows = load_session_rows(&session_shared)?;
     rows.retain(|row| {
         row.input_tokens + row.output_tokens + row.cache_creation_tokens + row.cache_read_tokens > 0
     });
@@ -214,8 +179,34 @@ pub(crate) fn run_session(args: SessionArgs) -> Result<()> {
     Ok(())
 }
 
+fn load_session_rows(shared: &SharedArgs) -> Result<Vec<UsageSummary>> {
+    let mut entries = load_entries(shared, None)?;
+    filter_loaded_entries_by_date(&mut entries, shared);
+    let mut grouped = Vec::<SessionAccumulator>::new();
+    let mut group_indexes = FxHashMap::<(Arc<str>, Arc<str>), usize>::default();
+    for entry in &entries {
+        let key = (
+            Arc::clone(&entry.project_path),
+            Arc::clone(&entry.session_id),
+        );
+        let index = *group_indexes.entry(key).or_insert_with(|| {
+            let index = grouped.len();
+            grouped.push(SessionAccumulator::default());
+            index
+        });
+        grouped[index].add_entry(entry);
+    }
+
+    let mut rows = Vec::with_capacity(grouped.len());
+    for group in grouped {
+        rows.push(group.into_summary()?);
+    }
+    Ok(rows)
+}
+
 fn run_session_id(id: &str, shared: &SharedArgs) -> Result<()> {
-    let entries = load_entries(shared, None)?;
+    let mut entries = load_entries(shared, None)?;
+    filter_loaded_entries_by_date(&mut entries, shared);
     let mut session_entries = entries
         .into_iter()
         .filter(|entry| {
@@ -853,7 +844,72 @@ mod tests {
     use ccusage_test_support::{EnvVarGuard, fs_fixture};
 
     use super::*;
-    use crate::cli::{Cli, Command};
+    use crate::cli::{Cli, Command, CostMode};
+
+    #[test]
+    fn claude_session_totals_only_include_entries_inside_date_window() {
+        let rows = claude_session_rows(
+            &[
+                r#"{"timestamp":"2026-08-12T12:00:00.000Z","sessionId":"session-a","requestId":"request-old","costUSD":1.25,"message":{"id":"message-old","model":"claude-sonnet-4-20250514","usage":{"input_tokens":10,"output_tokens":2}}}"#,
+                r#"{"timestamp":"2026-08-13T12:00:00.000Z","sessionId":"session-a","requestId":"request-new","costUSD":2.5,"message":{"id":"message-new","model":"claude-sonnet-4-20250514","usage":{"input_tokens":30,"output_tokens":4}}}"#,
+            ]
+            .join("\n"),
+            SharedArgs {
+                mode: CostMode::Display,
+                since: Some("20260813".to_string()),
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].input_tokens, 30);
+        assert_eq!(rows[0].output_tokens, 4);
+        assert_eq!(rows[0].total_tokens(), 34);
+        assert_eq!(rows[0].total_cost, 2.5);
+    }
+
+    #[test]
+    fn claude_session_until_includes_the_boundary_date() {
+        let rows = claude_session_rows(
+            r#"{"timestamp":"2026-08-14T09:38:56.467Z","sessionId":"session-a","requestId":"request-boundary","costUSD":3.75,"message":{"id":"message-boundary","model":"claude-sonnet-4-20250514","usage":{"input_tokens":40,"output_tokens":5}}}"#,
+            SharedArgs {
+                mode: CostMode::Display,
+                until: Some("20260814".to_string()),
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].total_tokens(), 45);
+        assert_eq!(rows[0].total_cost, 3.75);
+    }
+
+    #[test]
+    fn claude_session_date_window_uses_requested_timezone() {
+        let rows = claude_session_rows(
+            r#"{"timestamp":"2026-08-14T23:30:00.000Z","sessionId":"session-a","requestId":"request-timezone","costUSD":4.5,"message":{"id":"message-timezone","model":"claude-sonnet-4-20250514","usage":{"input_tokens":50,"output_tokens":6}}}"#,
+            SharedArgs {
+                mode: CostMode::Display,
+                since: Some("20260815".to_string()),
+                timezone: Some("Asia/Tokyo".to_string()),
+                ..SharedArgs::default()
+            },
+        );
+
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].total_tokens(), 56);
+        assert_eq!(rows[0].total_cost, 4.5);
+    }
+
+    fn claude_session_rows(log: &str, shared: SharedArgs) -> Vec<UsageSummary> {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": log,
+        });
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        load_session_rows(&shared).unwrap()
+    }
 
     #[test]
     fn statusline_invocation_passes_config_pricing_overrides_to_cost_loading() {


### PR DESCRIPTION
## Summary
- Filter Claude session entries before aggregating totals.
- Respect inclusive date bounds and the selected timezone.
- Document the behavior for the Claude session command only.

Fixes #1609

## Tests
- cargo test -p ccusage
- cargo test -p ccusage-adapter-claude
- just docs::typecheck
- cargo fmt --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Session reports now support date-range filtering, including inclusive start and end dates.
  - Date filtering respects the selected timezone and is applied before session totals are calculated.
  - Individual session reports now apply the same date filtering as session summaries.

- **Documentation**
  - Clarified that Cost represents estimated USD usage and Last Activity reflects the latest included message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->