### PR TITLE
fix(opencode): read v2 session usage

### DIFF
--- a/rust/adapters/opencode/src/lib.rs
+++ b/rust/adapters/opencode/src/lib.rs
@@ -26,21 +26,22 @@ pub fn has_data() -> bool {
 }
 
 pub fn run(args: AgentCommandArgs) -> Result<()> {
+    let kind = args.kind;
     let shared = args.shared;
-    let mut entries = loader::load_entries(&shared)?;
+    let mut entries = loader::load_entries(&shared, kind)?;
     filter_loaded_entries_by_date(&mut entries, &shared);
     if wants_json(&shared) {
         return print_json_or_jq(
-            report_json(&entries, args.kind, &shared.order)?,
+            report_json(&entries, kind, &shared.order)?,
             shared.jq.as_deref(),
             shared.no_cost,
         );
     }
-    let mut rows = summarize_entries(&entries, args.kind)?;
+    let mut rows = summarize_entries(&entries, kind)?;
     sort_summaries(&mut rows, &shared.order, |row| summary_period(row));
     print_usage_table(
         "OpenCode Token Usage Report",
-        first_column(args.kind),
+        first_column(kind),
         &rows,
         &shared,
         false,

--- a/rust/adapters/opencode/src/loader.rs
+++ b/rust/adapters/opencode/src/loader.rs
@@ -61,15 +61,17 @@ pub fn load_entries_from_directory(
     let window = DateWindow::from_shared(shared, tz.as_ref());
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
+    let mut aggregate_entries = Vec::new();
     if let Some(db_path) = db_path(opencode_dir) {
-        for entry in load_entries_from_database(
+        let database_entries = load_entries_from_database(
             &db_path,
             tz.as_ref(),
             shared.mode,
             pricing.as_ref(),
             shared,
             window,
-        ) {
+        );
+        for entry in database_entries.message_entries {
             if let Some(id) = entry_id(&entry)
                 && !seen.insert(id.to_string())
             {
@@ -77,6 +79,7 @@ pub fn load_entries_from_directory(
             }
             entries.push(entry);
         }
+        aggregate_entries = database_entries.aggregate_entries;
     }
 
     let messages_dir = opencode_dir.join("storage").join("message");
@@ -111,6 +114,22 @@ pub fn load_entries_from_directory(
         )
     });
     for entry in loaded.into_iter().flatten() {
+        if let Some(id) = entry_id(&entry)
+            && !seen.insert(id.to_string())
+        {
+            continue;
+        }
+        entries.push(entry);
+    }
+
+    let message_sessions = entries
+        .iter()
+        .map(|entry| entry.session_id.to_string())
+        .collect::<HashSet<_>>();
+    for entry in aggregate_entries {
+        if message_sessions.contains(entry.session_id.as_ref()) {
+            continue;
+        }
         if let Some(id) = entry_id(&entry)
             && !seen.insert(id.to_string())
         {
@@ -196,6 +215,12 @@ struct DatabaseLoadContext<'a> {
     db_path: &'a Path,
 }
 
+#[derive(Default)]
+struct DatabaseLoadResult {
+    message_entries: Vec<LoadedEntry>,
+    aggregate_entries: Vec<LoadedEntry>,
+}
+
 fn load_entries_from_database(
     db_path: &Path,
     tz: Option<&JiffTimeZone>,
@@ -203,7 +228,7 @@ fn load_entries_from_database(
     pricing: Option<&PricingMap>,
     shared: &SharedArgs,
     window: DateWindow,
-) -> Vec<LoadedEntry> {
+) -> DatabaseLoadResult {
     let Ok(connection) =
         sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
     else {
@@ -211,9 +236,9 @@ fn load_entries_from_database(
             shared,
             format!("Failed to open OpenCode database: {}", db_path.display()),
         );
-        return Vec::new();
+        return DatabaseLoadResult::default();
     };
-    let mut entries = Vec::new();
+    let mut message_entries = Vec::new();
 
     let mut seen_message_ids = HashSet::new();
     let mut message_sessions = HashSet::new();
@@ -278,7 +303,7 @@ fn load_entries_from_database(
                         ) {
                             let session_key = entry.session_id.to_string();
                             message_sessions.insert(session_key);
-                            push_unique_entry(&mut entries, &mut seen_message_ids, entry);
+                            push_unique_entry(&mut message_entries, &mut seen_message_ids, entry);
                         }
                     }
                     Ok(sqlite::State::Done) => break,
@@ -359,7 +384,7 @@ fn load_entries_from_database(
                         let session_key = entry.session_id.to_string();
                         v2_entries += 1;
                         message_sessions.insert(session_key);
-                        push_unique_entry(&mut entries, &mut seen_message_ids, entry);
+                        push_unique_entry(&mut message_entries, &mut seen_message_ids, entry);
                     }
                     Ok(sqlite::State::Done) => break,
                     Err(_) => {
@@ -386,31 +411,39 @@ fn load_entries_from_database(
         }
     }
 
-    let mut aggregate_tables = Vec::new();
-    if table_exists(&connection, "session_v2") {
-        aggregate_tables.push("session_v2");
-    }
-    if has_session_messages && table_exists(&connection, "session") {
-        aggregate_tables.push("session");
-    }
-    let aggregate_context = DatabaseLoadContext {
-        tz,
-        mode,
-        pricing,
-        window,
-        shared,
-        db_path,
-    };
-    for table in aggregate_tables {
-        for entry in load_session_aggregate_entries(&connection, table, &aggregate_context) {
-            if message_sessions.contains(entry.session_id.as_ref()) {
-                continue;
+    let mut aggregate_entries = Vec::new();
+    if window.is_unbounded() {
+        // Session aggregates are cumulative and cannot be sliced safely for a
+        // bounded report, so only unbounded reports may use this fallback.
+        let mut aggregate_tables = Vec::new();
+        if table_exists(&connection, "session_v2") {
+            aggregate_tables.push("session_v2");
+        }
+        if has_session_messages && table_exists(&connection, "session") {
+            aggregate_tables.push("session");
+        }
+        let aggregate_context = DatabaseLoadContext {
+            tz,
+            mode,
+            pricing,
+            window,
+            shared,
+            db_path,
+        };
+        for table in aggregate_tables {
+            for entry in load_session_aggregate_entries(&connection, table, &aggregate_context) {
+                if message_sessions.contains(entry.session_id.as_ref()) {
+                    continue;
+                }
+                push_unique_entry(&mut aggregate_entries, &mut seen_message_ids, entry);
             }
-            push_unique_entry(&mut entries, &mut seen_message_ids, entry);
         }
     }
 
-    entries
+    DatabaseLoadResult {
+        message_entries,
+        aggregate_entries,
+    }
 }
 
 fn read_message_file(
@@ -1226,6 +1259,49 @@ mod tests {
     }
 
     #[test]
+    fn suppresses_session_aggregate_when_legacy_json_has_message() {
+        let fixture = fs_fixture!({
+            "storage/message/legacy-json-session/legacy-json-message.json": r#"{"id":"legacy-json-message","sessionID":"legacy-json-session","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":120,"output":60},"cost":0.03}"#,
+        });
+        let db_path = fixture.path("opencode.db");
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "legacy-json-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "legacy-json-session");
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("legacy-json-message")
+        );
+        assert_eq!(entries[0].data.message.usage.input_tokens, 120);
+        assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
     fn uses_session_v2_aggregate_when_no_message_level_usage_exists() {
         let fixture = fs_fixture!({});
         let db_path = fixture.path("opencode.db");
@@ -1266,6 +1342,44 @@ mod tests {
         assert_eq!(entries[0].data.message.usage.output_tokens, 50);
         assert_eq!(entries[0].extra_total_tokens, 5);
         assert_eq!(entries[0].cost, 0.25);
+    }
+
+    #[test]
+    fn excludes_cumulative_session_aggregate_from_bounded_window() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "spanning-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 0.25,
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: 10,
+                cache_write_tokens: 20,
+                reasoning_tokens: 5,
+            },
+        );
+
+        // The cumulative aggregate includes usage outside this window, so it
+        // cannot be attributed safely to the requested date range.
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                since: Some("20260102".to_string()),
+                until: Some("20260103".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert!(entries.is_empty());
     }
 
     #[test]

--- a/rust/adapters/opencode/src/loader.rs
+++ b/rust/adapters/opencode/src/loader.rs
@@ -7,7 +7,10 @@ use std::{
 use jiff::tz::TimeZone as JiffTimeZone;
 
 use super::{
-    parser::{OpenCodeMessage, message_value_to_entry},
+    parser::{
+        OpenCodeMessage, OpenCodeSessionAggregate, message_value_to_entry,
+        session_message_value_to_entry, session_value_to_entry,
+    },
     paths::paths,
 };
 use crate::{
@@ -184,6 +187,15 @@ fn is_channel_db_name(name: &str) -> bool {
             .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
 }
 
+struct DatabaseLoadContext<'a> {
+    tz: Option<&'a JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&'a PricingMap>,
+    window: DateWindow,
+    shared: &'a SharedArgs,
+    db_path: &'a Path,
+}
+
 fn load_entries_from_database(
     db_path: &Path,
     tz: Option<&JiffTimeZone>,
@@ -201,78 +213,203 @@ fn load_entries_from_database(
         );
         return Vec::new();
     };
-    // Push the window into SQL only while a sample of `time_created` still looks
-    // millisecond-scaled. The sample cannot prove the whole column is, which is
-    // why the payload check in the loop stays authoritative either way.
-    let pushdown = if window.is_unbounded() || time_created_looks_like_millis(&connection) {
-        window.widened_for_pushdown()
-    } else {
-        debug_log(
-            shared,
-            format!(
-                "OpenCode time_created is not millisecond-scale; scanning unfiltered: {}",
-                db_path.display()
-            ),
-        );
-        DateWindow::UNBOUNDED
-    };
-    let statement = prepare_message_query(&connection, pushdown).or_else(|| {
-        // A pre-SQLite-era schema has no `time_created` column, so the filtered
-        // query cannot prepare. Scan unfiltered rather than return nothing.
-        debug_log(
-            shared,
-            format!(
-                "Failed to prepare filtered OpenCode query; scanning unfiltered: {}",
-                db_path.display()
-            ),
-        );
-        prepare_message_query(&connection, DateWindow::UNBOUNDED)
-    });
-    let Some(mut statement) = statement else {
-        debug_log(
-            shared,
-            format!("Failed to read OpenCode database: {}", db_path.display()),
-        );
-        return Vec::new();
-    };
     let mut entries = Vec::new();
-    loop {
-        match statement.next() {
-            Ok(sqlite::State::Row) => {
-                let Ok(id) = statement.read::<String, _>(0) else {
-                    continue;
-                };
-                let Ok(session_id) = statement.read::<String, _>(1) else {
-                    continue;
-                };
-                let Ok(data) = statement.read::<String, _>(2) else {
-                    continue;
-                };
-                if !window.is_unbounded()
-                    && let Some(millis) = extract_message_timestamp(&data)
-                    && !window.contains(millis)
-                {
-                    continue;
-                }
-                let Ok(value) = serde_json::from_str::<OpenCodeMessage>(&data) else {
-                    continue;
-                };
-                if let Some(entry) =
-                    message_value_to_entry(&value, Some(id), Some(session_id), tz, mode, pricing)
-                {
-                    entries.push(entry);
-                }
-            }
-            Ok(sqlite::State::Done) => break,
-            Err(_) => {
+
+    let mut seen_message_ids = HashSet::new();
+    let mut message_sessions = HashSet::new();
+
+    if table_exists(&connection, "message") {
+        // Push the window into SQL only while a sample of `time_created` still
+        // looks millisecond-scaled. The payload check remains authoritative.
+        let pushdown =
+            if window.is_unbounded() || time_created_looks_like_millis(&connection, "message") {
+                window.widened_for_pushdown()
+            } else {
                 debug_log(
                     shared,
-                    format!("Failed to query OpenCode database: {}", db_path.display()),
+                    format!(
+                        "OpenCode time_created is not millisecond-scale; scanning unfiltered: {}",
+                        db_path.display()
+                    ),
                 );
-                break;
+                DateWindow::UNBOUNDED
+            };
+        let statement = prepare_message_query(&connection, pushdown).or_else(|| {
+            // A pre-SQLite-era schema has no `time_created` column, so the
+            // filtered query cannot prepare. Scan unfiltered instead.
+            debug_log(
+                shared,
+                format!(
+                    "Failed to prepare filtered OpenCode query; scanning unfiltered: {}",
+                    db_path.display()
+                ),
+            );
+            prepare_message_query(&connection, DateWindow::UNBOUNDED)
+        });
+        if let Some(mut statement) = statement {
+            loop {
+                match statement.next() {
+                    Ok(sqlite::State::Row) => {
+                        let Ok(id) = statement.read::<String, _>(0) else {
+                            continue;
+                        };
+                        let Ok(session_id) = statement.read::<String, _>(1) else {
+                            continue;
+                        };
+                        let Ok(data) = statement.read::<String, _>(2) else {
+                            continue;
+                        };
+                        if !window.is_unbounded()
+                            && let Some(millis) = extract_message_timestamp(&data)
+                            && !window.contains(millis)
+                        {
+                            continue;
+                        }
+                        let Ok(value) = serde_json::from_str::<OpenCodeMessage>(&data) else {
+                            continue;
+                        };
+                        if let Some(entry) = message_value_to_entry(
+                            &value,
+                            Some(id),
+                            Some(session_id),
+                            tz,
+                            mode,
+                            pricing,
+                        ) {
+                            let session_key = entry.session_id.to_string();
+                            message_sessions.insert(session_key);
+                            push_unique_entry(&mut entries, &mut seen_message_ids, entry);
+                        }
+                    }
+                    Ok(sqlite::State::Done) => break,
+                    Err(_) => {
+                        debug_log(
+                            shared,
+                            format!("Failed to query OpenCode database: {}", db_path.display()),
+                        );
+                        break;
+                    }
+                }
             }
+        } else {
+            debug_log(
+                shared,
+                format!("Failed to read OpenCode database: {}", db_path.display()),
+            );
         }
     }
+
+    let has_session_messages = table_exists(&connection, "session_message");
+    if has_session_messages {
+        let pushdown = if window.is_unbounded()
+            || time_created_looks_like_millis(&connection, "session_message")
+        {
+            window.widened_for_pushdown()
+        } else {
+            DateWindow::UNBOUNDED
+        };
+        let statement = prepare_session_message_query(&connection, pushdown).or_else(|| {
+            debug_log(
+                shared,
+                format!(
+                    "Failed to prepare filtered OpenCode v2 query; scanning unfiltered: {}",
+                    db_path.display()
+                ),
+            );
+            prepare_session_message_query(&connection, DateWindow::UNBOUNDED)
+        });
+        let mut v2_rows = 0;
+        let mut v2_entries = 0;
+        if let Some(mut statement) = statement {
+            loop {
+                match statement.next() {
+                    Ok(sqlite::State::Row) => {
+                        v2_rows += 1;
+                        let Ok(id) = statement.read::<String, _>(0) else {
+                            continue;
+                        };
+                        let Ok(session_id) = statement.read::<String, _>(1) else {
+                            continue;
+                        };
+                        let Ok(message_type) = statement.read::<String, _>(2) else {
+                            continue;
+                        };
+                        if message_type != "assistant" {
+                            continue;
+                        }
+                        let Ok(data) = statement.read::<String, _>(3) else {
+                            continue;
+                        };
+                        let created = statement
+                            .read::<i64, _>(4)
+                            .ok()
+                            .or_else(|| statement.read::<f64, _>(4).ok().map(|value| value as i64))
+                            .unwrap_or(0);
+                        if !window.is_unbounded()
+                            && let Some(millis) = extract_message_timestamp(&data)
+                            && !window.contains(millis)
+                        {
+                            continue;
+                        }
+                        let Some(entry) = session_message_value_to_entry(
+                            &data, id, session_id, created, tz, mode, pricing,
+                        ) else {
+                            continue;
+                        };
+                        let session_key = entry.session_id.to_string();
+                        v2_entries += 1;
+                        message_sessions.insert(session_key);
+                        push_unique_entry(&mut entries, &mut seen_message_ids, entry);
+                    }
+                    Ok(sqlite::State::Done) => break,
+                    Err(_) => {
+                        debug_log(
+                            shared,
+                            format!(
+                                "Failed to query OpenCode v2 database: {}",
+                                db_path.display()
+                            ),
+                        );
+                        break;
+                    }
+                }
+            }
+        }
+        if v2_rows > 0 && v2_entries == 0 {
+            debug_log(
+                shared,
+                format!(
+                    "OpenCode v2 rows produced no usage entries: {v2_rows} rows in {}",
+                    db_path.display()
+                ),
+            );
+        }
+    }
+
+    let mut aggregate_tables = Vec::new();
+    if table_exists(&connection, "session_v2") {
+        aggregate_tables.push("session_v2");
+    }
+    if has_session_messages && table_exists(&connection, "session") {
+        aggregate_tables.push("session");
+    }
+    let aggregate_context = DatabaseLoadContext {
+        tz,
+        mode,
+        pricing,
+        window,
+        shared,
+        db_path,
+    };
+    for table in aggregate_tables {
+        for entry in load_session_aggregate_entries(&connection, table, &aggregate_context) {
+            if message_sessions.contains(entry.session_id.as_ref()) {
+                continue;
+            }
+            push_unique_entry(&mut entries, &mut seen_message_ids, entry);
+        }
+    }
+
     entries
 }
 
@@ -308,6 +445,277 @@ fn read_message_file(
     }
     let value = serde_json::from_slice::<OpenCodeMessage>(&content).ok()?;
     message_value_to_entry(&value, None, None, tz, mode, pricing)
+}
+
+fn push_unique_entry(
+    entries: &mut Vec<LoadedEntry>,
+    seen_message_ids: &mut HashSet<String>,
+    entry: LoadedEntry,
+) -> bool {
+    if let Some(id) = entry_id(&entry)
+        && !seen_message_ids.insert(id.to_string())
+    {
+        return false;
+    }
+    entries.push(entry);
+    true
+}
+
+fn table_exists(connection: &sqlite::Connection, table: &str) -> bool {
+    let Ok(mut statement) = connection
+        .prepare("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?1 LIMIT 1")
+    else {
+        return false;
+    };
+    if statement.bind((1, table)).is_err() {
+        return false;
+    }
+    matches!(statement.next(), Ok(sqlite::State::Row))
+}
+
+fn table_columns(connection: &sqlite::Connection, table: &str) -> HashSet<String> {
+    let sql = match table {
+        "message" => "SELECT * FROM message LIMIT 0",
+        "session" => "SELECT * FROM session LIMIT 0",
+        "session_v2" => "SELECT * FROM session_v2 LIMIT 0",
+        "session_message" => "SELECT * FROM session_message LIMIT 0",
+        _ => return HashSet::new(),
+    };
+    let Ok(statement) = connection.prepare(sql) else {
+        return HashSet::new();
+    };
+    let mut columns = HashSet::new();
+    for index in 0..statement.column_count() {
+        if let Ok(name) = statement.column_name(index) {
+            columns.insert(name.to_string());
+        }
+    }
+    columns
+}
+
+fn prepare_session_message_query(
+    connection: &sqlite::Connection,
+    window: DateWindow,
+) -> Option<sqlite::Statement<'_>> {
+    let columns = table_columns(connection, "session_message");
+    if !["id", "session_id", "type", "data"]
+        .into_iter()
+        .all(|column| columns.contains(column))
+    {
+        return None;
+    }
+    let has_time_created = columns.contains("time_created");
+    let time_created = if has_time_created {
+        "time_created"
+    } else {
+        "NULL"
+    };
+    let sql = if has_time_created {
+        match (window.start, window.end) {
+            (Some(_), Some(_)) => format!(
+                "SELECT id, session_id, type, data, {time_created} FROM session_message \
+                 WHERE time_created >= ?1 AND time_created < ?2"
+            ),
+            (Some(_), None) => format!(
+                "SELECT id, session_id, type, data, {time_created} FROM session_message \
+                 WHERE time_created >= ?1"
+            ),
+            (None, Some(_)) => format!(
+                "SELECT id, session_id, type, data, {time_created} FROM session_message \
+                 WHERE time_created < ?1"
+            ),
+            (None, None) => {
+                format!("SELECT id, session_id, type, data, {time_created} FROM session_message")
+            }
+        }
+    } else {
+        "SELECT id, session_id, type, data, NULL FROM session_message".to_string()
+    };
+    let mut statement = connection.prepare(&sql).ok()?;
+    if has_time_created {
+        for (index, bound) in [window.start, window.end].into_iter().flatten().enumerate() {
+            statement.bind((index + 1, bound)).ok()?;
+        }
+    }
+    Some(statement)
+}
+
+fn prepare_session_aggregate_query<'a>(
+    connection: &'a sqlite::Connection,
+    table: &str,
+) -> Option<sqlite::Statement<'a>> {
+    let table = match table {
+        "session" => "session",
+        "session_v2" => "session_v2",
+        _ => return None,
+    };
+    let columns = table_columns(connection, table);
+    if ![
+        "id",
+        "time_created",
+        "cost",
+        "tokens_input",
+        "tokens_output",
+        "tokens_cache_read",
+        "tokens_cache_write",
+    ]
+    .into_iter()
+    .all(|column| columns.contains(column))
+    {
+        return None;
+    }
+    let reasoning = if columns.contains("tokens_reasoning") {
+        "tokens_reasoning"
+    } else {
+        "0"
+    };
+    let model = if columns.contains("model") {
+        "model"
+    } else {
+        "NULL"
+    };
+    let sql = format!(
+        "SELECT id, time_created, cost, tokens_input, tokens_output, \
+         tokens_cache_read, tokens_cache_write, {reasoning}, {model} FROM {table}"
+    );
+    connection.prepare(&sql).ok()
+}
+
+fn load_session_aggregate_entries(
+    connection: &sqlite::Connection,
+    table: &str,
+    context: &DatabaseLoadContext<'_>,
+) -> Vec<LoadedEntry> {
+    let Some(mut statement) = prepare_session_aggregate_query(connection, table) else {
+        debug_log(
+            context.shared,
+            format!(
+                "Failed to read OpenCode {table} table: {}",
+                context.db_path.display()
+            ),
+        );
+        return Vec::new();
+    };
+    let mut entries = Vec::new();
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                let Ok(session_id) = statement.read::<String, _>(0) else {
+                    continue;
+                };
+                let Some(created) = read_f64(&statement, 1)
+                    .filter(|value| value.is_finite())
+                    .map(|value| value.trunc() as i64)
+                else {
+                    continue;
+                };
+                if !context.window.is_unbounded() && !context.window.contains(created) {
+                    continue;
+                }
+                let cost = read_f64(&statement, 2);
+                let input_tokens = read_u64(&statement, 3);
+                let output_tokens = read_u64(&statement, 4);
+                let cache_read_tokens = read_u64(&statement, 5);
+                let cache_write_tokens = read_u64(&statement, 6);
+                let reasoning_tokens = read_u64(&statement, 7);
+                let model = statement.read::<String, _>(8).ok();
+                let (model, provider) = parse_session_model(model.as_deref())
+                    .unwrap_or_else(|| ("unknown".to_string(), "unknown".to_string()));
+                if let Some(entry) = session_value_to_entry(
+                    OpenCodeSessionAggregate {
+                        session_id,
+                        created,
+                        model,
+                        provider,
+                        input_tokens,
+                        output_tokens,
+                        reasoning_tokens,
+                        cache_read_tokens,
+                        cache_write_tokens,
+                        cost,
+                    },
+                    context.tz,
+                    context.mode,
+                    context.pricing,
+                ) {
+                    entries.push(entry);
+                }
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => {
+                debug_log(
+                    context.shared,
+                    format!(
+                        "Failed to query OpenCode {table} table: {}",
+                        context.db_path.display()
+                    ),
+                );
+                break;
+            }
+        }
+    }
+    entries
+}
+
+fn parse_session_model(value: Option<&str>) -> Option<(String, String)> {
+    let value = value?.trim();
+    if value.is_empty() {
+        return None;
+    }
+    if let Ok(json) = serde_json::from_str::<serde_json::Value>(value) {
+        if let Some(model) = json
+            .as_str()
+            .map(str::trim)
+            .filter(|model| !model.is_empty())
+        {
+            return Some((model.to_string(), "unknown".to_string()));
+        }
+        if let Some(object) = json.as_object() {
+            let model = object
+                .get("id")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| object.get("modelID").and_then(serde_json::Value::as_str))
+                .map(str::trim)
+                .filter(|model| !model.is_empty())?;
+            let provider = object
+                .get("providerID")
+                .and_then(serde_json::Value::as_str)
+                .or_else(|| object.get("provider").and_then(serde_json::Value::as_str))
+                .map(str::trim)
+                .filter(|provider| !provider.is_empty())
+                .unwrap_or("unknown");
+            return Some((model.to_string(), provider.to_string()));
+        }
+    }
+    Some((value.to_string(), "unknown".to_string()))
+}
+
+fn read_u64(statement: &sqlite::Statement<'_>, index: usize) -> u64 {
+    statement
+        .read::<i64, _>(index)
+        .ok()
+        .and_then(|value| u64::try_from(value.max(0)).ok())
+        .or_else(|| {
+            statement
+                .read::<f64, _>(index)
+                .ok()
+                .filter(|value| value.is_finite() && *value > 0.0)
+                .map(|value| value.trunc() as u64)
+        })
+        .unwrap_or(0)
+}
+
+fn read_f64(statement: &sqlite::Statement<'_>, index: usize) -> Option<f64> {
+    statement
+        .read::<f64, _>(index)
+        .ok()
+        .filter(|value| value.is_finite())
+        .or_else(|| {
+            statement
+                .read::<i64, _>(index)
+                .ok()
+                .map(|value| value as f64)
+        })
 }
 
 fn entry_id(entry: &LoadedEntry) -> Option<&str> {
@@ -439,10 +847,18 @@ const MIN_MILLIS_SCALE: i64 = 100_000_000_000;
 /// does catch is a build that stored seconds, or left the column at zero, where
 /// millisecond bounds would otherwise exclude every row — those disable the
 /// push-down and leave the payload check to filter.
-fn time_created_looks_like_millis(connection: &sqlite::Connection) -> bool {
-    let Ok(mut statement) = connection
-        .prepare("SELECT max(time_created) FROM (SELECT time_created FROM message LIMIT 8)")
-    else {
+fn time_created_looks_like_millis(connection: &sqlite::Connection, table: &str) -> bool {
+    let sql = match table {
+        "message" => "SELECT max(time_created) FROM (SELECT time_created FROM message LIMIT 8)",
+        "session_message" => {
+            "SELECT max(time_created) FROM (SELECT time_created FROM session_message LIMIT 8)"
+        }
+        _ => return false,
+    };
+    if !table_columns(connection, table).contains("time_created") {
+        return false;
+    }
+    let Ok(mut statement) = connection.prepare(sql) else {
         return false;
     };
     match statement.next() {
@@ -513,6 +929,107 @@ mod tests {
         statement.next().unwrap();
     }
 
+    fn create_db_session_message_table(path: &Path, with_time_created: bool) {
+        let db = sqlite::open(path).unwrap();
+        let schema = if with_time_created {
+            "CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT, type TEXT, time_created INTEGER, data TEXT)"
+        } else {
+            "CREATE TABLE session_message (id TEXT PRIMARY KEY, session_id TEXT, type TEXT, data TEXT)"
+        };
+        db.execute(schema).unwrap();
+    }
+
+    fn insert_db_session_message(
+        path: &Path,
+        id: &str,
+        session_id: &str,
+        message_type: &str,
+        time_created: i64,
+        data: &str,
+        with_time_created: bool,
+    ) {
+        let db = sqlite::open(path).unwrap();
+        if with_time_created {
+            let mut statement = db
+                .prepare(
+                    "INSERT INTO session_message (id, session_id, type, time_created, data) \
+                     VALUES (?1, ?2, ?3, ?4, ?5)",
+                )
+                .unwrap();
+            statement.bind((1, id)).unwrap();
+            statement.bind((2, session_id)).unwrap();
+            statement.bind((3, message_type)).unwrap();
+            statement.bind((4, time_created)).unwrap();
+            statement.bind((5, data)).unwrap();
+            statement.next().unwrap();
+        } else {
+            let mut statement = db
+                .prepare(
+                    "INSERT INTO session_message (id, session_id, type, data) \
+                     VALUES (?1, ?2, ?3, ?4)",
+                )
+                .unwrap();
+            statement.bind((1, id)).unwrap();
+            statement.bind((2, session_id)).unwrap();
+            statement.bind((3, message_type)).unwrap();
+            statement.bind((4, data)).unwrap();
+            statement.next().unwrap();
+        }
+    }
+
+    fn create_db_session_aggregate_table(path: &Path, table: &str) {
+        let schema = match table {
+            "session_v2" => {
+                "CREATE TABLE session_v2 (id TEXT PRIMARY KEY, time_created INTEGER, cost REAL, tokens_input INTEGER, tokens_output INTEGER, tokens_cache_read INTEGER, tokens_cache_write INTEGER, tokens_reasoning INTEGER, model TEXT)"
+            }
+            "session" => {
+                "CREATE TABLE session (id TEXT PRIMARY KEY, time_created INTEGER, cost REAL, tokens_input INTEGER, tokens_output INTEGER, tokens_cache_read INTEGER, tokens_cache_write INTEGER, tokens_reasoning INTEGER, model TEXT)"
+            }
+            _ => panic!("unsupported test session table: {table}"),
+        };
+        sqlite::open(path).unwrap().execute(schema).unwrap();
+    }
+
+    struct SessionAggregateFixture<'a> {
+        session_id: &'a str,
+        time_created: i64,
+        model: &'a str,
+        cost: f64,
+        input_tokens: i64,
+        output_tokens: i64,
+        cache_read_tokens: i64,
+        cache_write_tokens: i64,
+        reasoning_tokens: i64,
+    }
+
+    fn insert_db_session_aggregate(
+        path: &Path,
+        table: &str,
+        fixture: &SessionAggregateFixture<'_>,
+    ) {
+        let sql = match table {
+            "session_v2" => {
+                "INSERT INTO session_v2 (id, time_created, cost, tokens_input, tokens_output, tokens_cache_read, tokens_cache_write, tokens_reasoning, model) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
+            }
+            "session" => {
+                "INSERT INTO session (id, time_created, cost, tokens_input, tokens_output, tokens_cache_read, tokens_cache_write, tokens_reasoning, model) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)"
+            }
+            _ => panic!("unsupported test session table: {table}"),
+        };
+        let db = sqlite::open(path).unwrap();
+        let mut statement = db.prepare(sql).unwrap();
+        statement.bind((1, fixture.session_id)).unwrap();
+        statement.bind((2, fixture.time_created)).unwrap();
+        statement.bind((3, fixture.cost)).unwrap();
+        statement.bind((4, fixture.input_tokens)).unwrap();
+        statement.bind((5, fixture.output_tokens)).unwrap();
+        statement.bind((6, fixture.cache_read_tokens)).unwrap();
+        statement.bind((7, fixture.cache_write_tokens)).unwrap();
+        statement.bind((8, fixture.reasoning_tokens)).unwrap();
+        statement.bind((9, fixture.model)).unwrap();
+        statement.next().unwrap();
+    }
+
     #[test]
     fn loads_message_json_files() {
         let fixture = fs_fixture!({
@@ -572,6 +1089,221 @@ mod tests {
         );
         assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 12);
         assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
+    fn loads_nested_v2_assistant_usage_and_ignores_session_aggregate() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_session_message_table(&db_path, true);
+        insert_db_session_message(
+            &db_path,
+            "msg-v2-user",
+            "v2-session",
+            "user",
+            1_767_312_000_000,
+            r#"{"text":"hello","time":{"created":1767312000000}}"#,
+            true,
+        );
+        insert_db_session_message(
+            &db_path,
+            "msg-v2-assistant",
+            "v2-session",
+            "assistant",
+            1_767_312_000_001,
+            r#"{"model":{"id":"gpt-test","providerID":"openai"},"time":{"created":1767312000000},"tokens":{"input":120,"output":60,"reasoning":10,"cache":{"read":12,"write":24}},"cost":0.03}"#,
+            true,
+        );
+        create_db_session_aggregate_table(&db_path, "session");
+        insert_db_session_aggregate(
+            &db_path,
+            "session",
+            &SessionAggregateFixture {
+                session_id: "v2-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries_from_directory(fixture.root(), &shared).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("msg-v2-assistant")
+        );
+        assert_eq!(entries[0].session_id.as_ref(), "v2-session");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 120);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 60);
+        assert_eq!(
+            entries[0].data.message.usage.cache_creation_input_tokens,
+            24
+        );
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 12);
+        assert_eq!(entries[0].extra_total_tokens, 10);
+        assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
+    fn loads_v2_messages_without_a_time_created_column() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_session_message_table(&db_path, false);
+        insert_db_session_message(
+            &db_path,
+            "msg-v2-no-time-column",
+            "v2-session",
+            "assistant",
+            1_767_312_000_000,
+            r#"{"model":{"id":"gpt-test","providerID":"openai"},"time":{"created":1767312000000},"tokens":{"input":2,"output":3},"cost":0.01}"#,
+            false,
+        );
+
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].date, "2026-01-02");
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("msg-v2-no-time-column")
+        );
+    }
+
+    #[test]
+    fn deduplicates_legacy_and_v2_rows_by_message_id() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_message(
+            &db_path,
+            "msg-shared",
+            "legacy-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":120,"output":60},"cost":0.03}"#,
+        );
+        create_db_session_message_table(&db_path, true);
+        insert_db_session_message(
+            &db_path,
+            "msg-shared",
+            "v2-session",
+            "assistant",
+            1_767_312_000_000,
+            r#"{"model":{"id":"gpt-test","providerID":"openai"},"time":{"created":1767312000000},"tokens":{"input":999,"output":999},"cost":9.99}"#,
+            true,
+        );
+
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "legacy-session");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 120);
+        assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
+    fn uses_session_v2_aggregate_when_no_message_level_usage_exists() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "aggregate-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 0.25,
+                input_tokens: 100,
+                output_tokens: 50,
+                cache_read_tokens: 10,
+                cache_write_tokens: 20,
+                reasoning_tokens: 5,
+            },
+        );
+
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "aggregate-session");
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("session:aggregate-session")
+        );
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 50);
+        assert_eq!(entries[0].extra_total_tokens, 5);
+        assert_eq!(entries[0].cost, 0.25);
+    }
+
+    #[test]
+    fn uses_current_session_table_as_v2_aggregate_fallback() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_session_message_table(&db_path, true);
+        create_db_session_aggregate_table(&db_path, "session");
+        insert_db_session_aggregate(
+            &db_path,
+            "session",
+            &SessionAggregateFixture {
+                session_id: "current-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 0.5,
+                input_tokens: 200,
+                output_tokens: 100,
+                cache_read_tokens: 20,
+                cache_write_tokens: 40,
+                reasoning_tokens: 0,
+            },
+        );
+
+        let entries = load_entries_from_directory(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "current-session");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 200);
+        assert_eq!(entries[0].cost, 0.5);
     }
 
     #[test]

