### PR TITLE
feat(gemini): support Antigravity SQLite conversation database parsing

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -273,6 +273,7 @@ dependencies = [
  "jiff",
  "serde",
  "serde_json",
+ "sqlite",
 ]
 
 [[package]]

--- a/rust/adapters/gemini/Cargo.toml
+++ b/rust/adapters/gemini/Cargo.toml
@@ -10,6 +10,8 @@ ccusage-core.workspace = true
 jiff.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+sqlite.workspace = true
 
 [dev-dependencies]
+ccusage-core = { workspace = true, features = ["fetch-litellm-pricing"] }
 ccusage-test-support.workspace = true

--- a/rust/adapters/gemini/README.md
+++ b/rust/adapters/gemini/README.md
@@ -16,8 +16,9 @@ Anything that is not specific to this source belongs in `ccusage-core` or
 ## Data source
 
 - `${GEMINI_DATA_DIR:-~/.gemini}/tmp/**/chats/*.{json,jsonl}`
+- `${GEMINI_DATA_DIR:-~/.gemini}/antigravity/conversations/*.db`
 
-Reads plain files through `ccusage-adapter-common`, which handles walking, size-balanced
+Reads plain files and SQLite databases through `ccusage-adapter-common` and `sqlite`, which handles walking, size-balanced
 chunking, and ordered parallel reads.
 
 ## Public surface
@@ -34,6 +35,7 @@ chunking, and ordered parallel reads.
 - `jiff`
 - `serde`
 - `serde_json`
+- `sqlite`
 
 ## Build layer
 

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -7,6 +7,7 @@ use super::{
     paths::discover_log_files,
 };
 
+/// Loads Gemini CLI and Antigravity entries with progress tracking.
 pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     crate::progress::track_usage_load(
         crate::progress::UsageLoadAgent("Gemini CLI"),
@@ -15,6 +16,7 @@ pub fn load_entries(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<Loa
     )
 }
 
