### PR TITLE
fix(codex): skip history outside date window

### DIFF
--- a/rust/adapters/codex/README.md
+++ b/rust/adapters/codex/README.md
@@ -31,7 +31,7 @@ chunking, and ordered parallel reads.
 - `aggregate::aggregate_events`
 - `aggregate::filter_events_by_date`
 - `aggregate::load_groups`
-- `loader::load_codex_events`
+- `loader::load_codex_events_with_detection`
 - `loader::load_codex_events_from_directory`
 - `report::calculate_codex_model_cost`
 - `report::calculate_group_cost`

--- a/rust/adapters/codex/src/aggregate.rs
+++ b/rust/adapters/codex/src/aggregate.rs
@@ -839,7 +839,7 @@ mod tests {
         };
 
         for single_thread in [true, false] {
-            let _ = replay::take_observed_file_reads();
+            let _ = replay::take_observed_file_read_events();
             let bounded = load_groups_from_directory(
                 &fixture.path("sessions"),
                 &SharedArgs {
@@ -854,9 +854,19 @@ mod tests {
             assert_eq!(group.output_tokens, 1);
             assert_eq!(group.total_tokens, 101);
             if single_thread {
-                let reads = replay::take_observed_file_reads();
-                assert!(reads.contains(&long_running_path));
-                assert!(!reads.contains(&historical_path));
+                let reads = replay::take_observed_file_read_events();
+                assert!(reads.iter().any(|read| matches!(
+                    read,
+                    replay::ObservedFileRead::MetadataProbe(path) if path == &long_running_path
+                )));
+                assert!(reads.iter().any(|read| matches!(
+                    read,
+                    replay::ObservedFileRead::MetadataProbe(path) if path == &historical_path
+                )));
+                assert!(!reads.iter().any(|read| matches!(
+                    read,
+                    replay::ObservedFileRead::ParentUsage(path) if path == &historical_path
+                )));
             }
 
             let unbounded = load_groups_from_directory(

--- a/rust/adapters/codex/src/aggregate.rs
+++ b/rust/adapters/codex/src/aggregate.rs
@@ -109,7 +109,7 @@ fn load_groups_from_sources(
             aggregate_files_with_dedupe(
                 &CodexAggregateRun {
                     sessions_dir: &group.dir,
-                    files: &files,
+                    files,
                     shared,
                     kind,
                     replay_plan: &replay_plan,

--- a/rust/adapters/codex/src/aggregate.rs
+++ b/rust/adapters/codex/src/aggregate.rs
@@ -75,21 +75,41 @@ fn load_groups_from_sources(
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
     let file_groups = paths::collect_deduped_codex_usage_files(sources);
-    let replay_plan = CodexReplayPlan::new(
-        file_groups
-            .iter()
-            .map(|group| (group.dir.as_path(), group.files.as_slice())),
-        shared.single_thread,
-    );
+    let files_by_group = file_groups
+        .iter()
+        .map(|group| paths::filter_codex_usage_files(&group.dir, &group.files, shared))
+        .collect::<Vec<_>>();
+    let replay_plan = if shared.since.is_some() || shared.until.is_some() {
+        CodexReplayPlan::for_bounded_files(
+            file_groups
+                .iter()
+                .zip(&files_by_group)
+                .map(|(group, files)| (group.dir.as_path(), files.as_slice())),
+            file_groups
+                .iter()
+                .map(|group| (group.dir.as_path(), group.files.as_slice())),
+            shared.single_thread,
+        )
+    } else {
+        CodexReplayPlan::new(
+            file_groups
+                .iter()
+                .map(|group| (group.dir.as_path(), group.files.as_slice())),
+            shared.single_thread,
+        )
+    };
     let mut groups = BTreeMap::new();
     let seen = create_dedupe_shards();
-    for group in &file_groups {
+    for (group, files) in file_groups.iter().zip(&files_by_group) {
+        if files.is_empty() {
+            continue;
+        }
         merge_groups(
             &mut groups,
             aggregate_files_with_dedupe(
                 &CodexAggregateRun {
                     sessions_dir: &group.dir,
-                    files: &group.files,
+                    files: &files,
                     shared,
                     kind,
                     replay_plan: &replay_plan,
@@ -107,9 +127,17 @@ pub(super) fn load_groups_from_directory(
     shared: &SharedArgs,
     kind: AgentReportKind,
 ) -> Result<BTreeMap<String, CodexGroup>> {
-    let files = paths::collect_codex_usage_files(sessions_dir);
-    let replay_plan =
-        CodexReplayPlan::new([(sessions_dir, files.as_slice())], shared.single_thread);
+    let all_files = paths::collect_codex_usage_files(sessions_dir);
+    let files = paths::filter_codex_usage_files(sessions_dir, &all_files, shared);
+    let replay_plan = if shared.since.is_some() || shared.until.is_some() {
+        CodexReplayPlan::for_bounded_files(
+            [(sessions_dir, files.as_slice())],
+            [(sessions_dir, all_files.as_slice())],
+            shared.single_thread,
+        )
+    } else {
+        CodexReplayPlan::new([(sessions_dir, all_files.as_slice())], shared.single_thread)
+    };
     let run = CodexAggregateRun {
         sessions_dir,
         files: &files,
@@ -678,7 +706,7 @@ mod tests {
 
     use crate::{
         CodexModelUsage, PricingMap, cli::CodexSpeed, model_aliases::set_model_aliases_for_tests,
-        paths::CodexUsageSource,
+        paths::CodexUsageSource, replay,
     };
 
     #[test]
@@ -745,6 +773,153 @@ mod tests {
             ),
             None,
         );
+    }
+
+    #[test]
+    fn skips_historical_files_before_parsing_but_keeps_long_running_sessions() {
+        let usage_line = |timestamp: &str, input_tokens: u64| {
+            json!({
+                "timestamp": timestamp,
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5",
+                        "last_token_usage": {
+                            "input_tokens": input_tokens,
+                            "cached_input_tokens": 0,
+                            "output_tokens": 1,
+                            "total_tokens": input_tokens + 1,
+                        },
+                    },
+                },
+            })
+            .to_string()
+        };
+        let historical = [
+            json!({
+                "timestamp": "2025-01-01T08:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "historical"},
+            })
+            .to_string(),
+            usage_line("2026-03-15T08:01:00.000Z", 999),
+        ]
+        .join("\n");
+        let long_running = [
+            json!({
+                "timestamp": "2026-01-01T08:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "long-running"},
+            })
+            .to_string(),
+            usage_line("2026-01-01T08:01:00.000Z", 10),
+            usage_line("2026-03-15T08:01:00.000Z", 100),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/historical.jsonl": &historical,
+            "sessions/2026/01/01/long-running.jsonl": &long_running,
+        });
+        let historical_path = fixture.path("sessions/2025/01/01/historical.jsonl");
+        let long_running_path = fixture.path("sessions/2026/01/01/long-running.jsonl");
+        crate::paths::set_file_modified(
+            &historical_path,
+            parse_ts_timestamp("2025-01-01T08:01:00.000Z").unwrap(),
+        );
+        crate::paths::set_file_modified(
+            &long_running_path,
+            parse_ts_timestamp("2026-03-15T08:01:00.000Z").unwrap(),
+        );
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for single_thread in [true, false] {
+            let _ = replay::take_observed_file_reads();
+            let bounded = load_groups_from_directory(
+                &fixture.path("sessions"),
+                &SharedArgs {
+                    single_thread,
+                    ..shared.clone()
+                },
+                AgentReportKind::Daily,
+            )
+            .unwrap();
+            let group = &bounded["2026-03-15"];
+            assert_eq!(group.input_tokens, 100);
+            assert_eq!(group.output_tokens, 1);
+            assert_eq!(group.total_tokens, 101);
+            if single_thread {
+                let reads = replay::take_observed_file_reads();
+                assert!(reads.contains(&long_running_path));
+                assert!(!reads.contains(&historical_path));
+            }
+
+            let unbounded = load_groups_from_directory(
+                &fixture.path("sessions"),
+                &SharedArgs {
+                    single_thread,
+                    ..SharedArgs::default()
+                },
+                AgentReportKind::Daily,
+            )
+            .unwrap();
+            assert_eq!(unbounded["2026-03-15"].input_tokens, 1_099);
+        }
+    }
+
+    #[test]
+    fn retains_next_utc_path_day_for_local_until_boundary() {
+        let late_utc = [
+            json!({
+                "timestamp": "2026-03-16T06:29:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "late-utc"},
+            })
+            .to_string(),
+            json!({
+                "timestamp": "2026-03-16T06:30:00.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "model": "gpt-5",
+                        "last_token_usage": {
+                            "input_tokens": 100,
+                            "cached_input_tokens": 0,
+                            "output_tokens": 1,
+                            "total_tokens": 101,
+                        },
+                    },
+                },
+            })
+            .to_string(),
+        ]
+        .join("\n");
+        let fixture = fs_fixture!({
+            "sessions/2026/03/16/late-utc.jsonl": &late_utc,
+        });
+        let late_utc_path = fixture.path("sessions/2026/03/16/late-utc.jsonl");
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("America/Los_Angeles".to_string()),
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+
+        let _ = replay::take_observed_file_reads();
+        let groups =
+            load_groups_from_directory(&fixture.path("sessions"), &shared, AgentReportKind::Daily)
+                .unwrap();
+
+        assert_eq!(groups["2026-03-15"].input_tokens, 100);
+        assert_eq!(groups["2026-03-15"].total_tokens, 101);
+        assert!(replay::take_observed_file_reads().contains(&late_utc_path));
     }
 
     #[test]

--- a/rust/adapters/codex/src/lib.rs
+++ b/rust/adapters/codex/src/lib.rs
@@ -15,7 +15,7 @@ use crate::{PricingMap, Result, cli::AgentCommandArgs, log_level, print_json_or_
 pub use aggregate::{aggregate_events, filter_events_by_date, load_groups};
 #[doc(hidden)]
 pub use loader::load_codex_events_from_directory;
-pub use loader::{load_codex_events, load_codex_events_with_detection};
+pub use loader::load_codex_events_with_detection;
 pub use report::{
     calculate_codex_model_cost, calculate_group_cost, codex_model_missing_pricing,
     non_cached_input_tokens,

--- a/rust/adapters/codex/src/lib.rs
+++ b/rust/adapters/codex/src/lib.rs
@@ -13,9 +13,9 @@ mod types;
 use crate::{PricingMap, Result, cli::AgentCommandArgs, log_level, print_json_or_jq, wants_json};
 
 pub use aggregate::{aggregate_events, filter_events_by_date, load_groups};
-pub use loader::load_codex_events;
 #[doc(hidden)]
 pub use loader::load_codex_events_from_directory;
+pub use loader::{load_codex_events, load_codex_events_with_detection};
 pub use report::{
     calculate_codex_model_cost, calculate_group_cost, codex_model_missing_pricing,
     non_cached_input_tokens,

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -12,6 +12,7 @@ use crate::{
 
 use super::{
     parser::visit_codex_session_file,
+    paths,
     paths::{
         CodexUsageSource, codex_usage_sources, collect_codex_usage_files,
         collect_deduped_codex_usage_files,
@@ -25,58 +26,149 @@ pub fn load_codex_events_from_directory(
 ) -> Result<Vec<CodexTokenUsageEvent>> {
     let files = collect_codex_usage_files(sessions_dir);
     let replay_plan = CodexReplayPlan::new([(sessions_dir, files.as_slice())], single_thread);
-    let mut events = if single_thread {
-        files
-            .iter()
-            .flat_map(|file| read_codex_session_file(sessions_dir, file, &replay_plan))
-            .collect::<Vec<_>>()
-    } else {
-        read_codex_session_files_parallel(sessions_dir, &files, &replay_plan)
-    };
+    let mut events =
+        read_codex_events_from_files(sessions_dir, &files, single_thread, &replay_plan);
     dedupe_codex_events(&mut events);
     Ok(events)
 }
 
 pub fn load_codex_events(shared: &SharedArgs) -> Result<Vec<CodexTokenUsageEvent>> {
+    load_codex_events_with_detection(shared).map(|(events, _)| events)
+}
+
+/// Loads Codex usage events and reports whether any source file existed before
+/// date filtering narrowed the files to parse.
+pub fn load_codex_events_with_detection(
+    shared: &SharedArgs,
+) -> Result<(Vec<CodexTokenUsageEvent>, bool)> {
     progress::track_usage_load(progress::UsageLoadAgent("Codex"), shared.json, || {
-        load_codex_events_inner(shared)
+        load_codex_events_from_sources_with_shared(&codex_usage_sources()?, shared)
     })
 }
 
-fn load_codex_events_inner(shared: &SharedArgs) -> Result<Vec<CodexTokenUsageEvent>> {
-    load_codex_events_from_sources(&codex_usage_sources()?, shared.single_thread)
-}
-
+#[cfg(test)]
 fn load_codex_events_from_sources(
     sources: &[CodexUsageSource],
     single_thread: bool,
 ) -> Result<Vec<CodexTokenUsageEvent>> {
+    load_codex_events_from_sources_with_files(sources, single_thread, None)
+        .map(|(events, _)| events)
+}
+
+fn load_codex_events_from_sources_with_shared(
+    sources: &[CodexUsageSource],
+    shared: &SharedArgs,
+) -> Result<(Vec<CodexTokenUsageEvent>, bool)> {
+    load_codex_events_from_sources_with_files(sources, shared.single_thread, Some(shared))
+}
+
+fn load_codex_events_from_sources_with_files(
+    sources: &[CodexUsageSource],
+    single_thread: bool,
+    shared: Option<&SharedArgs>,
+) -> Result<(Vec<CodexTokenUsageEvent>, bool)> {
     if let [source] = sources {
-        return load_codex_events_from_directory(&source.dir, single_thread);
+        if let Some(shared) = shared {
+            return load_codex_events_from_directory_with_shared(&source.dir, shared);
+        }
+        let files = collect_codex_usage_files(&source.dir);
+        let replay_plan =
+            CodexReplayPlan::new([(source.dir.as_path(), files.as_slice())], single_thread);
+        let mut events =
+            read_codex_events_from_files(&source.dir, &files, single_thread, &replay_plan);
+        dedupe_codex_events(&mut events);
+        return Ok((events, false));
     }
 
     let groups = collect_deduped_codex_usage_files(sources);
-    let replay_plan = CodexReplayPlan::new(
-        groups
-            .iter()
-            .map(|group| (group.dir.as_path(), group.files.as_slice())),
-        single_thread,
-    );
-    let mut events = Vec::new();
-    for group in groups {
-        let mut source_events = if single_thread {
-            group
-                .files
+    let detected_before_filter = groups.iter().any(|group| !group.files.is_empty());
+    let files_by_group = groups
+        .iter()
+        .map(|group| {
+            shared.map_or_else(
+                || group.files.clone(),
+                |shared| paths::filter_codex_usage_files(&group.dir, &group.files, shared),
+            )
+        })
+        .collect::<Vec<_>>();
+    let replay_plan = if shared.is_some_and(has_date_bounds) {
+        CodexReplayPlan::for_bounded_files(
+            groups
                 .iter()
-                .flat_map(|file| read_codex_session_file(&group.dir, file, &replay_plan))
-                .collect::<Vec<_>>()
-        } else {
-            read_codex_session_files_parallel(&group.dir, &group.files, &replay_plan)
-        };
+                .zip(&files_by_group)
+                .map(|(group, files)| (group.dir.as_path(), files.as_slice())),
+            groups
+                .iter()
+                .map(|group| (group.dir.as_path(), group.files.as_slice())),
+            single_thread,
+        )
+    } else {
+        CodexReplayPlan::new(
+            groups
+                .iter()
+                .map(|group| (group.dir.as_path(), group.files.as_slice())),
+            single_thread,
+        )
+    };
+    let mut events = Vec::new();
+    for (group, files) in groups.into_iter().zip(files_by_group) {
+        let mut source_events =
+            read_codex_events_from_files(&group.dir, &files, single_thread, &replay_plan);
         events.append(&mut source_events);
     }
     dedupe_codex_events(&mut events);
-    Ok(events)
+    let detected = if shared.is_some_and(|shared| has_date_bounds(shared)) {
+        detected_before_filter
+    } else {
+        !events.is_empty()
+    };
+    Ok((events, detected))
+}
+
+fn load_codex_events_from_directory_with_shared(
+    sessions_dir: &Path,
+    shared: &SharedArgs,
+) -> Result<(Vec<CodexTokenUsageEvent>, bool)> {
+    let all_files = collect_codex_usage_files(sessions_dir);
+    let files = paths::filter_codex_usage_files(sessions_dir, &all_files, shared);
+    let replay_plan = if has_date_bounds(shared) {
+        CodexReplayPlan::for_bounded_files(
+            [(sessions_dir, files.as_slice())],
+            [(sessions_dir, all_files.as_slice())],
+            shared.single_thread,
+        )
+    } else {
+        CodexReplayPlan::new([(sessions_dir, all_files.as_slice())], shared.single_thread)
+    };
+    let mut events =
+        read_codex_events_from_files(sessions_dir, &files, shared.single_thread, &replay_plan);
+    dedupe_codex_events(&mut events);
+    let detected = if has_date_bounds(shared) {
+        !all_files.is_empty()
+    } else {
+        !events.is_empty()
+    };
+    Ok((events, detected))
+}
+
+fn read_codex_events_from_files(
+    sessions_dir: &Path,
+    files: &[PathBuf],
+    single_thread: bool,
+    replay_plan: &CodexReplayPlan,
+) -> Vec<CodexTokenUsageEvent> {
+    if single_thread {
+        files
+            .iter()
+            .flat_map(|file| read_codex_session_file(sessions_dir, file, replay_plan))
+            .collect()
+    } else {
+        read_codex_session_files_parallel(sessions_dir, files, replay_plan)
+    }
+}
+
+fn has_date_bounds(shared: &SharedArgs) -> bool {
+    shared.since.is_some() || shared.until.is_some()
 }
 
 fn read_codex_session_files_parallel(
@@ -2065,6 +2157,65 @@ mod tests {
 
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].total_tokens, 110);
+    }
+
+    #[test]
+    fn bounded_loading_reads_an_old_parent_but_not_unrelated_history() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "parent", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+            "sessions/2025/01/01/unrelated.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "unrelated", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 999),
+            ]
+            .join("\n"),
+            "sessions/2026/03/15/child.jsonl": [
+                replay_metadata("2026-03-15T08:00:00.000Z", "child", Some("parent")),
+                replay_token_count("2026-03-15T08:00:00.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+        let parent = fixture.path("sessions/2025/01/01/parent.jsonl");
+        let unrelated = fixture.path("sessions/2025/01/01/unrelated.jsonl");
+        let child = fixture.path("sessions/2026/03/15/child.jsonl");
+        for path in [&parent, &unrelated] {
+            crate::paths::set_file_modified(
+                path,
+                crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+            );
+        }
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        let sources = [CodexUsageSource::new_for_test(
+            fixture.path("sessions"),
+            fixture.root().to_path_buf(),
+        )];
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            single_thread: true,
+            ..SharedArgs::default()
+        };
+
+        let _ = crate::replay::take_observed_file_reads();
+        let (events, detected) =
+            load_codex_events_from_sources_with_shared(&sources, &shared).unwrap();
+
+        assert!(detected);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].session_id, "2026/03/15/child");
+        assert_eq!(events[0].input_tokens, 50);
+        let reads = crate::replay::take_observed_file_reads();
+        assert!(reads.contains(&child));
+        assert!(reads.contains(&parent));
+        assert!(!reads.contains(&unrelated));
     }
 
     fn replay_metadata(timestamp: &str, id: &str, parent: Option<&str>) -> String {

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -1999,10 +1999,17 @@ mod tests {
             .join("\n"),
         });
 
-        assert_eq!(
-            replay_input_tokens_by_session(fixture.root()),
-            [("self".to_string(), 100), ("self".to_string(), 200)]
-        );
+        for single_thread in [true, false] {
+            let events = load_codex_events_from_directory(fixture.root(), single_thread).unwrap();
+            assert_eq!(
+                events
+                    .iter()
+                    .map(|event| (event.session_id.clone(), event.input_tokens))
+                    .collect::<Vec<_>>(),
+                [("self".to_string(), 100), ("self".to_string(), 200)],
+                "single_thread={single_thread}"
+            );
+        }
     }
 
     #[test]
@@ -2399,6 +2406,52 @@ mod tests {
             assert!(detected, "single_thread={single_thread}");
             assert_eq!(events.len(), 1, "single_thread={single_thread}");
             assert_eq!(events[0].input_tokens, 50, "single_thread={single_thread}");
+        }
+    }
+
+    #[test]
+    fn unbounded_loading_skips_a_self_parent_candidate_for_a_duplicate_parent_id() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/aaa-child.jsonl": [
+                replay_metadata(
+                    "2026-03-15T08:00:00.000Z",
+                    "shared-id",
+                    Some("shared-id"),
+                ),
+                replay_token_count("2026-03-15T08:00:01.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+            "sessions/2025/01/02/zzz-parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "shared-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+        });
+        let child = fixture.path("sessions/2025/01/01/aaa-child.jsonl");
+        let parent = fixture.path("sessions/2025/01/02/zzz-parent.jsonl");
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        crate::paths::set_file_modified(
+            &parent,
+            crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+        );
+
+        for single_thread in [true, false] {
+            let events =
+                load_codex_events_from_directory(&fixture.path("sessions"), single_thread).unwrap();
+            let child_events = events
+                .iter()
+                .filter(|event| event.session_id.ends_with("2025/01/01/aaa-child"))
+                .collect::<Vec<_>>();
+
+            assert_eq!(child_events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                child_events[0].input_tokens, 50,
+                "single_thread={single_thread}"
+            );
         }
     }
 

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -117,7 +117,7 @@ fn load_codex_events_from_sources_with_files(
         events.append(&mut source_events);
     }
     dedupe_codex_events(&mut events);
-    let detected = if shared.is_some_and(|shared| has_date_bounds(shared)) {
+    let detected = if shared.is_some_and(has_date_bounds) {
         detected_before_filter
     } else {
         !events.is_empty()

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -2346,6 +2346,63 @@ mod tests {
     }
 
     #[test]
+    fn bounded_loading_skips_a_self_parent_candidate_for_a_duplicate_parent_id() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/aaa-child.jsonl": [
+                replay_metadata(
+                    "2026-03-15T08:00:00.000Z",
+                    "shared-id",
+                    Some("shared-id"),
+                ),
+                replay_token_count("2026-03-15T08:00:01.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+            "sessions/2025/01/02/zzz-parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "shared-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+        });
+        let child = fixture.path("sessions/2025/01/01/aaa-child.jsonl");
+        let parent = fixture.path("sessions/2025/01/02/zzz-parent.jsonl");
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        crate::paths::set_file_modified(
+            &parent,
+            crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+        );
+        let sources = [CodexUsageSource::new_for_test(
+            fixture.path("sessions"),
+            fixture.root().to_path_buf(),
+        )];
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for single_thread in [true, false] {
+            let _ = crate::replay::take_observed_file_read_events();
+            let (events, detected) = load_codex_events_from_sources_with_shared(
+                &sources,
+                &SharedArgs {
+                    single_thread,
+                    ..shared.clone()
+                },
+            )
+            .unwrap();
+
+            assert!(detected, "single_thread={single_thread}");
+            assert_eq!(events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(events[0].input_tokens, 50, "single_thread={single_thread}");
+        }
+    }
+
+    #[test]
     fn bounded_loading_metadata_probes_history_but_reads_parent_usage_only() {
         let fixture = fs_fixture!({
             "sessions/2025/01/01/parent.jsonl": [

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -2156,7 +2156,197 @@ mod tests {
     }
 
     #[test]
-    fn bounded_loading_reads_an_old_parent_but_not_unrelated_history() {
+    fn bounded_loading_resolves_thread_id_rollout_parent_by_payload_id() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/2025-01-01T08-00-00-thread_id_rollout.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "parent-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+            "sessions/2026/03/15/child.jsonl": [
+                replay_metadata("2026-03-15T08:00:00.000Z", "child", Some("parent-id")),
+                replay_token_count("2026-03-15T08:00:00.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+        let parent =
+            fixture.path("sessions/2025/01/01/2025-01-01T08-00-00-thread_id_rollout.jsonl");
+        let child = fixture.path("sessions/2026/03/15/child.jsonl");
+        crate::paths::set_file_modified(
+            &parent,
+            crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+        );
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        let sources = [CodexUsageSource::new_for_test(
+            fixture.path("sessions"),
+            fixture.root().to_path_buf(),
+        )];
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for single_thread in [true, false] {
+            let (events, detected) = load_codex_events_from_sources_with_shared(
+                &sources,
+                &SharedArgs {
+                    single_thread,
+                    ..shared.clone()
+                },
+            )
+            .unwrap();
+
+            assert!(detected, "single_thread={single_thread}");
+            assert_eq!(events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(
+                events[0].session_id, "2026/03/15/child",
+                "single_thread={single_thread}"
+            );
+            assert_eq!(events[0].input_tokens, 50, "single_thread={single_thread}");
+        }
+    }
+
+    #[test]
+    fn bounded_loading_does_not_select_a_misleading_filename() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/aaa-target-id.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "different-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 999),
+            ]
+            .join("\n"),
+            "sessions/2025/01/02/zzz-actual-parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "target-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+            "sessions/2026/03/15/child.jsonl": [
+                replay_metadata("2026-03-15T08:00:00.000Z", "child", Some("target-id")),
+                replay_token_count("2026-03-15T08:00:00.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+        let misleading = fixture.path("sessions/2025/01/01/aaa-target-id.jsonl");
+        let parent = fixture.path("sessions/2025/01/02/zzz-actual-parent.jsonl");
+        let child = fixture.path("sessions/2026/03/15/child.jsonl");
+        for path in [&misleading, &parent] {
+            crate::paths::set_file_modified(
+                path,
+                crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+            );
+        }
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        let sources = [CodexUsageSource::new_for_test(
+            fixture.path("sessions"),
+            fixture.root().to_path_buf(),
+        )];
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for single_thread in [true, false] {
+            let _ = crate::replay::take_observed_file_read_events();
+            let (events, detected) = load_codex_events_from_sources_with_shared(
+                &sources,
+                &SharedArgs {
+                    single_thread,
+                    ..shared.clone()
+                },
+            )
+            .unwrap();
+
+            assert!(detected, "single_thread={single_thread}");
+            assert_eq!(events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(events[0].input_tokens, 50, "single_thread={single_thread}");
+            if single_thread {
+                let reads = crate::replay::take_observed_file_read_events();
+                assert!(reads.iter().any(|read| matches!(
+                    read,
+                    crate::replay::ObservedFileRead::ParentUsage(path) if path == &parent
+                )));
+                assert!(!reads.iter().any(|read| matches!(
+                    read,
+                    crate::replay::ObservedFileRead::ParentUsage(path) if path == &misleading
+                )));
+            }
+        }
+    }
+
+    #[test]
+    fn bounded_loading_uses_the_first_duplicate_parent_id() {
+        let fixture = fs_fixture!({
+            "sessions/2025/01/01/aaa-first-parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "parent-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 100),
+            ]
+            .join("\n"),
+            "sessions/2025/01/02/zzz-second-parent.jsonl": [
+                replay_metadata("2025-01-01T08:00:00.000Z", "parent-id", None),
+                replay_token_count("2025-01-01T08:01:00.000Z", 200),
+            ]
+            .join("\n"),
+            "sessions/2026/03/15/child.jsonl": [
+                replay_metadata("2026-03-15T08:00:00.000Z", "child", Some("parent-id")),
+                replay_token_count("2026-03-15T08:00:00.000Z", 100),
+                replay_token_count("2026-03-15T08:01:00.000Z", 50),
+            ]
+            .join("\n"),
+        });
+        let first_parent = fixture.path("sessions/2025/01/01/aaa-first-parent.jsonl");
+        let second_parent = fixture.path("sessions/2025/01/02/zzz-second-parent.jsonl");
+        let child = fixture.path("sessions/2026/03/15/child.jsonl");
+        for path in [&first_parent, &second_parent] {
+            crate::paths::set_file_modified(
+                path,
+                crate::parse_ts_timestamp("2025-01-01T08:00:00.000Z").unwrap(),
+            );
+        }
+        crate::paths::set_file_modified(
+            &child,
+            crate::parse_ts_timestamp("2026-03-15T08:00:00.000Z").unwrap(),
+        );
+        let sources = [CodexUsageSource::new_for_test(
+            fixture.path("sessions"),
+            fixture.root().to_path_buf(),
+        )];
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for single_thread in [true, false] {
+            let (events, detected) = load_codex_events_from_sources_with_shared(
+                &sources,
+                &SharedArgs {
+                    single_thread,
+                    ..shared.clone()
+                },
+            )
+            .unwrap();
+
+            assert!(detected, "single_thread={single_thread}");
+            assert_eq!(events.len(), 1, "single_thread={single_thread}");
+            assert_eq!(events[0].session_id, "2026/03/15/child");
+            assert_eq!(events[0].input_tokens, 50, "single_thread={single_thread}");
+        }
+    }
+
+    #[test]
+    fn bounded_loading_metadata_probes_history_but_reads_parent_usage_only() {
         let fixture = fs_fixture!({
             "sessions/2025/01/01/parent.jsonl": [
                 replay_metadata("2025-01-01T08:00:00.000Z", "parent", None),
@@ -2208,10 +2398,21 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].session_id, "2026/03/15/child");
         assert_eq!(events[0].input_tokens, 50);
-        let reads = crate::replay::take_observed_file_reads();
-        assert!(reads.contains(&child));
-        assert!(reads.contains(&parent));
-        assert!(!reads.contains(&unrelated));
+        let reads = crate::replay::take_observed_file_read_events();
+        for path in [&child, &parent, &unrelated] {
+            assert!(reads.iter().any(|read| matches!(
+                read,
+                crate::replay::ObservedFileRead::MetadataProbe(observed) if observed == path
+            )));
+        }
+        let parent_usage_reads = reads
+            .iter()
+            .filter_map(|read| match read {
+                crate::replay::ObservedFileRead::ParentUsage(path) => Some(path.clone()),
+                crate::replay::ObservedFileRead::MetadataProbe(_) => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(parent_usage_reads, vec![parent]);
     }
 
     fn replay_metadata(timestamp: &str, id: &str, parent: Option<&str>) -> String {

--- a/rust/adapters/codex/src/loader.rs
+++ b/rust/adapters/codex/src/loader.rs
@@ -32,10 +32,6 @@ pub fn load_codex_events_from_directory(
     Ok(events)
 }
 
-pub fn load_codex_events(shared: &SharedArgs) -> Result<Vec<CodexTokenUsageEvent>> {
-    load_codex_events_with_detection(shared).map(|(events, _)| events)
-}
-
 /// Loads Codex usage events and reports whether any source file existed before
 /// date filtering narrowed the files to parse.
 pub fn load_codex_events_with_detection(

--- a/rust/adapters/codex/src/paths.rs
+++ b/rust/adapters/codex/src/paths.rs
@@ -172,9 +172,9 @@ fn utc_path_date(millis: i64) -> Option<Date> {
     let timestamp = jiff::Timestamp::from_millisecond(millis).ok()?;
     let zoned = timestamp.to_zoned(JiffTimeZone::get("UTC").ok()?);
     Date::new(
-        i16::from(zoned.year()),
-        i8::from(zoned.month()),
-        i8::from(zoned.day()),
+        zoned.year(),
+        zoned.month(),
+        zoned.day(),
     )
     .ok()
 }

--- a/rust/adapters/codex/src/paths.rs
+++ b/rust/adapters/codex/src/paths.rs
@@ -1,9 +1,20 @@
 use std::{
-    env,
+    env, fs,
     path::{Path, PathBuf},
+    time::UNIX_EPOCH,
 };
 
-use crate::{Result, cli_error, fast::FxHashSet, home};
+#[cfg(test)]
+use std::{
+    fs::{File, FileTimes},
+    time::Duration,
+};
+
+use jiff::{civil::Date, tz::TimeZone as JiffTimeZone};
+
+use crate::{
+    Result, cli::SharedArgs, cli_error, date_range_bounds_ms, fast::FxHashSet, home, parse_tz,
+};
 
 pub(super) fn codex_usage_sources() -> Result<Vec<CodexUsageSource>> {
     Ok(codex_usage_sources_from_homes(codex_home_paths()?))
@@ -96,6 +107,122 @@ pub(super) fn collect_deduped_codex_usage_files(
     groups
 }
 
+pub(super) fn filter_codex_usage_files(
+    sessions_dir: &Path,
+    files: &[PathBuf],
+    shared: &SharedArgs,
+) -> Vec<PathBuf> {
+    let Some(eligibility) = CodexFileEligibility::from_shared(shared) else {
+        return files.to_vec();
+    };
+    files
+        .iter()
+        .filter(|file| {
+            eligibility.contains(
+                codex_file_date(sessions_dir, file),
+                file_modified_millis(file),
+            )
+        })
+        .cloned()
+        .collect()
+}
+
+#[derive(Clone, Copy)]
+struct CodexFileEligibility {
+    since_date: Option<Date>,
+    until_path_date: Option<Date>,
+    since_millis: Option<i64>,
+}
+
+impl CodexFileEligibility {
+    fn from_shared(shared: &SharedArgs) -> Option<Self> {
+        let timezone =
+            parse_tz(shared.timezone.as_deref()).or_else(|| Some(JiffTimeZone::system()));
+        let since_date = shared.since.as_deref().and_then(parse_compact_date);
+        let until_date = shared.until.as_deref().and_then(parse_compact_date);
+        let (since_millis, until_millis) = date_range_bounds_ms(
+            shared.since.as_deref(),
+            shared.until.as_deref(),
+            timezone.as_ref(),
+        );
+        if since_date.is_none() && until_date.is_none() {
+            return None;
+        }
+        Some(Self {
+            since_date,
+            until_path_date: until_millis.and_then(utc_path_date),
+            since_millis,
+        })
+    }
+
+    fn contains(self, start_date: Option<Date>, modified_millis: Option<i64>) -> bool {
+        self.until_path_date
+            .is_none_or(|until| start_date.is_none_or(|date| date <= until))
+            && self.since_date.is_none_or(|since| {
+                start_date.is_none_or(|date| date >= since)
+                    || modified_millis.is_none_or(|modified| {
+                        self.since_millis
+                            .is_none_or(|since_millis| modified >= since_millis)
+                    })
+            })
+    }
+}
+
+fn utc_path_date(millis: i64) -> Option<Date> {
+    let timestamp = jiff::Timestamp::from_millisecond(millis).ok()?;
+    let zoned = timestamp.to_zoned(JiffTimeZone::get("UTC").ok()?);
+    Date::new(
+        i16::from(zoned.year()),
+        i8::from(zoned.month()),
+        i8::from(zoned.day()),
+    )
+    .ok()
+}
+
+fn file_modified_millis(path: &Path) -> Option<i64> {
+    fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()?
+        .as_millis()
+        .try_into()
+        .ok()
+}
+
+fn codex_file_date(sessions_dir: &Path, file: &Path) -> Option<Date> {
+    let relative = file.strip_prefix(sessions_dir).ok()?;
+    let components = relative
+        .components()
+        .filter_map(|component| component.as_os_str().to_str())
+        .collect::<Vec<_>>();
+    components.windows(3).find_map(|parts| {
+        let year = parse_date_part(parts[0], 4)?;
+        let month = parse_date_part(parts[1], 2)?;
+        let day = parse_date_part(parts[2], 2)?;
+        Date::new(year as i16, month as i8, day as i8).ok()
+    })
+}
+
+fn parse_compact_date(value: &str) -> Option<Date> {
+    if value.len() != 8 || !value.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let year = parse_date_part(&value[..4], 4)?;
+    let month = parse_date_part(&value[4..6], 2)?;
+    let day = parse_date_part(&value[6..], 2)?;
+    Date::new(year as i16, month as i8, day as i8).ok()
+}
+
+fn parse_date_part(value: &str, length: usize) -> Option<u16> {
+    (value.len() == length && value.bytes().all(|byte| byte.is_ascii_digit())).then(|| {
+        value
+            .bytes()
+            .fold(0_u16, |number, byte| number * 10 + u16::from(byte - b'0'))
+    })
+}
+
 fn codex_usage_file_key(source: &CodexUsageSource, file: &Path) -> (PathBuf, PathBuf) {
     let relative = file.strip_prefix(&source.dir).unwrap_or(file).to_path_buf();
     (source.dedupe_scope.clone(), relative)
@@ -113,6 +240,17 @@ pub(super) fn codex_home_paths() -> Result<Vec<PathBuf>> {
 
     let home = home::home_dir().ok_or_else(|| cli_error("home directory is not set"))?;
     Ok(vec![home.join(".codex")])
+}
+
+#[cfg(test)]
+pub(super) fn set_file_modified(path: &Path, timestamp: crate::TimestampMs) {
+    let milliseconds = u64::try_from(timestamp.as_millis()).unwrap();
+    File::options()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(UNIX_EPOCH + Duration::from_millis(milliseconds)))
+        .unwrap();
 }
 
 #[cfg(test)]
@@ -247,6 +385,52 @@ mod tests {
         assert_eq!(
             codex_usage_file_key(&source, &source.dir.join(&file_name)),
             (PathBuf::from("/codex"), file_name)
+        );
+    }
+
+    #[test]
+    fn keeps_a_resumed_session_that_started_more_than_a_month_before_since() {
+        let fixture = Fixture::new();
+        let sessions_dir = fixture.create_dir_all("codex/sessions");
+        let historical = fixture.write_file("codex/sessions/2025/01/01/historical.jsonl", "");
+        let resumed = fixture.write_file("codex/sessions/2026/01/01/resumed.jsonl", "");
+        let current = fixture.write_file("codex/sessions/2026/03/15/current.jsonl", "");
+        set_file_modified(
+            &historical,
+            crate::parse_ts_timestamp("2025-01-01T00:00:00.000Z").unwrap(),
+        );
+        set_file_modified(
+            &resumed,
+            crate::parse_ts_timestamp("2026-03-15T12:00:00.000Z").unwrap(),
+        );
+        let shared = SharedArgs {
+            since: Some("20260315".to_string()),
+            until: Some("20260315".to_string()),
+            ..SharedArgs::default()
+        };
+
+        let filtered = filter_codex_usage_files(
+            &sessions_dir,
+            &[historical, resumed.clone(), current.clone()],
+            &shared,
+        );
+
+        assert_eq!(filtered, vec![resumed, current]);
+    }
+
+    #[test]
+    fn keeps_undated_files_when_date_filter_cannot_prove_their_range() {
+        let fixture = Fixture::new();
+        let sessions_dir = fixture.create_dir_all("codex/sessions");
+        let file = fixture.write_file("codex/sessions/custom.jsonl", "");
+        let shared = SharedArgs {
+            since: Some("20260131".to_string()),
+            ..SharedArgs::default()
+        };
+
+        assert_eq!(
+            filter_codex_usage_files(&sessions_dir, std::slice::from_ref(&file), &shared),
+            vec![file]
         );
     }
 }

--- a/rust/adapters/codex/src/paths.rs
+++ b/rust/adapters/codex/src/paths.rs
@@ -171,12 +171,7 @@ impl CodexFileEligibility {
 fn utc_path_date(millis: i64) -> Option<Date> {
     let timestamp = jiff::Timestamp::from_millisecond(millis).ok()?;
     let zoned = timestamp.to_zoned(JiffTimeZone::get("UTC").ok()?);
-    Date::new(
-        zoned.year(),
-        zoned.month(),
-        zoned.day(),
-    )
-    .ok()
+    Date::new(zoned.year(), zoned.month(), zoned.day()).ok()
 }
 
 fn file_modified_millis(path: &Path) -> Option<i64> {

--- a/rust/adapters/codex/src/replay.rs
+++ b/rust/adapters/codex/src/replay.rs
@@ -16,19 +16,55 @@ use crate::{CodexRawUsage, TimestampMs, chunk_file_indexes_by_size, parse_ts_tim
 use super::parser::{codex_value_timestamp, visit_codex_session_file};
 
 #[cfg(test)]
+#[derive(Debug, Eq, PartialEq)]
+pub(super) enum ObservedFileRead {
+    MetadataProbe(PathBuf),
+    ParentUsage(PathBuf),
+}
+
+#[cfg(test)]
 thread_local! {
-    static OBSERVED_FILE_READS: RefCell<Vec<PathBuf>> = const { RefCell::new(Vec::new()) };
+    static OBSERVED_FILE_READS: RefCell<Vec<ObservedFileRead>> = const { RefCell::new(Vec::new()) };
 }
 
 #[cfg(test)]
 pub(super) fn take_observed_file_reads() -> Vec<PathBuf> {
+    take_observed_file_read_events()
+        .into_iter()
+        .map(|read| match read {
+            ObservedFileRead::MetadataProbe(path) | ObservedFileRead::ParentUsage(path) => path,
+        })
+        .collect()
+}
+
+#[cfg(test)]
+pub(super) fn take_observed_file_read_events() -> Vec<ObservedFileRead> {
     OBSERVED_FILE_READS.with(|paths| std::mem::take(&mut *paths.borrow_mut()))
 }
 
-fn observe_file_read(path: &Path) {
+fn observe_metadata_probe(path: &Path) {
     #[cfg(test)]
     {
-        OBSERVED_FILE_READS.with(|paths| paths.borrow_mut().push(path.to_path_buf()));
+        OBSERVED_FILE_READS.with(|paths| {
+            paths
+                .borrow_mut()
+                .push(ObservedFileRead::MetadataProbe(path.to_path_buf()));
+        });
+    }
+    #[cfg(not(test))]
+    {
+        let _ = path;
+    }
+}
+
+fn observe_parent_usage(path: &Path) {
+    #[cfg(test)]
+    {
+        OBSERVED_FILE_READS.with(|paths| {
+            paths
+                .borrow_mut()
+                .push(ObservedFileRead::ParentUsage(path.to_path_buf()));
+        });
     }
     #[cfg(not(test))]
     {
@@ -110,18 +146,32 @@ impl CodexReplayPlan {
     ) -> Self {
         let children = collect_replay_files(children);
         let available_files = collect_replay_files(available_files);
-        let metadata = read_session_metadata(&children, single_thread);
+        let available_metadata = read_session_metadata(&available_files, single_thread);
+        let mut files_by_session_id = HashMap::with_capacity(available_files.len());
+        let mut metadata_by_path = HashMap::with_capacity(available_files.len());
+        for ((path, _), metadata) in available_files.iter().zip(available_metadata) {
+            if let Some(session_id) = metadata.session_id.as_deref() {
+                files_by_session_id
+                    .entry(session_id.to_string())
+                    .or_insert_with(|| path.clone());
+            }
+            metadata_by_path.entry(path.clone()).or_insert(metadata);
+        }
+        let child_metadata = children.iter().map(|(child, _)| {
+            metadata_by_path
+                .get(child)
+                .cloned()
+                .unwrap_or_else(|| read_codex_session_metadata(child))
+        });
         let parent_by_child = children
             .iter()
-            .zip(&metadata)
+            .zip(child_metadata)
             .filter_map(|((child, _), metadata)| {
                 let parent_id = metadata.parent_id.as_deref()?;
-                let path = available_files
-                    .iter()
-                    .find(|(parent, _)| {
-                        parent != child && session_file_matches_id(parent, parent_id)
-                    })
-                    .map(|(parent, _)| parent.clone());
+                let path = files_by_session_id
+                    .get(parent_id)
+                    .filter(|parent| **parent != *child)
+                    .cloned();
                 Some((
                     child.clone(),
                     ParentReplay {
@@ -183,17 +233,6 @@ fn collect_replay_files<'a>(
             files.iter().map(move |path| (path.clone(), sessions_dir))
         })
         .collect()
-}
-
-fn session_file_matches_id(path: &Path, session_id: &str) -> bool {
-    path.file_stem()
-        .and_then(|stem| stem.to_str())
-        .is_some_and(|stem| {
-            stem == session_id
-                || stem
-                    .strip_suffix(session_id)
-                    .is_some_and(|prefix| prefix.ends_with('-'))
-        })
 }
 
 fn replay_worker_count(files: usize, single_thread: bool) -> usize {
@@ -292,7 +331,7 @@ fn read_parent_usage_file(path: &Path, sessions_dir: &Path) -> (PathBuf, ParentU
 }
 
 fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawUsage)> {
-    observe_file_read(path);
+    observe_parent_usage(path);
     let mut usage = Vec::new();
     let _ = visit_codex_session_file(sessions_dir, path, None, |event| {
         usage.push((
@@ -311,7 +350,7 @@ fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawU
     usage
 }
 
-#[derive(Default)]
+#[derive(Clone, Default)]
 struct CodexSessionMetadata {
     session_id: Option<String>,
     parent_id: Option<String>,
@@ -319,7 +358,7 @@ struct CodexSessionMetadata {
 }
 
 fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
-    observe_file_read(path);
+    observe_metadata_probe(path);
     let Ok(file) = File::open(path) else {
         return CodexSessionMetadata::default();
     };

--- a/rust/adapters/codex/src/replay.rs
+++ b/rust/adapters/codex/src/replay.rs
@@ -147,13 +147,15 @@ impl CodexReplayPlan {
         let children = collect_replay_files(children);
         let available_files = collect_replay_files(available_files);
         let available_metadata = read_session_metadata(&available_files, single_thread);
-        let mut files_by_session_id = HashMap::with_capacity(available_files.len());
+        let mut files_by_session_id =
+            HashMap::<String, Vec<PathBuf>>::with_capacity(available_files.len());
         let mut metadata_by_path = HashMap::with_capacity(available_files.len());
         for ((path, _), metadata) in available_files.iter().zip(available_metadata) {
             if let Some(session_id) = metadata.session_id.as_deref() {
                 files_by_session_id
                     .entry(session_id.to_string())
-                    .or_insert_with(|| path.clone());
+                    .or_default()
+                    .push(path.clone());
             }
             metadata_by_path.entry(path.clone()).or_insert(metadata);
         }
@@ -170,7 +172,11 @@ impl CodexReplayPlan {
                 let parent_id = metadata.parent_id.as_deref()?;
                 let path = files_by_session_id
                     .get(parent_id)
-                    .filter(|parent| **parent != *child)
+                    .and_then(|candidates| {
+                        candidates
+                            .iter()
+                            .find(|candidate| candidate.as_path() != child)
+                    })
                     .cloned();
                 Some((
                     child.clone(),

--- a/rust/adapters/codex/src/replay.rs
+++ b/rust/adapters/codex/src/replay.rs
@@ -95,34 +95,8 @@ impl CodexReplayPlan {
     ) -> Self {
         let files = collect_replay_files(groups);
         let metadata = read_session_metadata(&files, single_thread);
-        // The same session can be reachable from more than one source directory,
-        // so keep the first file and stay independent of source ordering.
-        let mut files_by_session_id = HashMap::new();
-        for ((path, _), metadata) in files.iter().zip(&metadata) {
-            if let Some(session_id) = metadata.session_id.as_deref() {
-                files_by_session_id.entry(session_id).or_insert(path);
-            }
-        }
-        let parent_by_child = files
-            .iter()
-            .zip(&metadata)
-            .filter_map(|((child, _), metadata)| {
-                let parent_id = metadata.parent_id.as_deref()?;
-                let path = files_by_session_id
-                    .get(parent_id)
-                    // A session listing itself as its own parent would match its
-                    // whole stream and drop every event it recorded.
-                    .filter(|parent| **parent != child)
-                    .map(|parent| (*parent).clone());
-                Some((
-                    child.clone(),
-                    ParentReplay {
-                        path,
-                        forked_at: metadata.timestamp,
-                    },
-                ))
-            })
-            .collect::<HashMap<_, _>>();
+        let files_by_session_id = index_session_paths(&files, &metadata);
+        let parent_by_child = build_parent_replays(&files, metadata, &files_by_session_id);
         let parent_paths = parent_by_child
             .values()
             .filter_map(|parent| parent.path.clone())
@@ -147,16 +121,9 @@ impl CodexReplayPlan {
         let children = collect_replay_files(children);
         let available_files = collect_replay_files(available_files);
         let available_metadata = read_session_metadata(&available_files, single_thread);
-        let mut files_by_session_id =
-            HashMap::<String, Vec<PathBuf>>::with_capacity(available_files.len());
+        let files_by_session_id = index_session_paths(&available_files, &available_metadata);
         let mut metadata_by_path = HashMap::with_capacity(available_files.len());
         for ((path, _), metadata) in available_files.iter().zip(available_metadata) {
-            if let Some(session_id) = metadata.session_id.as_deref() {
-                files_by_session_id
-                    .entry(session_id.to_string())
-                    .or_default()
-                    .push(path.clone());
-            }
             metadata_by_path.entry(path.clone()).or_insert(metadata);
         }
         let child_metadata = children.iter().map(|(child, _)| {
@@ -165,28 +132,7 @@ impl CodexReplayPlan {
                 .cloned()
                 .unwrap_or_else(|| read_codex_session_metadata(child))
         });
-        let parent_by_child = children
-            .iter()
-            .zip(child_metadata)
-            .filter_map(|((child, _), metadata)| {
-                let parent_id = metadata.parent_id.as_deref()?;
-                let path = files_by_session_id
-                    .get(parent_id)
-                    .and_then(|candidates| {
-                        candidates
-                            .iter()
-                            .find(|candidate| candidate.as_path() != child)
-                    })
-                    .cloned();
-                Some((
-                    child.clone(),
-                    ParentReplay {
-                        path,
-                        forked_at: metadata.timestamp,
-                    },
-                ))
-            })
-            .collect::<HashMap<_, _>>();
+        let parent_by_child = build_parent_replays(&children, child_metadata, &files_by_session_id);
         let parent_paths = parent_by_child
             .values()
             .filter_map(|parent| parent.path.clone())
@@ -228,6 +174,55 @@ impl CodexReplayPlan {
         });
         Some(&stream.usage[..replay_len])
     }
+}
+
+fn index_session_paths(
+    files: &[(PathBuf, &Path)],
+    metadata: &[CodexSessionMetadata],
+) -> HashMap<String, Vec<PathBuf>> {
+    let mut files_by_session_id = HashMap::<String, Vec<PathBuf>>::with_capacity(files.len());
+    for ((path, _), metadata) in files.iter().zip(metadata) {
+        if let Some(session_id) = metadata.session_id.as_deref() {
+            files_by_session_id
+                .entry(session_id.to_string())
+                .or_default()
+                .push(path.clone());
+        }
+    }
+    files_by_session_id
+}
+
+fn build_parent_replays(
+    children: &[(PathBuf, &Path)],
+    metadata: impl IntoIterator<Item = CodexSessionMetadata>,
+    files_by_session_id: &HashMap<String, Vec<PathBuf>>,
+) -> HashMap<PathBuf, ParentReplay> {
+    children
+        .iter()
+        .zip(metadata)
+        .filter_map(|((child, _), metadata)| {
+            let parent_id = metadata.parent_id.as_deref()?;
+            Some((
+                child.clone(),
+                ParentReplay {
+                    path: first_non_child_path(files_by_session_id, parent_id, child),
+                    forked_at: metadata.timestamp,
+                },
+            ))
+        })
+        .collect()
+}
+
+fn first_non_child_path(
+    files_by_session_id: &HashMap<String, Vec<PathBuf>>,
+    parent_id: &str,
+    child: &Path,
+) -> Option<PathBuf> {
+    files_by_session_id
+        .get(parent_id)?
+        .iter()
+        .find(|candidate| candidate.as_path() != child)
+        .cloned()
 }
 
 fn collect_replay_files<'a>(

--- a/rust/adapters/codex/src/replay.rs
+++ b/rust/adapters/codex/src/replay.rs
@@ -6,11 +6,35 @@ use std::{
     thread,
 };
 
+#[cfg(test)]
+use std::cell::RefCell;
+
 use serde_json::Value;
 
 use crate::{CodexRawUsage, TimestampMs, chunk_file_indexes_by_size, parse_ts_timestamp};
 
 use super::parser::{codex_value_timestamp, visit_codex_session_file};
+
+#[cfg(test)]
+thread_local! {
+    static OBSERVED_FILE_READS: RefCell<Vec<PathBuf>> = const { RefCell::new(Vec::new()) };
+}
+
+#[cfg(test)]
+pub(super) fn take_observed_file_reads() -> Vec<PathBuf> {
+    OBSERVED_FILE_READS.with(|paths| std::mem::take(&mut *paths.borrow_mut()))
+}
+
+fn observe_file_read(path: &Path) {
+    #[cfg(test)]
+    {
+        OBSERVED_FILE_READS.with(|paths| paths.borrow_mut().push(path.to_path_buf()));
+    }
+    #[cfg(not(test))]
+    {
+        let _ = path;
+    }
+}
 
 pub(super) struct CodexReplayPlan {
     parent_by_child: HashMap<PathBuf, ParentReplay>,
@@ -33,12 +57,7 @@ impl CodexReplayPlan {
         groups: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
         single_thread: bool,
     ) -> Self {
-        let files = groups
-            .into_iter()
-            .flat_map(|(sessions_dir, files)| {
-                files.iter().map(move |path| (path.clone(), sessions_dir))
-            })
-            .collect::<Vec<_>>();
+        let files = collect_replay_files(groups);
         let metadata = read_session_metadata(&files, single_thread);
         // The same session can be reachable from more than one source directory,
         // so keep the first file and stay independent of source ordering.
@@ -84,6 +103,50 @@ impl CodexReplayPlan {
         }
     }
 
+    pub(super) fn for_bounded_files<'a>(
+        children: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
+        available_files: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
+        single_thread: bool,
+    ) -> Self {
+        let children = collect_replay_files(children);
+        let available_files = collect_replay_files(available_files);
+        let metadata = read_session_metadata(&children, single_thread);
+        let parent_by_child = children
+            .iter()
+            .zip(&metadata)
+            .filter_map(|((child, _), metadata)| {
+                let parent_id = metadata.parent_id.as_deref()?;
+                let path = available_files
+                    .iter()
+                    .find(|(parent, _)| {
+                        parent != child && session_file_matches_id(parent, parent_id)
+                    })
+                    .map(|(parent, _)| parent.clone());
+                Some((
+                    child.clone(),
+                    ParentReplay {
+                        path,
+                        forked_at: metadata.timestamp,
+                    },
+                ))
+            })
+            .collect::<HashMap<_, _>>();
+        let parent_paths = parent_by_child
+            .values()
+            .filter_map(|parent| parent.path.clone())
+            .collect::<HashSet<_>>();
+        let parents = available_files
+            .iter()
+            .filter(|(path, _)| parent_paths.contains(path))
+            .cloned()
+            .collect::<Vec<_>>();
+
+        Self {
+            parent_by_child,
+            usage_by_parent: read_parent_usage(&parents, single_thread),
+        }
+    }
+
     /// Usage history that `child` replayed from the session it forked from.
     ///
     /// Returns `None` for sessions that are not forks. Forked sessions whose
@@ -109,6 +172,28 @@ impl CodexReplayPlan {
         });
         Some(&stream.usage[..replay_len])
     }
+}
+
+fn collect_replay_files<'a>(
+    groups: impl IntoIterator<Item = (&'a Path, &'a [PathBuf])>,
+) -> Vec<(PathBuf, &'a Path)> {
+    groups
+        .into_iter()
+        .flat_map(|(sessions_dir, files)| {
+            files.iter().map(move |path| (path.clone(), sessions_dir))
+        })
+        .collect()
+}
+
+fn session_file_matches_id(path: &Path, session_id: &str) -> bool {
+    path.file_stem()
+        .and_then(|stem| stem.to_str())
+        .is_some_and(|stem| {
+            stem == session_id
+                || stem
+                    .strip_suffix(session_id)
+                    .is_some_and(|prefix| prefix.ends_with('-'))
+        })
 }
 
 fn replay_worker_count(files: usize, single_thread: bool) -> usize {
@@ -166,6 +251,12 @@ fn read_parent_usage(
         return HashMap::new();
     }
     let worker_count = replay_worker_count(parents.len(), single_thread);
+    if worker_count <= 1 {
+        return parents
+            .iter()
+            .map(|(path, sessions_dir)| read_parent_usage_file(path, sessions_dir))
+            .collect();
+    }
     let paths = parents
         .iter()
         .map(|(path, _)| path.clone())
@@ -180,11 +271,7 @@ fn read_parent_usage(
                         .into_iter()
                         .map(|index| {
                             let (path, sessions_dir) = &parents[index];
-                            let (timestamps, usage) = read_usage_events(sessions_dir, path)
-                                .into_iter()
-                                .map(|(timestamp, usage)| (parse_ts_timestamp(&timestamp), usage))
-                                .unzip();
-                            (path.clone(), ParentUsage { timestamps, usage })
+                            read_parent_usage_file(path, sessions_dir)
                         })
                         .collect::<Vec<_>>()
                 })
@@ -196,7 +283,16 @@ fn read_parent_usage(
     })
 }
 
+fn read_parent_usage_file(path: &Path, sessions_dir: &Path) -> (PathBuf, ParentUsage) {
+    let (timestamps, usage) = read_usage_events(sessions_dir, path)
+        .into_iter()
+        .map(|(timestamp, usage)| (parse_ts_timestamp(&timestamp), usage))
+        .unzip();
+    (path.to_path_buf(), ParentUsage { timestamps, usage })
+}
+
 fn read_usage_events(sessions_dir: &Path, path: &Path) -> Vec<(String, CodexRawUsage)> {
+    observe_file_read(path);
     let mut usage = Vec::new();
     let _ = visit_codex_session_file(sessions_dir, path, None, |event| {
         usage.push((
@@ -223,6 +319,7 @@ struct CodexSessionMetadata {
 }
 
 fn read_codex_session_metadata(path: &Path) -> CodexSessionMetadata {
+    observe_file_read(path);
     let Ok(file) = File::open(path) else {
         return CodexSessionMetadata::default();
     };

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -640,8 +640,7 @@ fn load_codex_rows(
         });
     }
 
-    let mut events = codex::load_codex_events(shared)?;
-    let detected = !events.is_empty();
+    let (mut events, detected) = codex::load_codex_events_with_detection(shared)?;
     codex::filter_events_by_date(&mut events, shared)?;
     let groups = codex::aggregate_events(&events, kind, shared.timezone.as_deref())?;
     let speed = codex::resolve_codex_speed(CodexSpeed::Auto);

--- a/rust/crates/ccusage-adapter-all/src/tests.rs
+++ b/rust/crates/ccusage-adapter-all/src/tests.rs
@@ -1,11 +1,13 @@
 use std::{
     ffi::OsString,
+    fs::{File, FileTimes},
+    path::Path,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
     },
     thread,
-    time::{Duration, Instant},
+    time::{Duration, Instant, UNIX_EPOCH},
 };
 
 use serde_json::json;
@@ -523,6 +525,47 @@ fn multi_section_codex_fixture_matches_standalone_sections_for_daily_and_session
     let shared = fixture_shared("20990201", "20990202");
 
     assert_daily_family_and_session_sections_match_standalone(&shared);
+}
+
+#[test]
+fn unified_report_filters_codex_paths_before_loading_historical_rows() {
+    let resumed_usage = codex_usage_line("2026-03-15T08:01:00.000Z", "gpt-5", 1_000);
+    let historical_usage = codex_usage_line("2026-03-15T08:02:00.000Z", "gpt-5", 9_999);
+    let fixture = fs_fixture!({
+        "codex/sessions/2025/01/01/resumed.jsonl": &resumed_usage,
+        "codex/sessions/2025/01/02/historical.jsonl": &historical_usage,
+    });
+    set_file_modified(
+        &fixture.path("codex/sessions/2025/01/01/resumed.jsonl"),
+        "2026-03-15T08:01:00.000Z",
+    );
+    set_file_modified(
+        &fixture.path("codex/sessions/2025/01/02/historical.jsonl"),
+        "2025-01-02T08:01:00.000Z",
+    );
+    let _env = isolated_agent_env(
+        &fixture,
+        "CODEX_HOME",
+        fixture.path("codex").into_os_string(),
+    );
+    let shared = fixture_shared("20260315", "20260315");
+
+    let result = load_rows(AgentReportKind::Daily, &shared).unwrap();
+
+    assert_eq!(result.rows.len(), 1);
+    assert_eq!(result.rows[0].period, "2026-03-15");
+    assert_eq!(result.rows[0].total_tokens, 1_300);
+    assert_eq!(result.detected_agents, vec!["codex"]);
+}
+
+fn set_file_modified(path: &Path, timestamp: &str) {
+    let milliseconds = u64::try_from(parse_ts_timestamp(timestamp).unwrap().as_millis()).unwrap();
+    File::options()
+        .write(true)
+        .open(path)
+        .unwrap()
+        .set_times(FileTimes::new().set_modified(UNIX_EPOCH + Duration::from_millis(milliseconds)))
+        .unwrap();
 }
 
 fn fixture_shared(since: &str, until: &str) -> SharedArgs {


### PR DESCRIPTION
## Summary
- Skip provably historical Codex session files before parsing bounded reports.
- Preserve resumed sessions, required fork parents, and timezone-safe boundaries.
- Keep Codex source detection when the selected range has no Codex rows.

Fixes #1598

## Tests
- cargo test -p ccusage-adapter-codex
- cargo test -p ccusage-adapter-all
- cargo fmt --all -- --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up date-bounded Codex reports by skipping session files that are provably outside the selected date window before parsing, instead of parsing every file and filtering afterward.

- Keeps fork parents and resumed sessions that span the window boundary, since replay still needs them.
- Treats file modified time as evidence that a session extends into the window when the path date alone falls outside it.
- Retains Codex source detection when the filtered range has no Codex rows by reporting pre-filter file presence from the unified loader.
- Resolves replay parents by session ID from file contents, so misleading filenames can't select the wrong parent, children can't replay from themselves, and first-wins precedence stays deterministic.
- Confines full parent usage parsing to selected files; historical files only get cheap metadata probes.

Fixes #1598

<sup>Written for commit fe4701da4e07c5a2609dfa3a6d660e8a3f328f87. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date-bounded Codex usage reports to exclude unrelated historical files.
  - Preserved long-running and resumed sessions across date boundaries.
  - Included relevant files from adjacent UTC dates for local timezone ranges.
  - Improved detection of available Codex data when filtering narrows the loaded files.
  - Ensured daily reports include usage from sessions resumed on the selected date without importing unrelated activity.
  - Improved consistency across single-directory and multi-source Codex reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->