--- a/rust/adapters/opencode/src/loader.rs
+++ b/rust/adapters/opencode/src/loader.rs
@@ -15,23 +15,32 @@ use super::{
 };
 use crate::{
     LoadedEntry, PricingMap, Result,
-    cli::{CostMode, SharedArgs},
+    cli::{AgentReportKind, CostMode, SharedArgs},
     collect_files_with_extension, date_range_bounds_ms, debug_log, parse_tz, read_files_parallel,
 };
 
-pub fn load_entries(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
+pub fn load_entries(shared: &SharedArgs, report_kind: AgentReportKind) -> Result<Vec<LoadedEntry>> {
+    let allow_aggregate_fallback = report_kind == AgentReportKind::Session;
     crate::progress::track_usage_load(
         crate::progress::UsageLoadAgent("OpenCode"),
         shared.json,
-        || load_entries_inner(shared),
+        || load_entries_inner(shared, allow_aggregate_fallback),
     )
 }
 
-fn load_entries_inner(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
+fn load_entries_inner(
+    shared: &SharedArgs,
+    allow_aggregate_fallback: bool,
+) -> Result<Vec<LoadedEntry>> {
     let mut entries = Vec::new();
     let mut seen = HashSet::new();
+    let mut message_sessions = HashSet::new();
+    let mut aggregate_entries = Vec::new();
     for path in paths()? {
-        for entry in load_entries_from_directory(&path, shared)? {
+        let directory_entries =
+            load_entries_from_directory_parts(&path, shared, allow_aggregate_fallback)?;
+        for entry in directory_entries.message_entries {
+            message_sessions.insert(entry.session_id.to_string());
             if let Some(id) = entry_id(&entry)
                 && !seen.insert(id.to_string())
             {
@@ -39,15 +48,66 @@ fn load_entries_inner(shared: &SharedArgs) -> Result<Vec<LoadedEntry>> {
             }
             entries.push(entry);
         }
+        aggregate_entries.extend(directory_entries.aggregate_entries);
     }
+    append_aggregate_entries(
+        &mut entries,
+        &mut seen,
+        &message_sessions,
+        aggregate_entries,
+    );
     entries.sort_by_key(|entry| entry.timestamp);
     Ok(entries)
 }
 
-pub fn load_entries_from_directory(
+#[cfg(test)]
+fn load_entries_from_directory(
     opencode_dir: &Path,
     shared: &SharedArgs,
 ) -> Result<Vec<LoadedEntry>> {
+    let directory_entries = load_entries_from_directory_parts(opencode_dir, shared, false)?;
+    let message_sessions = message_session_ids(&directory_entries.message_entries);
+    let mut seen = entry_ids(&directory_entries.message_entries);
+    let mut entries = directory_entries.message_entries;
+    append_aggregate_entries(
+        &mut entries,
+        &mut seen,
+        &message_sessions,
+        directory_entries.aggregate_entries,
+    );
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+#[cfg(test)]
+fn load_entries_from_directory_for_report(
+    opencode_dir: &Path,
+    shared: &SharedArgs,
+    report_kind: AgentReportKind,
+) -> Result<Vec<LoadedEntry>> {
+    let directory_entries = load_entries_from_directory_parts(
+        opencode_dir,
+        shared,
+        report_kind == AgentReportKind::Session,
+    )?;
+    let message_sessions = message_session_ids(&directory_entries.message_entries);
+    let mut seen = entry_ids(&directory_entries.message_entries);
+    let mut entries = directory_entries.message_entries;
+    append_aggregate_entries(
+        &mut entries,
+        &mut seen,
+        &message_sessions,
+        directory_entries.aggregate_entries,
+    );
+    entries.sort_by_key(|entry| entry.timestamp);
+    Ok(entries)
+}
+
+fn load_entries_from_directory_parts(
+    opencode_dir: &Path,
+    shared: &SharedArgs,
+    allow_aggregate_fallback: bool,
+) -> Result<DirectoryLoadResult> {
     let pricing = if shared.mode == CostMode::Display {
         None
     } else {
@@ -59,7 +119,7 @@ pub fn load_entries_from_directory(
     };
     let tz = parse_tz(shared.timezone.as_deref());
     let window = DateWindow::from_shared(shared, tz.as_ref());
-    let mut entries = Vec::new();
+    let mut message_entries = Vec::new();
     let mut seen = HashSet::new();
     let mut aggregate_entries = Vec::new();
     if let Some(db_path) = db_path(opencode_dir) {
@@ -70,6 +130,7 @@ pub fn load_entries_from_directory(
             pricing.as_ref(),
             shared,
             window,
+            allow_aggregate_fallback,
         );
         for entry in database_entries.message_entries {
             if let Some(id) = entry_id(&entry)
@@ -77,7 +138,7 @@ pub fn load_entries_from_directory(
             {
                 continue;
             }
-            entries.push(entry);
+            message_entries.push(entry);
         }
         aggregate_entries = database_entries.aggregate_entries;
     }
@@ -119,26 +180,13 @@ pub fn load_entries_from_directory(
         {
             continue;
         }
-        entries.push(entry);
+        message_entries.push(entry);
     }
 
-    let message_sessions = entries
-        .iter()
-        .map(|entry| entry.session_id.to_string())
-        .collect::<HashSet<_>>();
-    for entry in aggregate_entries {
-        if message_sessions.contains(entry.session_id.as_ref()) {
-            continue;
-        }
-        if let Some(id) = entry_id(&entry)
-            && !seen.insert(id.to_string())
-        {
-            continue;
-        }
-        entries.push(entry);
-    }
-    entries.sort_by_key(|entry| entry.timestamp);
-    Ok(entries)
+    Ok(DirectoryLoadResult {
+        message_entries,
+        aggregate_entries,
+    })
 }
 
 /// Reports whether `opencode_dir` holds any usage source at all: the SQLite
@@ -221,6 +269,12 @@ struct DatabaseLoadResult {
     aggregate_entries: Vec<LoadedEntry>,
 }
 
+#[derive(Default)]
+struct DirectoryLoadResult {
+    message_entries: Vec<LoadedEntry>,
+    aggregate_entries: Vec<LoadedEntry>,
+}
+
 fn load_entries_from_database(
     db_path: &Path,
     tz: Option<&JiffTimeZone>,
@@ -228,6 +282,7 @@ fn load_entries_from_database(
     pricing: Option<&PricingMap>,
     shared: &SharedArgs,
     window: DateWindow,
+    allow_aggregate_fallback: bool,
 ) -> DatabaseLoadResult {
     let Ok(connection) =
         sqlite::Connection::open_with_flags(db_path, sqlite::OpenFlags::new().with_read_only())
@@ -412,7 +467,7 @@ fn load_entries_from_database(
     }
 
     let mut aggregate_entries = Vec::new();
-    if window.is_unbounded() {
+    if allow_aggregate_fallback && !has_temporal_filter(shared) {
         // Session aggregates are cumulative and cannot be sliced safely for a
         // bounded report, so only unbounded reports may use this fallback.
         let mut aggregate_tables = Vec::new();
@@ -492,6 +547,42 @@ fn push_unique_entry(
     }
     entries.push(entry);
     true
+}
+
+#[cfg(test)]
+fn entry_ids(entries: &[LoadedEntry]) -> HashSet<String> {
+    entries
+        .iter()
+        .filter_map(entry_id)
+        .map(str::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+fn message_session_ids(entries: &[LoadedEntry]) -> HashSet<String> {
+    entries
+        .iter()
+        .map(|entry| entry.session_id.to_string())
+        .collect()
+}
+
+fn append_aggregate_entries(
+    entries: &mut Vec<LoadedEntry>,
+    seen: &mut HashSet<String>,
+    message_sessions: &HashSet<String>,
+    aggregate_entries: Vec<LoadedEntry>,
+) {
+    for entry in aggregate_entries {
+        if message_sessions.contains(entry.session_id.as_ref()) {
+            continue;
+        }
+        if let Some(id) = entry_id(&entry)
+            && !seen.insert(id.to_string())
+        {
+            continue;
+        }
+        entries.push(entry);
+    }
 }
 
 fn table_exists(connection: &sqlite::Connection, table: &str) -> bool {
@@ -792,6 +883,10 @@ struct DateWindow {
     end: Option<i64>,
 }
 
+fn has_temporal_filter(shared: &SharedArgs) -> bool {
+    shared.since.is_some() || shared.until.is_some() || shared.last.is_some()
+}
+
 impl DateWindow {
     const UNBOUNDED: Self = Self {
         start: None,
@@ -904,11 +999,13 @@ fn time_created_looks_like_millis(connection: &sqlite::Connection, table: &str) 
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
+    use std::{ffi::OsString, path::Path};
 
-    use super::load_entries_from_directory;
-    use crate::cli::{CostMode, SharedArgs};
-    use ccusage_test_support::fs_fixture;
+    use super::{
+        load_entries, load_entries_from_directory, load_entries_from_directory_for_report,
+    };
+    use crate::cli::{AgentReportKind, CostMode, SharedArgs};
+    use ccusage_test_support::{EnvVarsGuard, fs_fixture};
 
     // Mirrors the real OpenCode schema, where `time_created` repeats the
     // payload's `time.created`, so tests exercise the range push-down.
@@ -1169,7 +1266,12 @@ mod tests {
             timezone: Some("UTC".to_string()),
             ..SharedArgs::default()
         };
-        let entries = load_entries_from_directory(fixture.root(), &shared).unwrap();
+        let entries = load_entries_from_directory_for_report(
+            fixture.root(),
+            &shared,
+            AgentReportKind::Session,
+        )
+        .unwrap();
 
         assert_eq!(entries.len(), 1);
         assert_eq!(
@@ -1281,13 +1383,14 @@ mod tests {
             },
         );
 
-        let entries = load_entries_from_directory(
+        let entries = load_entries_from_directory_for_report(
             fixture.root(),
             &SharedArgs {
                 mode: CostMode::Display,
                 timezone: Some("UTC".to_string()),
                 ..SharedArgs::default()
             },
+            AgentReportKind::Session,
         )
         .unwrap();
 
@@ -1322,13 +1425,14 @@ mod tests {
             },
         );
 
-        let entries = load_entries_from_directory(
+        let entries = load_entries_from_directory_for_report(
             fixture.root(),
             &SharedArgs {
                 mode: CostMode::Display,
                 timezone: Some("UTC".to_string()),
                 ..SharedArgs::default()
             },
+            AgentReportKind::Session,
         )
         .unwrap();
 
@@ -1367,7 +1471,7 @@ mod tests {
 
         // The cumulative aggregate includes usage outside this window, so it
         // cannot be attributed safely to the requested date range.
-        let entries = load_entries_from_directory(
+        let entries = load_entries_from_directory_for_report(
             fixture.root(),
             &SharedArgs {
                 mode: CostMode::Display,
@@ -1376,10 +1480,209 @@ mod tests {
                 until: Some("20260103".to_string()),
                 ..SharedArgs::default()
             },
+            AgentReportKind::Session,
         )
         .unwrap();
 
         assert!(entries.is_empty());
+    }
+
+    #[test]
+    fn keeps_message_rows_but_excludes_aggregate_for_partial_since_bound() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_message(
+            &db_path,
+            "partial-since-message",
+            "partial-since-message-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":1,"output":1},"cost":0.01}"#,
+        );
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "partial-since-aggregate-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+
+        let entries = load_entries_from_directory_for_report(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                since: Some("2026".to_string()),
+                ..SharedArgs::default()
+            },
+            AgentReportKind::Session,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("partial-since-message")
+        );
+    }
+
+    #[test]
+    fn keeps_message_rows_but_excludes_aggregate_for_partial_until_bound() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_message(
+            &db_path,
+            "partial-until-message",
+            "partial-until-message-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":1,"output":1},"cost":0.01}"#,
+        );
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "partial-until-aggregate-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+
+        let entries = load_entries_from_directory_for_report(
+            fixture.root(),
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                until: Some("2026-02".to_string()),
+                ..SharedArgs::default()
+            },
+            AgentReportKind::Session,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("partial-until-message")
+        );
+    }
+
+    #[test]
+    fn suppresses_aggregate_when_message_usage_is_in_another_configured_directory() {
+        let aggregate_fixture = fs_fixture!({});
+        let aggregate_db_path = aggregate_fixture.path("opencode.db");
+        create_db_session_aggregate_table(&aggregate_db_path, "session_v2");
+        insert_db_session_aggregate(
+            &aggregate_db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "cross-directory-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+        let message_fixture = fs_fixture!({
+            "storage/message/cross-directory-session/cross-directory-message.json": r#"{"id":"cross-directory-message","sessionID":"cross-directory-session","providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":12,"output":6},"cost":0.03}"#,
+        });
+        let _guard = EnvVarsGuard::set_many([(
+            "OPENCODE_DATA_DIR",
+            Some(OsString::from(format!(
+                "{},{}",
+                aggregate_fixture.root().display(),
+                message_fixture.root().display()
+            ))),
+        )]);
+
+        let entries = load_entries(
+            &SharedArgs {
+                mode: CostMode::Display,
+                timezone: Some("UTC".to_string()),
+                ..SharedArgs::default()
+            },
+            AgentReportKind::Session,
+        )
+        .unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(
+            entries[0].data.message.id.as_deref(),
+            Some("cross-directory-message")
+        );
+        assert_eq!(entries[0].cost, 0.03);
+    }
+
+    #[test]
+    fn only_session_reports_use_cumulative_session_aggregate_fallback() {
+        let fixture = fs_fixture!({});
+        let db_path = fixture.path("opencode.db");
+        create_db_message(
+            &db_path,
+            "period-message",
+            "period-message-session",
+            r#"{"providerID":"anthropic","modelID":"claude-sonnet-4-20250514","time":{"created":1767312000000},"tokens":{"input":1,"output":1},"cost":0.01}"#,
+        );
+        create_db_session_aggregate_table(&db_path, "session_v2");
+        insert_db_session_aggregate(
+            &db_path,
+            "session_v2",
+            &SessionAggregateFixture {
+                session_id: "period-aggregate-session",
+                time_created: 1_767_312_000_000,
+                model: r#"{"id":"gpt-test","providerID":"openai"}"#,
+                cost: 9.99,
+                input_tokens: 9_999,
+                output_tokens: 9_999,
+                cache_read_tokens: 0,
+                cache_write_tokens: 0,
+                reasoning_tokens: 0,
+            },
+        );
+        let _guard = EnvVarsGuard::set_many([(
+            "OPENCODE_DATA_DIR",
+            Some(fixture.root().as_os_str().to_os_string()),
+        )]);
+        let shared = SharedArgs {
+            mode: CostMode::Display,
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+
+        for report_kind in [
+            AgentReportKind::Daily,
+            AgentReportKind::Weekly,
+            AgentReportKind::Monthly,
+        ] {
+            let entries = load_entries(&shared, report_kind).unwrap();
+            assert_eq!(entries.len(), 1);
+            assert_eq!(
+                entries[0].data.message.id.as_deref(),
+                Some("period-message")
+            );
+        }
+
+        let session_entries = load_entries(&shared, AgentReportKind::Session).unwrap();
+        assert_eq!(session_entries.len(), 2);
+        assert!(session_entries.iter().any(|entry| {
+            entry.data.message.id.as_deref() == Some("session:period-aggregate-session")
+        }));
     }
 
     #[test]
@@ -1404,13 +1707,14 @@ mod tests {
             },
         );
 
-        let entries = load_entries_from_directory(
+        let entries = load_entries_from_directory_for_report(
             fixture.root(),
             &SharedArgs {
                 mode: CostMode::Display,
                 timezone: Some("UTC".to_string()),
                 ..SharedArgs::default()
             },
+            AgentReportKind::Session,
         )
         .unwrap();
 

--- a/rust/adapters/opencode/src/parser.rs
+++ b/rust/adapters/opencode/src/parser.rs
@@ -48,6 +48,8 @@ struct OpenCodeTokens {
     input: u64,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
     output: u64,
+    #[serde(default, deserialize_with = "jsonl::lenient_u64")]
+    reasoning: u64,
     #[serde(default, deserialize_with = "jsonl::lenient_object")]
     cache: Option<OpenCodeCache>,
     #[serde(default, deserialize_with = "jsonl::lenient_u64")]
@@ -70,6 +72,75 @@ struct OpenCodeTime {
     created: Option<i64>,
 }
 
+#[derive(Debug, Default, Deserialize)]
+struct OpenCodeModelReference {
+    #[serde(default, deserialize_with = "jsonl::non_empty_string")]
+    id: Option<String>,
+    #[serde(
+        rename = "modelID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(
+        rename = "providerID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    provider_id: Option<String>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct OpenCodeV2Message {
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
+    model: Option<OpenCodeModelReference>,
+    #[serde(
+        rename = "modelID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    model_id: Option<String>,
+    #[serde(
+        rename = "providerID",
+        default,
+        deserialize_with = "jsonl::non_empty_string"
+    )]
+    provider_id: Option<String>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
+    tokens: Option<OpenCodeTokens>,
+    #[serde(default, deserialize_with = "jsonl::lenient_object")]
+    time: Option<OpenCodeTime>,
+    #[serde(default, deserialize_with = "jsonl::lenient_f64")]
+    cost: Option<f64>,
+}
+
+impl OpenCodeV2Message {
+    fn into_legacy_message(self, id: String, session_id: String, created: i64) -> OpenCodeMessage {
+        let model_id = self
+            .model
+            .as_ref()
+            .and_then(|model| model.id.clone().or_else(|| model.model_id.clone()))
+            .or(self.model_id);
+        let provider_id = self
+            .model
+            .and_then(|model| model.provider_id)
+            .or(self.provider_id);
+        let time = Some(OpenCodeTime {
+            created: self.time.and_then(|time| time.created).or(Some(created)),
+        });
+
+        OpenCodeMessage {
+            tokens: self.tokens,
+            model_id,
+            provider_id,
+            time,
+            id: Some(id),
+            session_id: Some(session_id),
+            cost: self.cost,
+        }
+    }
+}
+
 pub fn message_value_to_entry(
     value: &OpenCodeMessage,
     id: Option<String>,
@@ -77,6 +148,18 @@ pub fn message_value_to_entry(
     tz: Option<&JiffTimeZone>,
     mode: CostMode,
     pricing: Option<&PricingMap>,
+) -> Option<LoadedEntry> {
+    message_value_to_entry_inner(value, id, session_id, tz, mode, pricing, false)
+}
+
+fn message_value_to_entry_inner(
+    value: &OpenCodeMessage,
+    id: Option<String>,
+    session_id: Option<String>,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+    allow_cost_only: bool,
 ) -> Option<LoadedEntry> {
     let tokens = value.tokens.as_ref()?;
     let cache = tokens.cache.as_ref();
@@ -89,12 +172,14 @@ pub fn message_value_to_entry(
         cache_creation: None,
     };
     let total_tokens = tokens.total;
-    let (usage, extra_total_tokens) = apply_total_token_fallback(usage, 0, total_tokens);
+    let (usage, extra_total_tokens) =
+        apply_total_token_fallback(usage, tokens.reasoning, total_tokens);
     if usage.input_tokens == 0
         && usage.output_tokens == 0
         && usage.cache_creation_input_tokens == 0
         && usage.cache_read_input_tokens == 0
         && extra_total_tokens == 0
+        && !(allow_cost_only && value.cost.is_some_and(|cost| cost > 0.0))
     {
         return None;
     }
@@ -157,6 +242,71 @@ pub fn message_value_to_entry(
         missing_pricing_model,
         data,
     })
+}
+
+pub(crate) fn session_message_value_to_entry(
+    data: &str,
+    id: String,
+    session_id: String,
+    created: i64,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<LoadedEntry> {
+    let value = serde_json::from_str::<OpenCodeV2Message>(data).ok()?;
+    let value = value.into_legacy_message(id, session_id, created);
+    message_value_to_entry(&value, None, None, tz, mode, pricing)
+}
+
+pub(crate) struct OpenCodeSessionAggregate {
+    pub(crate) session_id: String,
+    pub(crate) created: i64,
+    pub(crate) model: String,
+    pub(crate) provider: String,
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) reasoning_tokens: u64,
+    pub(crate) cache_read_tokens: u64,
+    pub(crate) cache_write_tokens: u64,
+    pub(crate) cost: Option<f64>,
+}
+
+pub(crate) fn session_value_to_entry(
+    aggregate: OpenCodeSessionAggregate,
+    tz: Option<&JiffTimeZone>,
+    mode: CostMode,
+    pricing: Option<&PricingMap>,
+) -> Option<LoadedEntry> {
+    if aggregate.input_tokens == 0
+        && aggregate.output_tokens == 0
+        && aggregate.reasoning_tokens == 0
+        && aggregate.cache_read_tokens == 0
+        && aggregate.cache_write_tokens == 0
+        && aggregate.cost.unwrap_or(0.0) <= 0.0
+    {
+        return None;
+    }
+    let value = OpenCodeMessage {
+        tokens: Some(OpenCodeTokens {
+            input: aggregate.input_tokens,
+            output: aggregate.output_tokens,
+            reasoning: aggregate.reasoning_tokens,
+            cache: Some(OpenCodeCache {
+                read: aggregate.cache_read_tokens,
+                write: aggregate.cache_write_tokens,
+            }),
+            total: 0,
+        }),
+        model_id: Some(aggregate.model),
+        provider_id: Some(aggregate.provider),
+        time: Some(OpenCodeTime {
+            created: Some(aggregate.created),
+        }),
+        id: Some(format!("session:{}", aggregate.session_id)),
+        session_id: Some(aggregate.session_id),
+        cost: aggregate.cost,
+    };
+    message_value_to_entry_inner(&value, None, None, tz, mode, pricing, true)
 }
 
 fn calculate_open_code_cost(

--- a/rust/crates/ccusage-adapter-all/src/loader.rs
+++ b/rust/crates/ccusage-adapter-all/src/loader.rs
@@ -135,7 +135,7 @@ fn load_base_rows(
                     "opencode",
                     load_kind,
                     &loader_shared,
-                    || opencode::load_entries(&loader_shared),
+                    || opencode::load_entries(&loader_shared, load_kind),
                     opencode::summarize_entries,
                 )?;
                 // The OpenCode loader narrows to the date window as it reads, so


### PR DESCRIPTION
Fixes #1644\n\nOpenCode v2 stores assistant usage in session_message.data instead of the legacy message table. This change:\n\n- reads nested assistant usage from session_message;\n- preserves legacy message loading;\n- supports session_v2 and current session aggregate schemas;\n- ignores non-assistant rows;\n- deduplicates shared message IDs;\n- avoids counting session aggregates when message-level usage exists.\n\nValidation:\n- OpenCode focused tests: 49 passed\n- rustfmt passed\n- clippy passed\n\nThe issue reporter is included as a commit co-author.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1644. OpenCode v2 stores assistant usage in `session_message.data` instead of the legacy `message` table, so v2 usage was previously missing. This PR reads that usage and falls back to `session_v2` or `session` aggregates when no message-level usage exists.

- Deduplicates shared message IDs so the same message isn't counted twice.
- Skips session aggregates when message-level usage exists for that session, across all configured directories.
- Uses session aggregates only for unbounded Session reports, since cumulative totals can't be sliced to a date range.
- Ignores non-assistant `session_message` rows.
- Works with `session_message` schemas that lack a `time_created` column.
- Parses reasoning tokens from v2 message data.

<sup>Written for commit 5592b887e87bb170ff1f904d5ba53eb8877280ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1668?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for importing usage data from OpenCode v2 sessions and messages.
  * Session-level usage information can now be imported when detailed message data is unavailable.
  * Improved recognition of model, provider, token, reasoning, and cost details across supported formats.

* **Bug Fixes**
  * Prevented duplicate entries when messages appear in multiple sources.
  * Limited session-level fallback data to session reports.
  * Improved handling of missing timestamps, cost-only records, and bounded time ranges.
  * Preserved compatibility with legacy OpenCode databases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->