### PR TITLE
fix(cli): forward launcher signals to native child

### DIFF
--- a/apps/ccusage/src/cli.js
+++ b/apps/ccusage/src/cli.js
@@ -165,7 +165,7 @@ function isMainModule({ argvEntry = process.argv[1], moduleUrl, realpathPath = r
  */
 function getForwardedSignals(platform = process.platform) {
 	if (platform === 'win32') {
-		return ['SIGINT', 'SIGTERM'];
+		return ['SIGINT', 'SIGBREAK', 'SIGHUP'];
 	}
 
 	return ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'];
@@ -186,7 +186,6 @@ function createNativeSpawner({
 		new Promise((resolve) => {
 			const child = spawnProcess(command, args, { stdio: 'inherit' });
 			const signalHandlers = new Map();
-			const forwardedSignalSet = new Set();
 			const cleanup = () => {
 				for (const [signal, handler] of signalHandlers) {
 					signalSource.off(signal, handler);
@@ -197,10 +196,6 @@ function createNativeSpawner({
 			 * @param {NodeJS.Signals} signal
 			 */
 			const handleSignal = (signal) => {
-				if (forwardedSignalSet.has(signal)) {
-					return;
-				}
-				forwardedSignalSet.add(signal);
 				child.kill(signal);
 			};
 

--- a/apps/ccusage/src/cli.js
+++ b/apps/ccusage/src/cli.js
@@ -14,6 +14,9 @@ const require = createRequire(import.meta.url);
  * @typedef {{ error?: Error; signal?: NodeJS.Signals | null; status: number | null }} NativeSpawnResult
  * @typedef {(command: string, args: string[]) => Promise<NativeSpawnResult>} NativeSpawner
  * @typedef {{ argvEntry?: string; moduleUrl: string; realpathPath?: (path: string) => string }} MainModuleOptions
+ * @typedef {{ off: (signal: NodeJS.Signals, handler: () => void) => unknown; on: (signal: NodeJS.Signals, handler: () => void) => unknown }} SignalSource
+ * @typedef {{ kill: (signal: NodeJS.Signals) => unknown; on: import('node:events').EventEmitter['on'] }} NativeChild
+ * @typedef {(command: string, args: string[], options: { stdio: 'inherit' }) => NativeChild} NativeSpawnProcess
  */
 
 /**
@@ -157,13 +160,52 @@ function isMainModule({ argvEntry = process.argv[1], moduleUrl, realpathPath = r
 }
 
 /**
+ * @param {string} [platform]
+ * @returns {NodeJS.Signals[]}
+ */
+function getForwardedSignals(platform = process.platform) {
+	if (platform === 'win32') {
+		return ['SIGINT', 'SIGTERM'];
+	}
+
+	return ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'];
+}
+
+/**
+ * @param {{ signalSource?: SignalSource; spawnProcess?: NativeSpawnProcess; platform?: string }} [options]
  * @returns {NativeSpawner}
  */
-function createNativeSpawner() {
+function createNativeSpawner({
+	platform = process.platform,
+	signalSource = process,
+	spawnProcess = spawn,
+} = {}) {
+	const forwardedSignals = getForwardedSignals(platform);
+
 	return async (command, args) =>
 		new Promise((resolve) => {
-			const child = spawn(command, args, { stdio: 'inherit' });
+			const child = spawnProcess(command, args, { stdio: 'inherit' });
+			const signalHandlers = new Map();
+			const forwardedSignalSet = new Set();
+			const cleanup = () => {
+				for (const [signal, handler] of signalHandlers) {
+					signalSource.off(signal, handler);
+				}
+				signalHandlers.clear();
+			};
+			/**
+			 * @param {NodeJS.Signals} signal
+			 */
+			const handleSignal = (signal) => {
+				if (forwardedSignalSet.has(signal)) {
+					return;
+				}
+				forwardedSignalSet.add(signal);
+				child.kill(signal);
+			};
+
 			child.on('error', (error) => {
+				cleanup();
 				resolve({
 					error,
 					signal: null,
@@ -171,11 +213,20 @@ function createNativeSpawner() {
 				});
 			});
 			child.on('exit', (status, signal) => {
+				cleanup();
 				resolve({
 					signal,
 					status,
 				});
 			});
+
+			for (const signal of forwardedSignals) {
+				const handler = () => handleSignal(signal);
+				try {
+					signalSource.on(signal, handler);
+					signalHandlers.set(signal, handler);
+				} catch {}
+			}
 		});
 }
 
@@ -215,4 +266,10 @@ if (isMainModule({ moduleUrl: import.meta.url })) {
 	process.exitCode = await runCli(process.argv.slice(2));
 }
 
-export { ensureNativeBinaryExecutable, isMainModule, resolveCliRuntime, resolveNativeBinary };
+export {
+	createNativeSpawner,
+	ensureNativeBinaryExecutable,
+	isMainModule,
+	resolveCliRuntime,
+	resolveNativeBinary,
+};

--- a/apps/ccusage/src/cli.test.ts
+++ b/apps/ccusage/src/cli.test.ts
@@ -1,6 +1,8 @@
 import assert from 'node:assert/strict';
+import { EventEmitter } from 'node:events';
 import { describe, it, mock } from 'node:test';
 import {
+	createNativeSpawner,
 	ensureNativeBinaryExecutable,
 	isMainModule,
 	resolveCliRuntime,
@@ -121,5 +123,98 @@ void describe(resolveCliRuntime.name, () => {
 		});
 
 		assert.equal(actual, true);
+	});
+});
+
+void describe(createNativeSpawner.name, () => {
+	void it('forwards each supported launcher signal once', async () => {
+		const signalSource = new EventEmitter();
+		const kill = mock.fn(() => true);
+		const child = /** @type {import('node:child_process').ChildProcess} */ (
+			/** @type {unknown} */ (Object.assign(new EventEmitter(), { kill }))
+		);
+		const spawnProcess = mock.fn(() => child);
+		const spawnNative = createNativeSpawner({
+			platform: 'linux',
+			signalSource,
+			spawnProcess,
+		});
+
+		const resultPromise = spawnNative('/native/bin/ccusage', ['statusline']);
+		for (const signal of ['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT']) {
+			signalSource.emit(signal);
+			signalSource.emit(signal);
+		}
+		child.emit('exit', 0, null);
+
+		assert.deepEqual(await resultPromise, { signal: null, status: 0 });
+		assert.deepEqual(
+			kill.mock.calls.map((call) => call.arguments),
+			[['SIGINT'], ['SIGTERM'], ['SIGHUP'], ['SIGQUIT']],
+		);
+		const spawnCall = spawnProcess.mock.calls[0];
+		assert.ok(spawnCall);
+		assert.deepEqual(spawnCall.arguments, [
+			'/native/bin/ccusage',
+			['statusline'],
+			{ stdio: 'inherit' },
+		]);
+	});
+
+	void it('removes signal listeners after the child exits', async () => {
+		const signalSource = new EventEmitter();
+		const kill = mock.fn(() => true);
+		const child = /** @type {import('node:child_process').ChildProcess} */ (
+			/** @type {unknown} */ (Object.assign(new EventEmitter(), { kill }))
+		);
+		const spawnNative = createNativeSpawner({
+			platform: 'linux',
+			signalSource,
+			spawnProcess: () => child,
+		});
+
+		const resultPromise = spawnNative('/native/bin/ccusage', []);
+		child.emit('exit', 7, 'SIGTERM');
+
+		assert.deepEqual(await resultPromise, { signal: 'SIGTERM', status: 7 });
+		assert.deepEqual(
+			['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'].map((signal) =>
+				signalSource.listenerCount(signal),
+			),
+			[0, 0, 0, 0],
+		);
+		signalSource.emit('SIGTERM');
+		assert.equal(kill.mock.callCount(), 0);
+	});
+
+	void it('removes signal listeners after a child error', async () => {
+		const signalSource = new EventEmitter();
+		const kill = mock.fn(() => true);
+		const child = /** @type {import('node:child_process').ChildProcess} */ (
+			/** @type {unknown} */ (Object.assign(new EventEmitter(), { kill }))
+		);
+		const spawnNative = createNativeSpawner({
+			platform: 'linux',
+			signalSource,
+			spawnProcess: () => child,
+		});
+		const error = new Error('spawn failed');
+
+		const resultPromise = spawnNative('/native/bin/ccusage', []);
+		child.emit('error', error);
+
+		assert.deepEqual(await resultPromise, {
+			error,
+			signal: null,
+			status: null,
+		});
+		assert.deepEqual(
+			['SIGINT', 'SIGTERM', 'SIGHUP', 'SIGQUIT'].map((signal) =>
+				signalSource.listenerCount(signal),
+			),
+			[0, 0, 0, 0],
+		);
+		signalSource.emit('SIGINT');
+		assert.equal(kill.mock.callCount(), 0);
 	});
 });

--- a/apps/ccusage/src/cli.test.ts
+++ b/apps/ccusage/src/cli.test.ts
@@ -127,7 +127,7 @@ void describe(resolveCliRuntime.name, () => {
 });
 
 void describe(createNativeSpawner.name, () => {
-	void it('forwards each supported launcher signal once', async () => {
+	void it('forwards every supported launcher signal delivery', async () => {
 		const signalSource = new EventEmitter();
 		const kill = mock.fn(() => true);
 		const child = /** @type {import('node:child_process').ChildProcess} */ (
@@ -150,7 +150,16 @@ void describe(createNativeSpawner.name, () => {
 		assert.deepEqual(await resultPromise, { signal: null, status: 0 });
 		assert.deepEqual(
 			kill.mock.calls.map((call) => call.arguments),
-			[['SIGINT'], ['SIGTERM'], ['SIGHUP'], ['SIGQUIT']],
+			[
+				['SIGINT'],
+				['SIGINT'],
+				['SIGTERM'],
+				['SIGTERM'],
+				['SIGHUP'],
+				['SIGHUP'],
+				['SIGQUIT'],
+				['SIGQUIT'],
+			],
 		);
 		const spawnCall = spawnProcess.mock.calls[0];
 		assert.ok(spawnCall);
@@ -159,6 +168,41 @@ void describe(createNativeSpawner.name, () => {
 			['statusline'],
 			{ stdio: 'inherit' },
 		]);
+	});
+
+	void it('forwards the supported Windows console signals', async () => {
+		const signalSource = new EventEmitter();
+		const kill = mock.fn(() => true);
+		const child = /** @type {import('node:child_process').ChildProcess} */ (
+			/** @type {unknown} */ (Object.assign(new EventEmitter(), { kill }))
+		);
+		const spawnNative = createNativeSpawner({
+			platform: 'win32',
+			signalSource,
+			spawnProcess: () => child,
+		});
+
+		const resultPromise = spawnNative('/native/bin/ccusage.exe', []);
+		assert.deepEqual(
+			['SIGINT', 'SIGBREAK', 'SIGHUP'].map((signal) => signalSource.listenerCount(signal)),
+			[1, 1, 1],
+		);
+		signalSource.emit('SIGINT');
+		signalSource.emit('SIGBREAK');
+		signalSource.emit('SIGHUP');
+		signalSource.emit('SIGTERM');
+		assert.equal(signalSource.listenerCount('SIGTERM'), 0);
+		assert.deepEqual(
+			kill.mock.calls.map((call) => call.arguments),
+			[['SIGINT'], ['SIGBREAK'], ['SIGHUP']],
+		);
+		child.emit('exit', 0, null);
+
+		assert.deepEqual(await resultPromise, { signal: null, status: 0 });
+		assert.deepEqual(
+			['SIGINT', 'SIGBREAK', 'SIGHUP'].map((signal) => signalSource.listenerCount(signal)),
+			[0, 0, 0],
+		);
 	});
 
 	void it('removes signal listeners after the child exits', async () => {


### PR DESCRIPTION
Addresses #1596\n\nThe npm launcher forwards every catchable termination signal to the native child and removes the forwarding listeners when the child exits or fails to spawn.\n\nThis covers the catchable-signal orphan path. SIGKILL cannot be intercepted by Node, and platform-native parent-death handling remains out of scope, so this PR must not auto-close the issue.\n\nUnix signals: SIGINT, SIGTERM, SIGHUP, SIGQUIT.\nWindows console signals: SIGINT, SIGBREAK, SIGHUP.\n\nValidation:\n- 34 launcher tests passed\n- oxlint passed\n- treefmt passed\n\nThe issue reporter is included as a commit co-author.