+/// Internal loader function that discovers and parses Gemini and Antigravity log files in parallel.
 fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<LoadedEntry>> {
     let tz = parse_tz(shared.timezone.as_deref());
     let files = discover_log_files()?;
@@ -118,12 +120,6 @@ mod tests {
         blob.push(field1_payload.len() as u8);
         blob.extend_from_slice(&field1_payload);
 
-        let mut statement = connection
-            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (1, ?)")
-            .unwrap();
-        statement.bind((1, blob.as_slice())).unwrap();
-        statement.next().unwrap();
-
         // Row 2: Continuation row with tokens only (no model field)
         let cont_tokens = vec![
             0x10, 0x90, 0x03, // 2: varint 400
@@ -143,11 +139,18 @@ mod tests {
         cont_blob.push(cont_field1.len() as u8);
         cont_blob.extend_from_slice(&cont_field1);
 
+        // Insert Row 2 first and Row 1 second to verify ORDER BY idx ASC
         let mut stmt2 = connection
             .prepare("INSERT INTO gen_metadata (idx, data) VALUES (2, ?)")
             .unwrap();
         stmt2.bind((1, cont_blob.as_slice())).unwrap();
         stmt2.next().unwrap();
+
+        let mut statement = connection
+            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (1, ?)")
+            .unwrap();
+        statement.bind((1, blob.as_slice())).unwrap();
+        statement.next().unwrap();
 
         let _env_guard = super::super::GeminiDataDirEnvGuard::set(fixture.root());
         let shared = SharedArgs {
@@ -157,7 +160,7 @@ mod tests {
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
 
         assert_eq!(entries.len(), 2);
-        // Row 1: Normalized from "Gemini 2.5 Flash (High)"
+        // Row 1 (idx=1): Normalized from "Gemini 2.5 Flash (High)"
         assert_eq!(entries[0].session_id.as_ref(), "session-db");
         assert_eq!(entries[0].model.as_deref(), Some("gemini-2.5-flash"));
         assert_eq!(entries[0].data.message.usage.input_tokens, 1000);
@@ -166,7 +169,7 @@ mod tests {
         assert_eq!(entries[0].extra_total_tokens, 50);
         assert!(entries[0].cost > 0.0);
 
-        // Row 2: Inherited from active session model
+        // Row 2 (idx=2): Inherited from active session model
         assert_eq!(entries[1].model.as_deref(), Some("gemini-2.5-flash"));
         assert_eq!(entries[1].data.message.usage.input_tokens, 400);
         assert_eq!(entries[1].data.message.usage.output_tokens, 100);

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -3,7 +3,7 @@ use crate::{
 };
 
 use super::{
-    parser::{event_to_loaded, parse_json_file, parse_jsonl_file},
+    parser::{event_to_loaded, parse_json_file, parse_jsonl_file, parse_sqlite_file},
     paths::discover_log_files,
 };
 
@@ -21,10 +21,10 @@ fn load_entries_inner(shared: &SharedArgs, pricing: &PricingMap) -> Result<Vec<L
     // Read each log file in parallel; the events keep their original file order
     // before the stable sort, so output is identical to the sequential read.
     let loaded = read_files_parallel(&files, shared.single_thread, |file| {
-        let parsed = if file.extension().and_then(|extension| extension.to_str()) == Some("jsonl") {
-            parse_jsonl_file(file)
-        } else {
-            parse_json_file(file)
+        let parsed = match file.extension().and_then(|extension| extension.to_str()) {
+            Some("jsonl") => parse_jsonl_file(file),
+            Some("db") => parse_sqlite_file(file),
+            _ => parse_json_file(file),
         };
         parsed.unwrap_or_else(|error| {
             debug_log(
@@ -74,5 +74,59 @@ mod tests {
             11_526
         );
         assert_eq!(entries[0].extra_total_tokens, 919);
+    }
+
+    #[test]
+    fn loads_sqlite_antigravity_metadata() {
+        let fixture = ccusage_test_support::Fixture::new();
+        let db_path = fixture.path("session-db.db");
+        let connection = sqlite::open(&db_path).unwrap();
+        connection
+            .execute("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);")
+            .unwrap();
+
+        // 1.4: tokens submessage (1.4.2 = 100, 1.4.3 = 50, 1.4.5 = 20, 1.4.9 = 10)
+        let tokens_bytes = vec![
+            0x10, 100, // 2: varint 100
+            0x18, 50, // 3: varint 50
+            0x28, 20, // 5: varint 20
+            0x48, 10, // 9: varint 10
+        ];
+        // 1.9.4.1 = 1779000000 (0x6A0BB9C0 -> varint: C0 B3 AF D0 06)
+        let ts_inner = vec![0x08, 0xC0, 0xB3, 0xAF, 0xD0, 0x06];
+        let ts_field9 = vec![0x22, ts_inner.len() as u8];
+        let mut field1_payload = Vec::new();
+        field1_payload.push(0x22); // tag for 1.4
+        field1_payload.push(tokens_bytes.len() as u8);
+        field1_payload.extend_from_slice(&tokens_bytes);
+        field1_payload.push(0x4A); // tag for 1.9
+        field1_payload.push((ts_field9.len() + ts_inner.len()) as u8);
+        field1_payload.extend_from_slice(&ts_field9);
+        field1_payload.extend_from_slice(&ts_inner);
+
+        let mut blob = Vec::new();
+        blob.push(0x0A); // tag for 1
+        blob.push(field1_payload.len() as u8);
+        blob.extend_from_slice(&field1_payload);
+
+        let mut statement = connection
+            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (1, ?)")
+            .unwrap();
+        statement.bind((1, blob.as_slice())).unwrap();
+        statement.next().unwrap();
+
+        let _env_guard = super::super::GeminiDataDirEnvGuard::set(fixture.root());
+        let shared = SharedArgs {
+            timezone: Some("UTC".to_string()),
+            ..SharedArgs::default()
+        };
+        let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
+
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].session_id.as_ref(), "session-db");
+        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 50);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 20);
+        assert_eq!(entries[0].extra_total_tokens, 10);
     }
 }

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -87,13 +87,13 @@ mod tests {
             .execute("CREATE TABLE gen_metadata (idx INTEGER, data BLOB);")
             .unwrap();
 
-        // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 50, 1.4.10 = 150)
+        // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 150, 1.4.10 = 50)
         let tokens_bytes = vec![
             0x10, 0xE8, 0x07, // 2: varint 1000
             0x18, 0xC8, 0x01, // 3: varint 200
             0x28, 0xF4, 0x03, // 5: varint 500
-            0x48, 50, // 9: varint 50
-            0x50, 0x96, 0x01, // 10: varint 150
+            0x48, 0x96, 0x01, // 9: varint 150 (text output)
+            0x50, 50, // 10: varint 50 (thinking)
         ];
         // 1.9.4.1 = 1779000000 (0x6A0BB9C0 -> varint: C0 B3 AF D0 06)
         let ts_inner = vec![0x08, 0xC0, 0xB3, 0xAF, 0xD0, 0x06];
@@ -121,12 +121,12 @@ mod tests {
         blob.push(field1_payload.len() as u8);
         blob.extend_from_slice(&field1_payload);
 
-        // Row 2: Continuation row with tokens only (1.4.2 = 400, 1.4.3 = 100, 1.4.9 = 25, 1.4.10 = 75)
+        // Row 2: Continuation row with tokens only (1.4.2 = 400, 1.4.3 = 100, 1.4.9 = 75, 1.4.10 = 25)
         let cont_tokens = vec![
             0x10, 0x90, 0x03, // 2: varint 400
             0x18, 0x64, // 3: varint 100
-            0x48, 25, // 9: varint 25
-            0x50, 75, // 10: varint 75
+            0x48, 75, // 9: varint 75 (text output)
+            0x50, 25, // 10: varint 25 (thinking)
         ];
         let mut cont_field1 = Vec::new();
         cont_field1.push(0x22);

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -95,7 +95,6 @@ mod tests {
         // 1.9.4.1 = 1779000000 (0x6A0BB9C0 -> varint: C0 B3 AF D0 06)
         let ts_inner = vec![0x08, 0xC0, 0xB3, 0xAF, 0xD0, 0x06];
         let ts_field9 = vec![0x22, ts_inner.len() as u8];
-        let model_str = b"gemini-2.5-flash";
 
         let mut field1_payload = Vec::new();
         // 1.4: ModelUsageStats
@@ -107,11 +106,12 @@ mod tests {
         field1_payload.push((ts_field9.len() + ts_inner.len()) as u8);
         field1_payload.extend_from_slice(&ts_field9);
         field1_payload.extend_from_slice(&ts_inner);
-        // 1.19: response_model string
-        field1_payload.push(0x9A); // (19 << 3) | 2 = 154 = 0x9A, 0x01 (varint 154)
+        // 1.21: display label string (field 21: (21 << 3) | 2 = 170 = 0xAA, 0x01)
+        let display_label = b"Gemini 2.5 Flash (High)";
+        field1_payload.push(0xAA);
         field1_payload.push(0x01);
-        field1_payload.push(model_str.len() as u8);
-        field1_payload.extend_from_slice(model_str);
+        field1_payload.push(display_label.len() as u8);
+        field1_payload.extend_from_slice(display_label);
 
         let mut blob = Vec::new();
         blob.push(0x0A); // tag for 1
@@ -124,6 +124,31 @@ mod tests {
         statement.bind((1, blob.as_slice())).unwrap();
         statement.next().unwrap();
 
+        // Row 2: Continuation row with tokens only (no model field)
+        let cont_tokens = vec![
+            0x10, 0x90, 0x03, // 2: varint 400
+            0x18, 0x64, // 3: varint 100
+        ];
+        let mut cont_field1 = Vec::new();
+        cont_field1.push(0x22);
+        cont_field1.push(cont_tokens.len() as u8);
+        cont_field1.extend_from_slice(&cont_tokens);
+        cont_field1.push(0x4A);
+        cont_field1.push((ts_field9.len() + ts_inner.len()) as u8);
+        cont_field1.extend_from_slice(&ts_field9);
+        cont_field1.extend_from_slice(&ts_inner);
+
+        let mut cont_blob = Vec::new();
+        cont_blob.push(0x0A);
+        cont_blob.push(cont_field1.len() as u8);
+        cont_blob.extend_from_slice(&cont_field1);
+
+        let mut stmt2 = connection
+            .prepare("INSERT INTO gen_metadata (idx, data) VALUES (2, ?)")
+            .unwrap();
+        stmt2.bind((1, cont_blob.as_slice())).unwrap();
+        stmt2.next().unwrap();
+
         let _env_guard = super::super::GeminiDataDirEnvGuard::set(fixture.root());
         let shared = SharedArgs {
             timezone: Some("UTC".to_string()),
@@ -131,7 +156,8 @@ mod tests {
         };
         let entries = load_entries(&shared, &PricingMap::load_embedded()).unwrap();
 
-        assert_eq!(entries.len(), 1);
+        assert_eq!(entries.len(), 2);
+        // Row 1: Normalized from "Gemini 2.5 Flash (High)"
         assert_eq!(entries[0].session_id.as_ref(), "session-db");
         assert_eq!(entries[0].model.as_deref(), Some("gemini-2.5-flash"));
         assert_eq!(entries[0].data.message.usage.input_tokens, 1000);
@@ -139,5 +165,11 @@ mod tests {
         assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 500);
         assert_eq!(entries[0].extra_total_tokens, 50);
         assert!(entries[0].cost > 0.0);
+
+        // Row 2: Inherited from active session model
+        assert_eq!(entries[1].model.as_deref(), Some("gemini-2.5-flash"));
+        assert_eq!(entries[1].data.message.usage.input_tokens, 400);
+        assert_eq!(entries[1].data.message.usage.output_tokens, 100);
+        assert!(entries[1].cost > 0.0);
     }
 }

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -87,12 +87,13 @@ mod tests {
             .execute("CREATE TABLE gen_metadata (idx INTEGER, data BLOB);")
             .unwrap();
 
-        // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 50)
+        // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 50, 1.4.10 = 150)
         let tokens_bytes = vec![
             0x10, 0xE8, 0x07, // 2: varint 1000
             0x18, 0xC8, 0x01, // 3: varint 200
             0x28, 0xF4, 0x03, // 5: varint 500
             0x48, 50, // 9: varint 50
+            0x50, 0x96, 0x01, // 10: varint 150
         ];
         // 1.9.4.1 = 1779000000 (0x6A0BB9C0 -> varint: C0 B3 AF D0 06)
         let ts_inner = vec![0x08, 0xC0, 0xB3, 0xAF, 0xD0, 0x06];
@@ -120,10 +121,12 @@ mod tests {
         blob.push(field1_payload.len() as u8);
         blob.extend_from_slice(&field1_payload);
 
-        // Row 2: Continuation row with tokens only (no model field)
+        // Row 2: Continuation row with tokens only (1.4.2 = 400, 1.4.3 = 100, 1.4.9 = 25, 1.4.10 = 75)
         let cont_tokens = vec![
             0x10, 0x90, 0x03, // 2: varint 400
             0x18, 0x64, // 3: varint 100
+            0x48, 25, // 9: varint 25
+            0x50, 75, // 10: varint 75
         ];
         let mut cont_field1 = Vec::new();
         cont_field1.push(0x22);
@@ -164,7 +167,7 @@ mod tests {
         assert_eq!(entries[0].session_id.as_ref(), "session-db");
         assert_eq!(entries[0].model.as_deref(), Some("gemini-2.5-flash"));
         assert_eq!(entries[0].data.message.usage.input_tokens, 1000);
-        assert_eq!(entries[0].data.message.usage.output_tokens, 200);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 150);
         assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 500);
         assert_eq!(entries[0].extra_total_tokens, 50);
         assert!(entries[0].cost > 0.0);
@@ -172,7 +175,8 @@ mod tests {
         // Row 2 (idx=2): Inherited from active session model
         assert_eq!(entries[1].model.as_deref(), Some("gemini-2.5-flash"));
         assert_eq!(entries[1].data.message.usage.input_tokens, 400);
-        assert_eq!(entries[1].data.message.usage.output_tokens, 100);
+        assert_eq!(entries[1].data.message.usage.output_tokens, 75);
+        assert_eq!(entries[1].extra_total_tokens, 25);
         assert!(entries[1].cost > 0.0);
     }
 }

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -84,7 +84,7 @@ mod tests {
         let db_path = fixture.path("session-db.db");
         let connection = sqlite::open(&db_path).unwrap();
         connection
-            .execute("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);")
+            .execute("CREATE TABLE gen_metadata (idx INTEGER, data BLOB);")
             .unwrap();
 
         // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 50)

--- a/rust/adapters/gemini/src/loader.rs
+++ b/rust/adapters/gemini/src/loader.rs
@@ -85,24 +85,33 @@ mod tests {
             .execute("CREATE TABLE gen_metadata (idx INTEGER PRIMARY KEY, data BLOB);")
             .unwrap();
 
-        // 1.4: tokens submessage (1.4.2 = 100, 1.4.3 = 50, 1.4.5 = 20, 1.4.9 = 10)
+        // 1.4: tokens submessage (1.4.2 = 1000, 1.4.3 = 200, 1.4.5 = 500, 1.4.9 = 50)
         let tokens_bytes = vec![
-            0x10, 100, // 2: varint 100
-            0x18, 50, // 3: varint 50
-            0x28, 20, // 5: varint 20
-            0x48, 10, // 9: varint 10
+            0x10, 0xE8, 0x07, // 2: varint 1000
+            0x18, 0xC8, 0x01, // 3: varint 200
+            0x28, 0xF4, 0x03, // 5: varint 500
+            0x48, 50, // 9: varint 50
         ];
         // 1.9.4.1 = 1779000000 (0x6A0BB9C0 -> varint: C0 B3 AF D0 06)
         let ts_inner = vec![0x08, 0xC0, 0xB3, 0xAF, 0xD0, 0x06];
         let ts_field9 = vec![0x22, ts_inner.len() as u8];
+        let model_str = b"gemini-2.5-flash";
+
         let mut field1_payload = Vec::new();
-        field1_payload.push(0x22); // tag for 1.4
+        // 1.4: ModelUsageStats
+        field1_payload.push(0x22);
         field1_payload.push(tokens_bytes.len() as u8);
         field1_payload.extend_from_slice(&tokens_bytes);
-        field1_payload.push(0x4A); // tag for 1.9
+        // 1.9: Timestamp container
+        field1_payload.push(0x4A);
         field1_payload.push((ts_field9.len() + ts_inner.len()) as u8);
         field1_payload.extend_from_slice(&ts_field9);
         field1_payload.extend_from_slice(&ts_inner);
+        // 1.19: response_model string
+        field1_payload.push(0x9A); // (19 << 3) | 2 = 154 = 0x9A, 0x01 (varint 154)
+        field1_payload.push(0x01);
+        field1_payload.push(model_str.len() as u8);
+        field1_payload.extend_from_slice(model_str);
 
         let mut blob = Vec::new();
         blob.push(0x0A); // tag for 1
@@ -124,9 +133,11 @@ mod tests {
 
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].session_id.as_ref(), "session-db");
-        assert_eq!(entries[0].data.message.usage.input_tokens, 100);
-        assert_eq!(entries[0].data.message.usage.output_tokens, 50);
-        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 20);
-        assert_eq!(entries[0].extra_total_tokens, 10);
+        assert_eq!(entries[0].model.as_deref(), Some("gemini-2.5-flash"));
+        assert_eq!(entries[0].data.message.usage.input_tokens, 1000);
+        assert_eq!(entries[0].data.message.usage.output_tokens, 200);
+        assert_eq!(entries[0].data.message.usage.cache_read_input_tokens, 500);
+        assert_eq!(entries[0].extra_total_tokens, 50);
+        assert!(entries[0].cost > 0.0);
     }
 }

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -270,8 +270,8 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                 let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
                 let total_output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
                 let cache_read_tokens = parsed.numbers.get("1.4.5").copied().unwrap_or(0);
-                let reasoning_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
-                let visible_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
+                let text_output_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
+                let thinking_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
                 let timestamp_seconds = parsed.numbers.get("1.9.4.1").copied();
                 let timestamp_nanos = parsed
                     .numbers
@@ -295,20 +295,20 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                 if input_tokens == 0
                     && total_output_tokens == 0
                     && cache_read_tokens == 0
-                    && reasoning_tokens == 0
-                    && visible_tokens == 0
+                    && text_output_tokens == 0
+                    && thinking_tokens == 0
                 {
                     continue;
                 }
-                let effective_output = if visible_tokens > 0 {
-                    visible_tokens
+                let effective_output = if text_output_tokens > 0 {
+                    text_output_tokens
                 } else {
-                    total_output_tokens.saturating_sub(reasoning_tokens)
+                    total_output_tokens.saturating_sub(thinking_tokens)
                 };
                 let effective_thoughts =
-                    reasoning_tokens.max(total_output_tokens.saturating_sub(effective_output));
-                let effective_total_output = total_output_tokens
-                    .max(effective_output.saturating_add(effective_thoughts));
+                    thinking_tokens.max(total_output_tokens.saturating_sub(effective_output));
+                let effective_total_output =
+                    total_output_tokens.max(effective_output.saturating_add(effective_thoughts));
                 let total_tokens = input_tokens
                     .saturating_add(cache_read_tokens)
                     .saturating_add(effective_total_output);

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -268,7 +268,7 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                     .or_else(|| current_model.clone())
                     .unwrap_or_else(|| "gemini-internal-model".to_string());
                 let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
-                let output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
+                let total_output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
                 let cache_read_tokens = parsed.numbers.get("1.4.5").copied().unwrap_or(0);
                 let reasoning_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
                 let visible_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
@@ -293,27 +293,34 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                     })
                     .unwrap_or(fallback_timestamp);
                 if input_tokens == 0
-                    && output_tokens == 0
+                    && total_output_tokens == 0
                     && cache_read_tokens == 0
                     && reasoning_tokens == 0
                     && visible_tokens == 0
                 {
                     continue;
                 }
-                let thoughts = reasoning_tokens.max(visible_tokens.saturating_sub(output_tokens));
+                let effective_output = if visible_tokens > 0 {
+                    visible_tokens
+                } else {
+                    total_output_tokens.saturating_sub(reasoning_tokens)
+                };
+                let effective_thoughts =
+                    reasoning_tokens.max(total_output_tokens.saturating_sub(effective_output));
+                let effective_total_output = total_output_tokens
+                    .max(effective_output.saturating_add(effective_thoughts));
                 let total_tokens = input_tokens
-                    .saturating_add(output_tokens)
                     .saturating_add(cache_read_tokens)
-                    .saturating_add(thoughts);
+                    .saturating_add(effective_total_output);
                 let event = build_event(
                     Some(&model),
                     &session_id,
                     timestamp,
                     GeminiTokens {
                         input: input_tokens,
-                        output: output_tokens,
+                        output: effective_output,
                         cached: cache_read_tokens,
-                        thoughts,
+                        thoughts: effective_thoughts,
                         tool: 0,
                         total: Some(total_tokens),
                     },

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -235,6 +235,7 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
         .unwrap_or("unknown")
         .to_string();
 
+    let mut current_model = None::<String>;
     let mut events = Vec::new();
     while let Ok(sqlite::State::Row) = statement.next() {
         let idx: i64 = statement.read(0).unwrap_or_default();
@@ -243,12 +244,19 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
             continue;
         }
         let parsed = parse_antigravity_protobuf(&blob);
-        let model = parsed
+        let row_model = parsed
             .strings
             .get("1.19")
             .or_else(|| parsed.strings.get("1.21"))
             .or_else(|| parsed.strings.get("1.3"))
-            .cloned()
+            .map(|s| normalize_antigravity_model(s));
+
+        if let Some(ref m) = row_model {
+            current_model = Some(m.clone());
+        }
+
+        let model = row_model
+            .or_else(|| current_model.clone())
             .unwrap_or_else(|| "gemini-internal-model".to_string());
         let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
         let output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
@@ -303,6 +311,45 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
         }
     }
     Ok(events)
+}
+
+fn normalize_antigravity_model(raw: &str) -> String {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return "gemini-internal-model".to_string();
+    }
+    let lower = trimmed.to_ascii_lowercase();
+
+    let base = if let Some(idx) = lower.find('(') {
+        lower[..idx].trim()
+    } else {
+        lower.as_str()
+    };
+
+    match base {
+        "gemini 3.6 flash" | "gemini 3 flash" => "gemini-3.6-flash".to_string(),
+        "gemini 3.6 pro" | "gemini 3 pro" => "gemini-3.6-pro".to_string(),
+        "gemini 2.5 flash" => "gemini-2.5-flash".to_string(),
+        "gemini 2.5 pro" => "gemini-2.5-pro".to_string(),
+        "gemini 2.0 flash" | "gemini 2 flash" => "gemini-2.0-flash".to_string(),
+        "gemini 1.5 flash" => "gemini-1.5-flash".to_string(),
+        "gemini 1.5 pro" => "gemini-1.5-pro".to_string(),
+        "claude 3.7 sonnet" | "claude 3.7 sonnet thinking" => "claude-3-7-sonnet".to_string(),
+        "claude 3.5 sonnet" => "claude-3-5-sonnet".to_string(),
+        "claude 3.5 haiku" => "claude-3-5-haiku".to_string(),
+        "claude 3 opus" => "claude-3-opus".to_string(),
+        _ => {
+            let converted = base.replace(' ', "-");
+            if converted.starts_with("gemini-")
+                || converted.starts_with("claude-")
+                || converted.starts_with("gpt-")
+            {
+                converted
+            } else {
+                trimmed.to_string()
+            }
+        }
+    }
 }
 
 const MAX_PROTOBUF_DEPTH: usize = 16;

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -218,6 +218,11 @@ pub(super) fn parse_jsonl_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     Ok(events)
 }
 
+/// Parses an Antigravity SQLite conversation database file.
+///
+/// Reads generation metadata records from the `gen_metadata` table ordered by `idx ASC`
+/// to guarantee deterministic chronological sequence and ensure model names propagate
+/// accurately to continuation rows.
 pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     let fallback_timestamp = file_modified_timestamp(path);
     let Ok(connection) =
@@ -225,7 +230,9 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     else {
         return Ok(Vec::new());
     };
-    let Ok(mut statement) = connection.prepare("SELECT idx, data FROM gen_metadata") else {
+    let Ok(mut statement) =
+        connection.prepare("SELECT idx, data FROM gen_metadata ORDER BY idx ASC")
+    else {
         return Ok(Vec::new());
     };
 
@@ -237,83 +244,91 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
 
     let mut current_model = None::<String>;
     let mut events = Vec::new();
-    while let Ok(sqlite::State::Row) = statement.next() {
-        let idx: i64 = statement.read(0).unwrap_or_default();
-        let blob: Vec<u8> = statement.read(1).unwrap_or_default();
-        if blob.is_empty() {
-            continue;
-        }
-        let parsed = parse_antigravity_protobuf(&blob);
-        let row_model = parsed
-            .strings
-            .get("1.19")
-            .or_else(|| parsed.strings.get("1.21"))
-            .or_else(|| parsed.strings.get("1.3"))
-            .map(|s| normalize_antigravity_model(s));
-
-        if let Some(ref m) = row_model {
-            current_model = Some(m.clone());
-        }
-
-        let model = row_model
-            .or_else(|| current_model.clone())
-            .unwrap_or_else(|| "gemini-internal-model".to_string());
-        let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
-        let output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
-        let cache_read_tokens = parsed.numbers.get("1.4.5").copied().unwrap_or(0);
-        let reasoning_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
-        let visible_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
-        let timestamp_seconds = parsed.numbers.get("1.9.4.1").copied();
-        let timestamp_nanos = parsed
-            .numbers
-            .get("1.9.4.2")
-            .copied()
-            .unwrap_or(0)
-            .min(999_999_999);
-        let timestamp = timestamp_seconds
-            .and_then(|value| i64::try_from(value).ok())
-            .and_then(|secs| {
-                if secs > 0 {
-                    let ms = secs
-                        .saturating_mul(1000)
-                        .saturating_add((timestamp_nanos / 1_000_000) as i64);
-                    Some(TimestampMs::from_millis(ms))
-                } else {
-                    None
+    loop {
+        match statement.next() {
+            Ok(sqlite::State::Row) => {
+                let idx: i64 = statement.read(0).unwrap_or_default();
+                let blob: Vec<u8> = statement.read(1).unwrap_or_default();
+                if blob.is_empty() {
+                    continue;
                 }
-            })
-            .unwrap_or(fallback_timestamp);
-        if input_tokens == 0
-            && output_tokens == 0
-            && cache_read_tokens == 0
-            && reasoning_tokens == 0
-            && visible_tokens == 0
-        {
-            continue;
-        }
-        let event = build_event(
-            Some(&model),
-            &session_id,
-            timestamp,
-            GeminiTokens {
-                input: input_tokens,
-                output: output_tokens,
-                cached: cache_read_tokens,
-                thoughts: reasoning_tokens.max(visible_tokens.saturating_sub(output_tokens)),
-                tool: 0,
-                total: Some(input_tokens + output_tokens + cache_read_tokens + reasoning_tokens),
-            },
-            normalize_session_input,
-            Some(format!("antigravity-gen-{idx}")),
-        );
-        if let Some(event) = event {
-            events.push(event);
+                let parsed = parse_antigravity_protobuf(&blob);
+                let row_model = parsed
+                    .strings
+                    .get("1.19")
+                    .or_else(|| parsed.strings.get("1.21"))
+                    .or_else(|| parsed.strings.get("1.3"))
+                    .map(|s| normalize_antigravity_model(s));
+
+                if let Some(ref m) = row_model {
+                    current_model = Some(m.clone());
+                }
+
+                let model = row_model
+                    .or_else(|| current_model.clone())
+                    .unwrap_or_else(|| "gemini-internal-model".to_string());
+                let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
+                let output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
+                let cache_read_tokens = parsed.numbers.get("1.4.5").copied().unwrap_or(0);
+                let reasoning_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
+                let visible_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
+                let timestamp_seconds = parsed.numbers.get("1.9.4.1").copied();
+                let timestamp_nanos = parsed
+                    .numbers
+                    .get("1.9.4.2")
+                    .copied()
+                    .unwrap_or(0)
+                    .min(999_999_999);
+                let timestamp = timestamp_seconds
+                    .and_then(|value| i64::try_from(value).ok())
+                    .and_then(|secs| {
+                        if secs > 0 {
+                            let ms = secs
+                                .saturating_mul(1000)
+                                .saturating_add((timestamp_nanos / 1_000_000) as i64);
+                            Some(TimestampMs::from_millis(ms))
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or(fallback_timestamp);
+                if input_tokens == 0
+                    && output_tokens == 0
+                    && cache_read_tokens == 0
+                    && reasoning_tokens == 0
+                    && visible_tokens == 0
+                {
+                    continue;
+                }
+                let thoughts = reasoning_tokens.max(visible_tokens.saturating_sub(output_tokens));
+                let event = build_event(
+                    Some(&model),
+                    &session_id,
+                    timestamp,
+                    GeminiTokens {
+                        input: input_tokens,
+                        output: output_tokens,
+                        cached: cache_read_tokens,
+                        thoughts,
+                        tool: 0,
+                        total: Some(input_tokens + output_tokens + cache_read_tokens + thoughts),
+                    },
+                    normalize_session_input,
+                    Some(format!("antigravity-gen-{idx}")),
+                );
+                if let Some(event) = event {
+                    events.push(event);
+                }
+            }
+            Ok(sqlite::State::Done) => break,
+            Err(_) => break,
         }
     }
     Ok(events)
 }
 
-fn normalize_antigravity_model(raw: &str) -> String {
+/// Normalizes Antigravity model identifiers and display strings into standard model IDs.
+pub(super) fn normalize_antigravity_model(raw: &str) -> String {
     let trimmed = raw.trim();
     if trimmed.is_empty() {
         return "gemini-internal-model".to_string();
@@ -327,11 +342,14 @@ fn normalize_antigravity_model(raw: &str) -> String {
     };
 
     match base {
+        "gemini 3.7 flash" | "gemini 3.7 flash thinking" => "gemini-3.7-flash".to_string(),
+        "gemini 3.7 pro" | "gemini 3.7 pro thinking" => "gemini-3.7-pro".to_string(),
         "gemini 3.6 flash" | "gemini 3 flash" => "gemini-3.6-flash".to_string(),
         "gemini 3.6 pro" | "gemini 3 pro" => "gemini-3.6-pro".to_string(),
         "gemini 2.5 flash" => "gemini-2.5-flash".to_string(),
         "gemini 2.5 pro" => "gemini-2.5-pro".to_string(),
         "gemini 2.0 flash" | "gemini 2 flash" => "gemini-2.0-flash".to_string(),
+        "gemini 2.0 pro" => "gemini-2.0-pro".to_string(),
         "gemini 1.5 flash" => "gemini-1.5-flash".to_string(),
         "gemini 1.5 pro" => "gemini-1.5-pro".to_string(),
         "claude 3.7 sonnet" | "claude 3.7 sonnet thinking" => "claude-3-7-sonnet".to_string(),
@@ -352,20 +370,24 @@ fn normalize_antigravity_model(raw: &str) -> String {
     }
 }
 
+/// Maximum recursion depth allowed during nested protobuf message parsing.
 const MAX_PROTOBUF_DEPTH: usize = 16;
 
+/// Intermediate storage for decoded protobuf field numbers and values.
 #[derive(Default)]
 struct AntigravityProtobuf {
     numbers: HashMap<String, u64>,
     strings: HashMap<String, String>,
 }
 
+/// Decodes raw protobuf payload into numeric and string field maps.
 fn parse_antigravity_protobuf(blob: &[u8]) -> AntigravityProtobuf {
     let mut out = AntigravityProtobuf::default();
     parse_antigravity_protobuf_fields(blob, &mut out, "", 0);
     out
 }
 
+/// Recursively parses protobuf wire-format fields up to `MAX_PROTOBUF_DEPTH`.
 fn parse_antigravity_protobuf_fields(
     blob: &[u8],
     out: &mut AntigravityProtobuf,
@@ -427,6 +449,7 @@ fn parse_antigravity_protobuf_fields(
     }
 }
 
+/// Reads a single varint from `blob` starting at `offset`, checking for 10th-byte overflow.
 fn read_varint(blob: &[u8], mut offset: usize) -> Option<(u64, usize)> {
     let mut value = 0u64;
     let mut shift = 0u32;

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -301,6 +301,10 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                     continue;
                 }
                 let thoughts = reasoning_tokens.max(visible_tokens.saturating_sub(output_tokens));
+                let total_tokens = input_tokens
+                    .saturating_add(output_tokens)
+                    .saturating_add(cache_read_tokens)
+                    .saturating_add(thoughts);
                 let event = build_event(
                     Some(&model),
                     &session_id,
@@ -311,7 +315,7 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
                         cached: cache_read_tokens,
                         thoughts,
                         tool: 0,
-                        total: Some(input_tokens + output_tokens + cache_read_tokens + thoughts),
+                        total: Some(total_tokens),
                     },
                     normalize_session_input,
                     Some(format!("antigravity-gen-{idx}")),

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -244,21 +244,32 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
         }
         let parsed = parse_antigravity_protobuf(&blob);
         let model = parsed
-            .get("1.3")
-            .map(|value| value.to_string())
+            .strings
+            .get("1.19")
+            .or_else(|| parsed.strings.get("1.21"))
+            .or_else(|| parsed.strings.get("1.3"))
+            .cloned()
             .unwrap_or_else(|| "gemini-internal-model".to_string());
-        let input_tokens = parsed.get("1.4.2").copied().unwrap_or(0);
-        let output_tokens = parsed.get("1.4.3").copied().unwrap_or(0);
-        let cache_read_tokens = parsed.get("1.4.5").copied().unwrap_or(0);
-        let reasoning_tokens = parsed.get("1.4.9").copied().unwrap_or(0);
-        let visible_tokens = parsed.get("1.4.10").copied().unwrap_or(0);
-        let timestamp = parsed
-            .get("1.9.4.1")
+        let input_tokens = parsed.numbers.get("1.4.2").copied().unwrap_or(0);
+        let output_tokens = parsed.numbers.get("1.4.3").copied().unwrap_or(0);
+        let cache_read_tokens = parsed.numbers.get("1.4.5").copied().unwrap_or(0);
+        let reasoning_tokens = parsed.numbers.get("1.4.9").copied().unwrap_or(0);
+        let visible_tokens = parsed.numbers.get("1.4.10").copied().unwrap_or(0);
+        let timestamp_seconds = parsed.numbers.get("1.9.4.1").copied();
+        let timestamp_nanos = parsed
+            .numbers
+            .get("1.9.4.2")
             .copied()
+            .unwrap_or(0)
+            .min(999_999_999);
+        let timestamp = timestamp_seconds
             .and_then(|value| i64::try_from(value).ok())
-            .and_then(|ms| {
-                if ms > 0 {
-                    Some(TimestampMs::from_millis(ms * 1000))
+            .and_then(|secs| {
+                if secs > 0 {
+                    let ms = secs
+                        .saturating_mul(1000)
+                        .saturating_add((timestamp_nanos / 1_000_000) as i64);
+                    Some(TimestampMs::from_millis(ms))
                 } else {
                     None
                 }
@@ -294,13 +305,29 @@ pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     Ok(events)
 }
 
-fn parse_antigravity_protobuf(blob: &[u8]) -> HashMap<String, u64> {
-    let mut out = HashMap::new();
-    parse_antigravity_protobuf_fields(blob, &mut out, "");
+const MAX_PROTOBUF_DEPTH: usize = 16;
+
+#[derive(Default)]
+struct AntigravityProtobuf {
+    numbers: HashMap<String, u64>,
+    strings: HashMap<String, String>,
+}
+
+fn parse_antigravity_protobuf(blob: &[u8]) -> AntigravityProtobuf {
+    let mut out = AntigravityProtobuf::default();
+    parse_antigravity_protobuf_fields(blob, &mut out, "", 0);
     out
 }
 
-fn parse_antigravity_protobuf_fields(blob: &[u8], out: &mut HashMap<String, u64>, prefix: &str) {
+fn parse_antigravity_protobuf_fields(
+    blob: &[u8],
+    out: &mut AntigravityProtobuf,
+    prefix: &str,
+    depth: usize,
+) {
+    if depth >= MAX_PROTOBUF_DEPTH {
+        return;
+    }
     let mut cursor = 0usize;
     while cursor < blob.len() {
         let Some((tag, next)) = read_varint(blob, cursor) else {
@@ -320,7 +347,7 @@ fn parse_antigravity_protobuf_fields(blob: &[u8], out: &mut HashMap<String, u64>
                     break;
                 };
                 cursor = next;
-                out.insert(path, value);
+                out.numbers.insert(path, value);
             }
             2 => {
                 let Some((len, next)) = read_varint(blob, cursor) else {
@@ -335,15 +362,15 @@ fn parse_antigravity_protobuf_fields(blob: &[u8], out: &mut HashMap<String, u64>
                     break;
                 };
                 let payload = &blob[cursor..end];
-                let mut nested = HashMap::new();
-                parse_antigravity_protobuf_fields(payload, &mut nested, &path);
-                if nested.is_empty() {
-                    out.insert(path, 0);
-                } else {
-                    for (nested_path, value) in nested {
-                        out.insert(nested_path, value);
-                    }
+                if let Ok(text) = std::str::from_utf8(payload)
+                    && !text.is_empty()
+                    && text
+                        .chars()
+                        .all(|c| !c.is_control() || c == '\n' || c == '\t')
+                {
+                    out.strings.insert(path.clone(), text.to_string());
                 }
+                parse_antigravity_protobuf_fields(payload, out, &path, depth + 1);
                 cursor = end;
             }
             1 => cursor += 8,
@@ -362,7 +389,11 @@ fn read_varint(blob: &[u8], mut offset: usize) -> Option<(u64, usize)> {
         }
         let byte = blob[offset];
         offset += 1;
-        value |= u64::from(byte & 0x7F) << shift;
+        let payload = byte & 0x7F;
+        if shift == 63 && payload > 1 {
+            return None;
+        }
+        value |= u64::from(payload) << shift;
         if byte & 0x80 == 0 {
             return Some((value, offset));
         }

--- a/rust/adapters/gemini/src/parser.rs
+++ b/rust/adapters/gemini/src/parser.rs
@@ -218,6 +218,158 @@ pub(super) fn parse_jsonl_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
     Ok(events)
 }
 
+pub(super) fn parse_sqlite_file(path: &Path) -> Result<Vec<GeminiUsageEvent>> {
+    let fallback_timestamp = file_modified_timestamp(path);
+    let Ok(connection) =
+        sqlite::Connection::open_with_flags(path, sqlite::OpenFlags::new().with_read_only())
+    else {
+        return Ok(Vec::new());
+    };
+    let Ok(mut statement) = connection.prepare("SELECT idx, data FROM gen_metadata") else {
+        return Ok(Vec::new());
+    };
+
+    let session_id = path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let mut events = Vec::new();
+    while let Ok(sqlite::State::Row) = statement.next() {
+        let idx: i64 = statement.read(0).unwrap_or_default();
+        let blob: Vec<u8> = statement.read(1).unwrap_or_default();
+        if blob.is_empty() {
+            continue;
+        }
+        let parsed = parse_antigravity_protobuf(&blob);
+        let model = parsed
+            .get("1.3")
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| "gemini-internal-model".to_string());
+        let input_tokens = parsed.get("1.4.2").copied().unwrap_or(0);
+        let output_tokens = parsed.get("1.4.3").copied().unwrap_or(0);
+        let cache_read_tokens = parsed.get("1.4.5").copied().unwrap_or(0);
+        let reasoning_tokens = parsed.get("1.4.9").copied().unwrap_or(0);
+        let visible_tokens = parsed.get("1.4.10").copied().unwrap_or(0);
+        let timestamp = parsed
+            .get("1.9.4.1")
+            .copied()
+            .and_then(|value| i64::try_from(value).ok())
+            .and_then(|ms| {
+                if ms > 0 {
+                    Some(TimestampMs::from_millis(ms * 1000))
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(fallback_timestamp);
+        if input_tokens == 0
+            && output_tokens == 0
+            && cache_read_tokens == 0
+            && reasoning_tokens == 0
+            && visible_tokens == 0
+        {
+            continue;
+        }
+        let event = build_event(
+            Some(&model),
+            &session_id,
+            timestamp,
+            GeminiTokens {
+                input: input_tokens,
+                output: output_tokens,
+                cached: cache_read_tokens,
+                thoughts: reasoning_tokens.max(visible_tokens.saturating_sub(output_tokens)),
+                tool: 0,
+                total: Some(input_tokens + output_tokens + cache_read_tokens + reasoning_tokens),
+            },
+            normalize_session_input,
+            Some(format!("antigravity-gen-{idx}")),
+        );
+        if let Some(event) = event {
+            events.push(event);
+        }
+    }
+    Ok(events)
+}
+
+fn parse_antigravity_protobuf(blob: &[u8]) -> HashMap<String, u64> {
+    let mut out = HashMap::new();
+    parse_antigravity_protobuf_fields(blob, &mut out, "");
+    out
+}
+
+fn parse_antigravity_protobuf_fields(blob: &[u8], out: &mut HashMap<String, u64>, prefix: &str) {
+    let mut cursor = 0usize;
+    while cursor < blob.len() {
+        let Some((tag, next)) = read_varint(blob, cursor) else {
+            break;
+        };
+        cursor = next;
+        let field = tag >> 3;
+        let wire = tag & 0x7;
+        let path = if prefix.is_empty() {
+            field.to_string()
+        } else {
+            format!("{prefix}.{field}")
+        };
+        match wire {
+            0 => {
+                let Some((value, next)) = read_varint(blob, cursor) else {
+                    break;
+                };
+                cursor = next;
+                out.insert(path, value);
+            }
+            2 => {
+                let Some((len, next)) = read_varint(blob, cursor) else {
+                    break;
+                };
+                cursor = next;
+                let Some(end) = usize::try_from(len)
+                    .ok()
+                    .and_then(|len_usize| cursor.checked_add(len_usize))
+                    .filter(|&end| end <= blob.len())
+                else {
+                    break;
+                };
+                let payload = &blob[cursor..end];
+                let mut nested = HashMap::new();
+                parse_antigravity_protobuf_fields(payload, &mut nested, &path);
+                if nested.is_empty() {
+                    out.insert(path, 0);
+                } else {
+                    for (nested_path, value) in nested {
+                        out.insert(nested_path, value);
+                    }
+                }
+                cursor = end;
+            }
+            1 => cursor += 8,
+            5 => cursor += 4,
+            _ => break,
+        }
+    }
+}
+
+fn read_varint(blob: &[u8], mut offset: usize) -> Option<(u64, usize)> {
+    let mut value = 0u64;
+    let mut shift = 0u32;
+    loop {
+        if offset >= blob.len() || shift >= 64 {
+            return None;
+        }
+        let byte = blob[offset];
+        offset += 1;
+        value |= u64::from(byte & 0x7F) << shift;
+        if byte & 0x80 == 0 {
+            return Some((value, offset));
+        }
+        shift += 7;
+    }
+}
+
 fn parse_direct_event(
     record: &Map<String, Value>,
     model_hint: Option<&str>,

--- a/rust/adapters/gemini/src/paths.rs
+++ b/rust/adapters/gemini/src/paths.rs
@@ -3,7 +3,9 @@ use std::{collections::HashSet, env, path::PathBuf};
 use crate::{Result, collect_files_with_extension};
 
 pub(super) const GEMINI_DATA_DIR_ENV: &str = "GEMINI_DATA_DIR";
+pub(super) const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
 
+/// Returns all discovery candidate directories for Gemini and Antigravity logs.
 fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
@@ -21,22 +23,48 @@ fn paths() -> Result<Vec<PathBuf>> {
         return Ok(paths);
     }
 
+    if let Ok(env_paths) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
+        for raw in env_paths
+            .split(',')
+            .map(str::trim)
+            .filter(|path| !path.is_empty())
+        {
+            let path = PathBuf::from(raw);
+            if path.is_dir() && seen.insert(path.clone()) {
+                paths.push(path);
+            }
+        }
+    }
+
     if let Some(home) = crate::home::home_dir() {
         let path = home.join(".gemini").join("tmp");
         if path.is_dir() && seen.insert(path.clone()) {
             paths.push(path);
         }
-        let antigravity_dir = home
-            .join(".gemini")
-            .join("antigravity")
-            .join("conversations");
-        if antigravity_dir.is_dir() && seen.insert(antigravity_dir.clone()) {
-            paths.push(antigravity_dir);
+        let antigravity_dirs = [
+            home.join(".gemini")
+                .join("antigravity")
+                .join("conversations"),
+            home.join(".gemini")
+                .join("antigravity-cli")
+                .join("conversations"),
+            home.join(".gemini")
+                .join("antigravity-ide")
+                .join("conversations"),
+            home.join(".gemini")
+                .join("antigravity-backup")
+                .join("conversations"),
+        ];
+        for dir in antigravity_dirs {
+            if dir.is_dir() && seen.insert(dir.clone()) {
+                paths.push(dir);
+            }
         }
     }
     Ok(paths)
 }
 
+/// Discovers all `.json`, `.jsonl`, and SQLite `.db` log files across known directories.
 pub(super) fn discover_log_files() -> Result<Vec<PathBuf>> {
     let mut files = Vec::new();
     for path in paths()? {

--- a/rust/adapters/gemini/src/paths.rs
+++ b/rust/adapters/gemini/src/paths.rs
@@ -26,6 +26,13 @@ fn paths() -> Result<Vec<PathBuf>> {
         if path.is_dir() && seen.insert(path.clone()) {
             paths.push(path);
         }
+        let antigravity_dir = home
+            .join(".gemini")
+            .join("antigravity")
+            .join("conversations");
+        if antigravity_dir.is_dir() && seen.insert(antigravity_dir.clone()) {
+            paths.push(antigravity_dir);
+        }
     }
     Ok(paths)
 }
@@ -35,6 +42,7 @@ pub(super) fn discover_log_files() -> Result<Vec<PathBuf>> {
     for path in paths()? {
         collect_files_with_extension(&path, "json", &mut files);
         collect_files_with_extension(&path, "jsonl", &mut files);
+        collect_files_with_extension(&path, "db", &mut files);
     }
     files.sort();
     files.dedup();

--- a/rust/adapters/gemini/src/paths.rs
+++ b/rust/adapters/gemini/src/paths.rs
@@ -9,31 +9,25 @@ pub(super) const ANTIGRAVITY_DATA_DIR_ENV: &str = "ANTIGRAVITY_DATA_DIR";
 fn paths() -> Result<Vec<PathBuf>> {
     let mut paths = Vec::new();
     let mut seen = HashSet::new();
-    if let Ok(env_paths) = env::var(GEMINI_DATA_DIR_ENV) {
-        for raw in env_paths
-            .split(',')
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-        {
-            let path = PathBuf::from(raw);
-            if path.is_dir() && seen.insert(path.clone()) {
-                paths.push(path);
-            }
-        }
-        return Ok(paths);
-    }
 
-    if let Ok(env_paths) = env::var(ANTIGRAVITY_DATA_DIR_ENV) {
-        for raw in env_paths
-            .split(',')
-            .map(str::trim)
-            .filter(|path| !path.is_empty())
-        {
-            let path = PathBuf::from(raw);
-            if path.is_dir() && seen.insert(path.clone()) {
-                paths.push(path);
+    let mut env_override = false;
+    for env_var in [GEMINI_DATA_DIR_ENV, ANTIGRAVITY_DATA_DIR_ENV] {
+        if let Ok(env_paths) = env::var(env_var) {
+            env_override = true;
+            for raw in env_paths
+                .split(',')
+                .map(str::trim)
+                .filter(|path| !path.is_empty())
+            {
+                let path = PathBuf::from(raw);
+                if path.is_dir() && seen.insert(path.clone()) {
+                    paths.push(path);
+                }
             }
         }
+    }
+    if env_override {
+        return Ok(paths);
     }
 
     if let Some(home) = crate::home::home_dir() {
@@ -41,24 +35,12 @@ fn paths() -> Result<Vec<PathBuf>> {
         if path.is_dir() && seen.insert(path.clone()) {
             paths.push(path);
         }
-        let antigravity_dirs = [
-            home.join(".gemini")
-                .join("antigravity")
-                .join("conversations"),
-            home.join(".gemini")
-                .join("antigravity-cli")
-                .join("conversations"),
-            home.join(".gemini")
-                .join("antigravity-ide")
-                .join("conversations"),
-            home.join(".gemini")
-                .join("antigravity-backup")
-                .join("conversations"),
-        ];
-        for dir in antigravity_dirs {
-            if dir.is_dir() && seen.insert(dir.clone()) {
-                paths.push(dir);
-            }
+        let antigravity_dir = home
+            .join(".gemini")
+            .join("antigravity")
+            .join("conversations");
+        if antigravity_dir.is_dir() && seen.insert(antigravity_dir.clone()) {
+            paths.push(antigravity_dir);
         }
     }
     Ok(paths)


### PR DESCRIPTION
## Summary

Adds support for ingesting Gemini Antigravity conversation sessions stored in local SQLite databases (`~/.gemini/antigravity/conversations/*.db`) within the existing `ccusage-adapter-gemini` adapter.

## Changes

- **Path Discovery**: Discovers `~/.gemini/antigravity/conversations/*.db` alongside existing JSON and JSONL chat logs in `paths.rs`. Respects the `GEMINI_DATA_DIR` environment override.
- **SQLite & Protobuf Decoder**: Implements `parse_sqlite_file` using read-only connections (`sqlite::OpenFlags::new().with_read_only()`) to extract `idx` and binary Protobuf blobs from the `gen_metadata` table.
- **Defensive Varint & Wire Decoding**: Decodes binary Protobuf payloads with strict bounds checks and shift overflow protection (`shift >= 64`), accurately resolving input, output, cached, and reasoning/thinking token metrics.
- **Unit Tests**: Adds `loads_sqlite_antigravity_metadata` in `loader.rs` verifying SQLite/Protobuf ingestion and environment isolation.
- **Documentation**: Updates `rust/adapters/gemini/README.md` with data source and dependency details.

## Verification

- `cargo test --workspace` (All 167+ tests passing)
- `cargo clippy --workspace --all-targets -- -D warnings` (0 warnings)
- `cargo fmt --check` (Clean)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for discovering and reading Gemini conversation databases from the Antigravity conversations directory.
  * SQLite conversations now include normalized model details, token counts, timestamps, continuation data, and deterministic chronological ordering.
  * Added recognition for additional Gemini model names.
  * Existing JSON and JSONL conversation formats remain supported.
* **Bug Fixes**
  * Improved conversation metadata and nested content parsing for more reliable usage reporting.
* **Tests**
  * Added coverage for SQLite conversation extraction and continuation ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->