### PR TITLE
fix(pricing): validate ETag cache refreshes

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "insta",
  "jiff",
  "memchr",
- "miniz_oxide",
+ "miniz_oxide 0.9.1",
  "minreq",
  "rustc-hash",
  "serde",
@@ -488,6 +488,15 @@ dependencies = [
  "encode_unicode",
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -591,6 +600,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.8.9",
+]
 
 [[package]]
 name = "fs_extra"
@@ -798,6 +817,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
 dependencies = [
  "libmimalloc-sys",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -1091,6 +1120,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1238,6 +1273,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
  "base64",
+ "flate2",
  "log",
  "percent-encoding",
  "rustls",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -63,7 +63,7 @@ smallvec = "1.15.2"
 sqlite = { version = "0.37.0", default-features = false, features = ["bundled", "linkage"] }
 terminal_size = "0.4.4"
 unicode-width = "0.2.2"
-ureq = { version = "3.4.0", default-features = false, features = ["rustls"] }
+ureq = { version = "3.4.0", default-features = false, features = ["rustls", "gzip"] }
 
 [profile.release]
 codegen-units = 1

--- a/rust/crates/ccusage-core/src/pricing.rs
+++ b/rust/crates/ccusage-core/src/pricing.rs
@@ -73,8 +73,16 @@ impl PricingEndpoint {
         }
     }
 
-    /// Returns whether a body has a non-empty pricing shape for this endpoint.
+    /// Returns whether a body contains at least one entry the endpoint loader can use.
     pub fn validates(self, json: &str) -> bool {
+        match self {
+            Self::LiteLlm => litellm_json_has_loader_usable_entry(json),
+            Self::ModelsDev => models_dev_json_has_loader_usable_entry(json),
+        }
+    }
+
+    /// Returns whether a body has a non-empty pricing shape for this endpoint.
+    pub fn validates_shape(self, json: &str) -> bool {
         let Ok(Value::Object(entries)) = serde_json::from_str::<Value>(json) else {
             return false;
         };
@@ -83,6 +91,33 @@ impl PricingEndpoint {
             Self::LiteLlm => entries.values().any(litellm_entry_has_required_cost),
             Self::ModelsDev => models_dev_object_has_required_shape(&entries),
         }
+    }
+}
+
+fn litellm_json_has_loader_usable_entry(json: &str) -> bool {
+    let Ok(Value::Object(entries)) = serde_json::from_str::<Value>(json) else {
+        return false;
+    };
+    entries
+        .values()
+        .any(|value| parse_litellm_pricing(value.clone()).is_some())
+}
+
+fn models_dev_json_has_loader_usable_entry(json: &str) -> bool {
+    let Some(raw) = parse_models_dev_json(json) else {
+        return false;
+    };
+    let rules = models_dev_catalog_rules();
+    match raw {
+        ModelsDevJson::Providers(providers) => providers.values().any(|provider| {
+            provider
+                .models
+                .iter()
+                .any(|(model_key, model)| models_dev_usable_cost(rules, model_key, model).is_some())
+        }),
+        ModelsDevJson::Models(models) => models
+            .iter()
+            .any(|(model_key, model)| models_dev_usable_cost(rules, model_key, model).is_some()),
     }
 }
 
@@ -698,6 +733,20 @@ fn per_token(per_million: f64) -> f64 {
     per_million / 1_000_000.0
 }
 
+fn models_dev_usable_cost<'a>(
+    rules: &ModelsDevCatalogRules,
+    source_model_id: &str,
+    model: &'a ModelsDevModel,
+) -> Option<&'a ModelsDevCost> {
+    if !rules.is_token_priced(source_model_id, model.modalities.as_ref()) {
+        return None;
+    }
+    let cost = model.cost.as_ref()?;
+    let input = cost.input?;
+    let output = cost.output?;
+    (input != 0.0 || output != 0.0).then_some(cost)
+}
+
 #[derive(Debug, Deserialize)]
 struct ModelsDevLimit {
     context: Option<u64>,
@@ -935,9 +984,9 @@ impl PricingMap {
             // slip past and bill per-image or per-second rates as per-token ones.
             // It is generation's only remaining gate, so the online refresh
             // carries the same ids the snapshot does.
-            if !rules.is_token_priced(&model_key, model.modalities.as_ref()) {
+            let Some(cost) = models_dev_usable_cost(rules, &model_key, &model) else {
                 continue;
-            }
+            };
             // Same reason: the tier half of the verdict reads the source key,
             // before it is resolved away.
             let declared_id = model.id.as_deref().filter(|id| !id.is_empty());
@@ -949,8 +998,8 @@ impl PricingMap {
             // An empty declared id falls back to the source key, exactly as the
             // generator's `selectModelsDevPricingKey` does: keeping "" would
             // store the model under a name no lookup ever asks for.
-            let model_id = match model.id.filter(|id| !id.is_empty()) {
-                Some(id) => id,
+            let model_id = match model.id.as_ref().filter(|id| !id.is_empty()) {
+                Some(id) => id.clone(),
                 None => source_key.clone(),
             };
             // Dotted, dashed and case spellings name one model, so they contend
@@ -962,21 +1011,13 @@ impl PricingMap {
             if claimed.is_none() && self.entries.contains_key(&model_id) {
                 continue;
             }
-            let Some(cost) = model.cost else {
-                continue;
-            };
             let Some(input) = cost.input else {
                 continue;
             };
             let Some(output) = cost.output else {
                 continue;
             };
-            // Flat-fee subscription catalogs such as `kimi-for-coding` publish
-            // all-zero token costs, which would report every request as free.
-            if input == 0.0 && output == 0.0 {
-                continue;
-            }
-            let context_limit = model.limit.and_then(|limit| limit.context);
+            let context_limit = model.limit.as_ref().and_then(|limit| limit.context);
             let long_context = cost.long_context_tier();
             let claim = ModelsDevClaim {
                 trust,
@@ -2296,21 +2337,29 @@ mod tests {
     }
 
     #[test]
-    fn validates_only_the_schema_for_each_pricing_endpoint() {
+    fn validates_pricing_documents_per_endpoint() {
         let litellm =
             r#"{"gpt-test":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#;
         let models_dev =
             r#"{"openai":{"models":{"gpt-test":{"cost":{"input":1.0,"output":2.0}}}}}"#;
+        let zero_loaded_models_dev = r#"{"openai":{"models":{"unpriced":{"modalities":{"input":[],"output":["text"]},"cost":{"input":1.0,"output":2.0}}}}}"#;
 
         assert!(PricingEndpoint::LiteLlm.validates(litellm));
         assert!(PricingEndpoint::LiteLlm.validates(r#"{"gpt-test":{"i":1.0,"o":2.0}}"#));
         assert!(!PricingEndpoint::LiteLlm.validates(models_dev));
+        assert!(PricingEndpoint::ModelsDev.validates_shape(models_dev));
         assert!(PricingEndpoint::ModelsDev.validates(models_dev));
         assert!(!PricingEndpoint::ModelsDev.validates(litellm));
         assert!(!PricingEndpoint::ModelsDev.validates("{}"));
-        assert!(
-            !PricingEndpoint::ModelsDev
-                .validates(r#"{"openai":{"models":{"free":{"cost":{"input":0.0,"output":0.0}}}}}"#)
+        assert!(!PricingEndpoint::ModelsDev.validates_shape(
+            r#"{"openai":{"models":{"free":{"cost":{"input":0.0,"output":0.0}}}}}"#
+        ));
+        assert!(PricingEndpoint::ModelsDev.validates_shape(zero_loaded_models_dev));
+        assert!(!PricingEndpoint::ModelsDev.validates(zero_loaded_models_dev));
+        let mut pricing = PricingMap::default();
+        assert_eq!(
+            pricing.load_models_dev_json_missing(zero_loaded_models_dev),
+            Some(0)
         );
     }
 

--- a/rust/crates/ccusage-core/src/pricing.rs
+++ b/rust/crates/ccusage-core/src/pricing.rs
@@ -56,6 +56,35 @@ const MODELS_DEV_FAILURE_RETRY_AFTER: Duration = Duration::from_secs(60);
 // suffixes are treated as distinct model versions.
 const MODEL_DATE_SUFFIX_DIGITS: usize = 8;
 
+/// Identifies the upstream document whose schema a pricing response must use.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PricingEndpoint {
+    LiteLlm,
+    ModelsDev,
+}
+
+impl PricingEndpoint {
+    /// Returns the pricing endpoint represented by a fetch URL.
+    pub fn for_url(url: &str) -> Option<Self> {
+        match url {
+            LITELLM_PRICING_URL => Some(Self::LiteLlm),
+            MODELS_DEV_API_URL => Some(Self::ModelsDev),
+            _ => None,
+        }
+    }
+
+    /// Returns whether a body contains usable pricing data for this endpoint.
+    pub fn validates(self, json: &str) -> bool {
+        let mut map = PricingMap::default();
+        match self {
+            Self::LiteLlm => map.load_json(json) > 0,
+            Self::ModelsDev => map
+                .load_models_dev_json_missing(json)
+                .is_some_and(|loaded_count| loaded_count > 0),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 pub struct Pricing {
     pub input: f64,
@@ -2136,7 +2165,10 @@ where
         }
     };
     let mut map = PricingMap::default();
-    if map.load_models_dev_json_missing(&json).is_none() {
+    if !map
+        .load_models_dev_json_missing(&json)
+        .is_some_and(|loaded_count| loaded_count > 0)
+    {
         if should_log_pricing_refresh_details() {
             eprintln!("WARN  Failed to parse models.dev pricing; using LiteLLM pricing.");
         }
@@ -2180,8 +2212,9 @@ fn fetch_json_url(url: &str) -> std::io::Result<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        Fuzzy, Pricing, PricingMap, build_time_models_dev_json, build_time_pricing_json,
-        embedded_models_dev_pricing, long_context_split_threshold, model_without_date_suffix,
+        Fuzzy, Pricing, PricingEndpoint, PricingMap, build_time_models_dev_json,
+        build_time_pricing_json, embedded_models_dev_pricing, long_context_split_threshold,
+        model_without_date_suffix,
     };
     use ccusage_test_support::fs_fixture;
     use std::sync::atomic::{AtomicUsize, Ordering};
@@ -2191,6 +2224,20 @@ mod tests {
         let pricing = PricingMap::load_embedded();
         assert!(pricing.len() > 0);
         assert!(pricing.find("claude-sonnet-4-20250514").is_some());
+    }
+
+    #[test]
+    fn validates_only_the_schema_for_each_pricing_endpoint() {
+        let litellm =
+            r#"{"gpt-test":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#;
+        let models_dev =
+            r#"{"openai":{"models":{"gpt-test":{"cost":{"input":1.0,"output":2.0}}}}}"#;
+
+        assert!(PricingEndpoint::LiteLlm.validates(litellm));
+        assert!(!PricingEndpoint::LiteLlm.validates(models_dev));
+        assert!(PricingEndpoint::ModelsDev.validates(models_dev));
+        assert!(!PricingEndpoint::ModelsDev.validates(litellm));
+        assert!(!PricingEndpoint::ModelsDev.validates("{}"));
     }
 
     #[test]

--- a/rust/crates/ccusage-core/src/pricing.rs
+++ b/rust/crates/ccusage-core/src/pricing.rs
@@ -73,16 +73,85 @@ impl PricingEndpoint {
         }
     }
 
-    /// Returns whether a body contains usable pricing data for this endpoint.
+    /// Returns whether a body has a non-empty pricing shape for this endpoint.
     pub fn validates(self, json: &str) -> bool {
-        let mut map = PricingMap::default();
+        let Ok(Value::Object(entries)) = serde_json::from_str::<Value>(json) else {
+            return false;
+        };
+
         match self {
-            Self::LiteLlm => map.load_json(json) > 0,
-            Self::ModelsDev => map
-                .load_models_dev_json_missing(json)
-                .is_some_and(|loaded_count| loaded_count > 0),
+            Self::LiteLlm => entries.values().any(litellm_entry_has_required_cost),
+            Self::ModelsDev => models_dev_object_has_required_shape(&entries),
         }
     }
+}
+
+fn litellm_entry_has_required_cost(value: &Value) -> bool {
+    let Some(entry) = value.as_object() else {
+        return false;
+    };
+    let full = entry
+        .get("input_cost_per_token")
+        .is_some_and(Value::is_number)
+        && entry
+            .get("output_cost_per_token")
+            .is_some_and(Value::is_number);
+    let compact = entry.get("i").is_some_and(Value::is_number)
+        && entry.get("o").is_some_and(Value::is_number);
+    full || compact
+}
+
+fn models_dev_object_has_required_shape(entries: &serde_json::Map<String, Value>) -> bool {
+    if entries.values().any(models_dev_entry_has_models_field) {
+        return entries.values().all(models_dev_provider_has_required_shape)
+            && entries.values().any(models_dev_provider_has_required_cost);
+    }
+    entries.values().all(models_dev_entry_has_required_cost)
+        && entries.values().any(models_dev_entry_has_nonzero_cost)
+}
+
+fn models_dev_provider_has_required_shape(value: &Value) -> bool {
+    let Some(provider) = value.as_object() else {
+        return false;
+    };
+    let Some(models) = provider.get("models").and_then(Value::as_object) else {
+        return false;
+    };
+    models.values().all(Value::is_object)
+}
+
+fn models_dev_provider_has_required_cost(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|provider| provider.get("models"))
+        .and_then(Value::as_object)
+        .is_some_and(|models| models.values().any(models_dev_model_has_required_cost))
+}
+
+fn models_dev_model_has_required_cost(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|model| model.get("cost"))
+        .and_then(Value::as_object)
+        .is_some_and(models_dev_cost_has_required_rates)
+}
+
+fn models_dev_entry_has_nonzero_cost(value: &Value) -> bool {
+    value
+        .as_object()
+        .and_then(|entry| entry.get("cost"))
+        .and_then(Value::as_object)
+        .is_some_and(models_dev_cost_has_required_rates)
+}
+
+fn models_dev_cost_has_required_rates(cost: &serde_json::Map<String, Value>) -> bool {
+    let Some(input) = cost.get("input").and_then(Value::as_f64) else {
+        return false;
+    };
+    let Some(output) = cost.get("output").and_then(Value::as_f64) else {
+        return false;
+    };
+    input != 0.0 || output != 0.0
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -2234,10 +2303,15 @@ mod tests {
             r#"{"openai":{"models":{"gpt-test":{"cost":{"input":1.0,"output":2.0}}}}}"#;
 
         assert!(PricingEndpoint::LiteLlm.validates(litellm));
+        assert!(PricingEndpoint::LiteLlm.validates(r#"{"gpt-test":{"i":1.0,"o":2.0}}"#));
         assert!(!PricingEndpoint::LiteLlm.validates(models_dev));
         assert!(PricingEndpoint::ModelsDev.validates(models_dev));
         assert!(!PricingEndpoint::ModelsDev.validates(litellm));
         assert!(!PricingEndpoint::ModelsDev.validates("{}"));
+        assert!(
+            !PricingEndpoint::ModelsDev
+                .validates(r#"{"openai":{"models":{"free":{"cost":{"input":0.0,"output":0.0}}}}}"#)
+        );
     }
 
     #[test]

--- a/rust/crates/ccusage/src/http.rs
+++ b/rust/crates/ccusage/src/http.rs
@@ -1,32 +1,659 @@
-use std::time::Duration;
+use std::{
+    fs,
+    io::{self, Read},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
+use ccusage_core::pricing::PricingEndpoint;
 
 const PRICING_FETCH_TIMEOUT_SECONDS: u64 = 10;
 const PRICING_FETCH_MAX_BYTES: u64 = 64 * 1024 * 1024;
+const CACHE_ETAG_MAX_BYTES: u64 = 4096;
+const CACHE_FILE_MAX_BYTES: u64 = PRICING_FETCH_MAX_BYTES + CACHE_ETAG_MAX_BYTES + 1;
 
-/// Fetches a JSON document for the pricing refresh.
+/// Fetches a validated pricing document for the refresh.
 ///
 /// This lives in the binary so that `ureq` and its TLS stack are not dependencies
 /// of `ccusage-core`, which every adapter builds against; `main` installs it
 /// through `ccusage_core::pricing::set_json_fetcher`.
-pub(crate) fn fetch_json(url: &str) -> std::io::Result<String> {
+///
+/// Each response body is kept on disk next to its ETag, and later fetches
+/// revalidate with `If-None-Match`. A cached body is used only after the server
+/// confirms it with a 304 and the body passes the endpoint's pricing validator.
+pub(crate) fn fetch_json(url: &str) -> io::Result<String> {
+    let endpoint = PricingEndpoint::for_url(url).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("unsupported pricing URL: {url}"),
+        )
+    })?;
+    let cache_dir = default_cache_dir();
+    fetch_json_with_cache_dir(url, cache_dir.as_deref(), endpoint)
+}
+
+/// Returns a per-user cache directory, or `None` when no safe directory exists.
+fn default_cache_dir() -> Option<PathBuf> {
+    cache_dir_under(
+        std::env::var_os("XDG_CACHE_HOME").map(PathBuf::from),
+        ccusage_core::home::home_dir(),
+    )
+}
+
+fn cache_dir_under(xdg_cache_home: Option<PathBuf>, home: Option<PathBuf>) -> Option<PathBuf> {
+    xdg_cache_home
+        .filter(|path| path.is_absolute())
+        .or_else(|| {
+            home.filter(|path| path.is_absolute())
+                .map(|home| home.join(".cache"))
+        })
+        .map(|base| base.join("ccusage").join("http-cache"))
+}
+
+fn fetch_json_with_cache_dir(
+    url: &str,
+    cache_dir: Option<&Path>,
+    endpoint: PricingEndpoint,
+) -> io::Result<String> {
+    fetch_json_with_cache_dir_inner(url, cache_dir, endpoint, true)
+}
+
+fn fetch_json_with_cache_dir_inner(
+    url: &str,
+    cache_dir: Option<&Path>,
+    endpoint: PricingEndpoint,
+    revalidate: bool,
+) -> io::Result<String> {
+    let cache = cache_dir.map(|dir| CacheEntry::for_url(dir, url));
+    let cached = if revalidate {
+        cache.as_ref().and_then(CacheEntry::read)
+    } else {
+        None
+    };
+
     let agent = ureq::Agent::config_builder()
         .timeout_global(Some(Duration::from_secs(PRICING_FETCH_TIMEOUT_SECONDS)))
         .build()
         .new_agent();
-    let mut response = agent
-        .get(url)
+    let mut request = agent.get(url);
+    if let Some(cached) = cached.as_ref() {
+        request = request.header("if-none-match", &cached.etag);
+    }
+    let mut response = request
         .call()
-        .map_err(|error| std::io::Error::other(error.to_string()))?;
-    if response.status().as_u16() != 200 {
-        return Err(std::io::Error::other(format!(
-            "HTTP {}",
-            response.status().as_u16()
+        .map_err(|error| io::Error::other(error.to_string()))?;
+    let status = response.status().as_u16();
+
+    if status == 304 {
+        let Some(cached) = cached else {
+            return Err(io::Error::other("HTTP 304 without a cached body"));
+        };
+        if endpoint.validates(&cached.body) {
+            return Ok(cached.body);
+        }
+        if let Some(cache) = cache.as_ref() {
+            cache.invalidate();
+        }
+        return fetch_json_with_cache_dir_inner(url, cache_dir, endpoint, false);
+    }
+    if status != 200 {
+        return Err(io::Error::other(format!("HTTP {status}")));
+    }
+
+    if response
+        .headers()
+        .get("content-length")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.parse::<u64>().ok())
+        .is_some_and(|length| length > PRICING_FETCH_MAX_BYTES)
+    {
+        return Err(io::Error::other(format!(
+            "response body over {PRICING_FETCH_MAX_BYTES} bytes"
         )));
     }
-    response
-        .body_mut()
-        .with_config()
-        .limit(PRICING_FETCH_MAX_BYTES)
-        .read_to_string()
-        .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error.to_string()))
+
+    let body = read_bounded_body(
+        response.body_mut().with_config().reader(),
+        PRICING_FETCH_MAX_BYTES,
+    )
+    .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
+    if !endpoint.validates(&body) {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("pricing response failed {endpoint:?} validation"),
+        ));
+    }
+
+    if let Some(etag) = response
+        .headers()
+        .get("etag")
+        .and_then(|value| value.to_str().ok())
+        && let Some(cache) = cache.as_ref()
+    {
+        cache.write(etag, &body);
+    }
+    Ok(body)
+}
+
+fn read_bounded_body(mut reader: impl Read, max_bytes: u64) -> io::Result<String> {
+    let mut body = String::new();
+    let bytes_read = reader
+        .by_ref()
+        .take(max_bytes + 1)
+        .read_to_string(&mut body)?;
+    if bytes_read as u64 > max_bytes {
+        return Err(io::Error::other(format!(
+            "response body over {max_bytes} bytes"
+        )));
+    }
+    Ok(body)
+}
+
+/// The ETag and body are replaced by one rename so concurrent readers never
+/// observe a mixed pair from different refreshes.
+struct CacheEntry {
+    path: PathBuf,
+}
+
+struct CachedResponse {
+    etag: String,
+    body: String,
+}
+
+impl CacheEntry {
+    fn for_url(dir: &Path, url: &str) -> Self {
+        Self {
+            path: dir.join(format!("{}.cache", cache_file_stem(url))),
+        }
+    }
+
+    fn read(&self) -> Option<CachedResponse> {
+        let mut raw = String::new();
+        let bytes_read = fs::File::open(&self.path)
+            .ok()?
+            .take(CACHE_FILE_MAX_BYTES + 1)
+            .read_to_string(&mut raw)
+            .ok()?;
+        if bytes_read as u64 > CACHE_FILE_MAX_BYTES {
+            return None;
+        }
+        let (etag, body) = raw.split_once('\n')?;
+        let etag = etag.trim();
+        if etag.is_empty()
+            || etag.len() as u64 > CACHE_ETAG_MAX_BYTES
+            || !etag.is_ascii()
+            || etag.bytes().any(|byte| byte.is_ascii_control())
+        {
+            return None;
+        }
+        Some(CachedResponse {
+            etag: etag.to_string(),
+            body: body.to_string(),
+        })
+    }
+
+    fn write(&self, etag: &str, body: &str) {
+        if etag.is_empty()
+            || etag.len() as u64 > CACHE_ETAG_MAX_BYTES
+            || !etag.is_ascii()
+            || etag.bytes().any(|byte| byte.is_ascii_control())
+        {
+            return;
+        }
+        static TMP_SEQ: AtomicU64 = AtomicU64::new(0);
+        if let Some(parent) = self.path.parent() {
+            let _ = fs::create_dir_all(parent);
+        }
+        let Some(file_name) = self.path.file_name().and_then(|name| name.to_str()) else {
+            return;
+        };
+        let tmp_path = self.path.with_file_name(format!(
+            "{file_name}.tmp.{}.{}",
+            std::process::id(),
+            TMP_SEQ.fetch_add(1, Ordering::Relaxed),
+        ));
+        match fs::write(&tmp_path, format!("{etag}\n{body}")) {
+            Ok(()) => {
+                if fs::rename(&tmp_path, &self.path).is_err() {
+                    let _ = fs::remove_file(&tmp_path);
+                }
+            }
+            Err(_) => {
+                let _ = fs::remove_file(&tmp_path);
+            }
+        }
+    }
+
+    fn invalidate(&self) {
+        let _ = fs::remove_file(&self.path);
+    }
+}
+
+/// Derives a filesystem-safe, collision-resistant file stem from a URL.
+fn cache_file_stem(url: &str) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in url.bytes() {
+        hash ^= u64::from(byte);
+        hash = hash.wrapping_mul(0x0100_0000_01b3);
+    }
+    let name: String = url
+        .trim_start_matches("https://")
+        .trim_start_matches("http://")
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '.' | '-' | '_') {
+                character
+            } else {
+                '-'
+            }
+        })
+        .take(80)
+        .collect();
+    format!("{name}-{hash:016x}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        CacheEntry, PRICING_FETCH_MAX_BYTES, PricingEndpoint, cache_dir_under, cache_file_stem,
+        fetch_json_with_cache_dir, read_bounded_body,
+    };
+    use ccusage_test_support::Fixture;
+    use std::{
+        fs,
+        io::{self, Cursor, Read as _, Write as _},
+        net::{TcpListener, TcpStream},
+        path::PathBuf,
+        thread,
+        time::{Duration, Instant},
+    };
+
+    const LITELLM_BODY: &str =
+        r#"{"gpt-test":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#;
+    const MODELS_DEV_BODY: &str =
+        r#"{"openai":{"models":{"gpt-test":{"cost":{"input":1.0,"output":2.0}}}}}"#;
+
+    fn accept_with_timeout(listener: &TcpListener) -> io::Result<TcpStream> {
+        let deadline = Instant::now() + Duration::from_secs(5);
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    stream.set_nonblocking(false)?;
+                    return Ok(stream);
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Err(io::Error::new(
+                            io::ErrorKind::TimedOut,
+                            "timed out waiting for test request",
+                        ));
+                    }
+                    thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn read_request(stream: &mut TcpStream) -> io::Result<String> {
+        stream.set_read_timeout(Some(Duration::from_secs(2)))?;
+        let mut request = Vec::new();
+        let mut byte = [0u8; 1];
+        while !request.ends_with(b"\r\n\r\n") {
+            if stream.read(&mut byte)? == 0 {
+                break;
+            }
+            request.push(byte[0]);
+        }
+        Ok(String::from_utf8_lossy(&request).into_owned())
+    }
+
+    fn serve_responses(
+        responses: Vec<String>,
+    ) -> (String, thread::JoinHandle<io::Result<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        listener
+            .set_nonblocking(true)
+            .expect("make test server nonblocking");
+        let url = format!(
+            "http://{}/pricing.json",
+            listener.local_addr().expect("test server address")
+        );
+        let handle = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let mut stream = accept_with_timeout(&listener)?;
+                requests.push(read_request(&mut stream)?);
+                stream.write_all(response.as_bytes())?;
+            }
+            Ok(requests)
+        });
+        (url, handle)
+    }
+
+    fn close_after_request() -> (String, thread::JoinHandle<io::Result<String>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        listener
+            .set_nonblocking(true)
+            .expect("make test server nonblocking");
+        let url = format!(
+            "http://{}/pricing.json",
+            listener.local_addr().expect("test server address")
+        );
+        let handle = thread::spawn(move || {
+            let mut stream = accept_with_timeout(&listener)?;
+            read_request(&mut stream)
+        });
+        (url, handle)
+    }
+
+    fn ok_response(etag: &str, body: &str) -> String {
+        format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\netag: {etag}\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+            body.len(),
+        )
+    }
+
+    fn not_modified_response() -> String {
+        "HTTP/1.1 304 Not Modified\r\ncontent-length: 0\r\nconnection: close\r\n\r\n".to_string()
+    }
+
+    fn unique_test_dir(label: &str) -> PathBuf {
+        std::env::temp_dir().join(format!(
+            "ccusage-http-cache-test-{label}-{}",
+            std::process::id()
+        ))
+    }
+
+    #[test]
+    fn cache_round_trips_etag_and_body_without_validating_until_revalidation() {
+        let dir = unique_test_dir("round-trip");
+        let _ = fs::remove_dir_all(&dir);
+        let entry = CacheEntry::for_url(&dir, "https://example.com/pricing.json");
+
+        assert!(entry.read().is_none());
+        entry.write("\"abc123\"", "{}");
+        let cached = entry.read().expect("cache entry after write");
+        assert_eq!(cached.etag, "\"abc123\"");
+        assert_eq!(cached.body, "{}");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_read_rejects_unusable_etag_or_truncated_entry() {
+        let dir = unique_test_dir("bad-etag");
+        let _ = fs::remove_dir_all(&dir);
+        let entry = CacheEntry::for_url(&dir, "https://example.com/pricing.json");
+
+        entry.write("\"ok\"", "{}");
+        fs::write(&entry.path, "   \nbody").expect("overwrite cache");
+        assert!(entry.read().is_none(), "blank etag must not revalidate");
+        fs::write(&entry.path, "etag\rwith-cr\nbody").expect("overwrite cache");
+        assert!(
+            entry.read().is_none(),
+            "control characters must not reach a header value"
+        );
+        fs::write(&entry.path, "etag-without-newline").expect("overwrite cache");
+        assert!(entry.read().is_none(), "a truncated entry must not be used");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_writes_replace_the_pair_atomically_and_leave_no_temporary_files() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let url = "https://example.com/pricing.json";
+        let pairs: Vec<_> = (0..8)
+            .map(|index| {
+                (
+                    format!("\"etag-{index}\""),
+                    format!("body-{index}\nwith-newlines"),
+                )
+            })
+            .collect();
+        let handles: Vec<_> = pairs
+            .iter()
+            .cloned()
+            .map(|(etag, body)| {
+                let dir = dir.clone();
+                let url = url.to_string();
+                thread::spawn(move || CacheEntry::for_url(&dir, &url).write(&etag, &body))
+            })
+            .collect();
+        for handle in handles {
+            handle.join().expect("cache writer");
+        }
+
+        let entry = CacheEntry::for_url(&dir, url);
+        let cached = entry.read().expect("cache entry after concurrent writes");
+        assert!(
+            pairs
+                .iter()
+                .any(|(etag, body)| cached.etag == *etag && cached.body == *body),
+            "read a torn cache pair: {:?}",
+            (cached.etag, cached.body)
+        );
+        let cache_path = entry.path.clone();
+        let leftovers: Vec<_> = fs::read_dir(&dir)
+            .expect("cache dir")
+            .filter_map(Result::ok)
+            .filter(|entry| entry.path() != cache_path)
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "leftover temporary files: {leftovers:?}"
+        );
+    }
+
+    #[test]
+    fn reuses_a_validated_cache_body_after_304() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses(vec![not_modified_response()]);
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"cached\"", LITELLM_BODY);
+
+        let body = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm)
+            .expect("304 should reuse validated cache");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(body, LITELLM_BODY);
+        let request = requests.first().expect("one request").to_ascii_lowercase();
+        assert!(request.contains("if-none-match: \"cached\""));
+        assert!(request.contains("accept-encoding: gzip"));
+    }
+
+    #[test]
+    fn invalid_cached_body_after_304_retries_without_validator() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses(vec![
+            not_modified_response(),
+            ok_response("\"fresh\"", LITELLM_BODY),
+        ]);
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"poisoned\"", "{}");
+
+        let body = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm)
+            .expect("invalid 304 body should trigger a fresh fetch");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(body, LITELLM_BODY);
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("if-none-match: \"poisoned\"")
+        );
+        assert!(!requests[1].to_ascii_lowercase().contains("if-none-match"));
+        let cached = entry.read().expect("fresh cache entry");
+        assert_eq!(cached.etag, "\"fresh\"");
+        assert_eq!(cached.body, LITELLM_BODY);
+    }
+
+    #[test]
+    fn does_not_reuse_a_models_dev_body_for_a_litellm_304() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses(vec![
+            not_modified_response(),
+            ok_response("\"fresh\"", LITELLM_BODY),
+        ]);
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"models-dev\"", MODELS_DEV_BODY);
+
+        let body = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm)
+            .expect("wrong-schema cache must be refreshed");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(body, LITELLM_BODY);
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("if-none-match: \"models-dev\"")
+        );
+        assert!(!requests[1].to_ascii_lowercase().contains("if-none-match"));
+    }
+
+    #[test]
+    fn does_not_reuse_a_litellm_body_for_a_models_dev_304() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses(vec![
+            not_modified_response(),
+            ok_response("\"fresh\"", MODELS_DEV_BODY),
+        ]);
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"litellm\"", LITELLM_BODY);
+
+        let body = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::ModelsDev)
+            .expect("wrong-schema cache must be refreshed");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(body, MODELS_DEV_BODY);
+        assert!(
+            requests[0]
+                .to_ascii_lowercase()
+                .contains("if-none-match: \"litellm\"")
+        );
+        assert!(!requests[1].to_ascii_lowercase().contains("if-none-match"));
+    }
+
+    #[test]
+    fn rejects_a_fresh_body_for_the_wrong_endpoint_and_does_not_cache_it() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses(vec![ok_response("\"wrong\"", MODELS_DEV_BODY)]);
+
+        let error = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm)
+            .expect_err("models.dev body must not be accepted as LiteLLM pricing");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(error.kind(), io::ErrorKind::InvalidData);
+        assert!(!requests[0].to_ascii_lowercase().contains("if-none-match"));
+        assert!(CacheEntry::for_url(&dir, &url).read().is_none());
+    }
+
+    #[test]
+    fn transport_errors_do_not_reuse_cached_body() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = close_after_request();
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"cached\"", LITELLM_BODY);
+
+        assert!(
+            fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm).is_err(),
+            "a transport failure must not turn an unbounded-age cache into a response"
+        );
+        let request = server.join().expect("test server").expect("server request");
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("if-none-match: \"cached\"")
+        );
+        let cached = entry.read().expect("transport failure keeps cache on disk");
+        assert_eq!(cached.body, LITELLM_BODY);
+    }
+
+    #[test]
+    fn oversized_response_does_not_reuse_cached_body() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\netag: \"oversized\"\r\ncontent-length: {}\r\nconnection: close\r\n\r\n",
+            PRICING_FETCH_MAX_BYTES + 1,
+        );
+        let (url, server) = serve_responses(vec![response]);
+        let entry = CacheEntry::for_url(&dir, &url);
+        entry.write("\"cached\"", LITELLM_BODY);
+
+        assert!(
+            fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::LiteLlm).is_err(),
+            "an oversized response must not reuse cached pricing"
+        );
+        let _ = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+        assert_eq!(entry.read().expect("cache remains").body, LITELLM_BODY);
+    }
+
+    #[test]
+    fn bounded_body_reader_rejects_data_over_its_limit() {
+        let error = read_bounded_body(Cursor::new("12345"), 4).expect_err("body is oversized");
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+    }
+
+    #[test]
+    fn cache_file_stem_is_filesystem_safe_and_distinct_per_url() {
+        let litellm = cache_file_stem(
+            "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json",
+        );
+        let models_dev = cache_file_stem("https://models.dev/api.json");
+
+        assert_ne!(litellm, models_dev);
+        for stem in [&litellm, &models_dev] {
+            assert!(
+                stem.chars()
+                    .all(|character| character.is_ascii_alphanumeric()
+                        || matches!(character, '.' | '-' | '_')),
+                "stem {stem} must be filesystem-safe"
+            );
+        }
+        assert_ne!(
+            cache_file_stem(&format!("https://example.com/{}/a.json", "x".repeat(200))),
+            cache_file_stem(&format!("https://example.com/{}/b.json", "x".repeat(200))),
+        );
+    }
+
+    #[test]
+    fn cache_dir_prefers_xdg_then_home() {
+        assert_eq!(
+            cache_dir_under(Some(PathBuf::from("/xdg")), Some(PathBuf::from("/home/u"))),
+            Some(PathBuf::from("/xdg/ccusage/http-cache")),
+        );
+        assert_eq!(
+            cache_dir_under(None, Some(PathBuf::from("/home/u"))),
+            Some(PathBuf::from("/home/u/.cache/ccusage/http-cache")),
+        );
+        assert_eq!(cache_dir_under(Some(PathBuf::from("relative")), None), None);
+    }
 }

--- a/rust/crates/ccusage/src/http.rs
+++ b/rust/crates/ccusage/src/http.rs
@@ -371,10 +371,15 @@ mod tests {
         );
         let handle = thread::spawn(move || {
             let mut requests = Vec::new();
-            for response in responses {
-                let Some(mut stream) = accept_until_idle(&listener, Duration::from_millis(250))?
-                else {
-                    break;
+            for (response_index, response) in responses.into_iter().enumerate() {
+                let mut stream = if response_index == 0 {
+                    accept_with_timeout(&listener)?
+                } else {
+                    let Some(stream) = accept_until_idle(&listener, Duration::from_millis(250))?
+                    else {
+                        break;
+                    };
+                    stream
                 };
                 requests.push(read_request(&mut stream)?);
                 stream.write_all(response.as_bytes())?;

--- a/rust/crates/ccusage/src/http.rs
+++ b/rust/crates/ccusage/src/http.rs
@@ -118,7 +118,7 @@ fn fetch_json_with_cache_dir_inner(
         PRICING_FETCH_MAX_BYTES,
     )
     .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error.to_string()))?;
-    if !endpoint.validates(&body) {
+    if !endpoint.validates_shape(&body) {
         return Err(io::Error::new(
             io::ErrorKind::InvalidData,
             format!("pricing response failed {endpoint:?} validation"),
@@ -276,6 +276,7 @@ mod tests {
         r#"{"gpt-test":{"input_cost_per_token":0.000001,"output_cost_per_token":0.000002}}"#;
     const MODELS_DEV_BODY: &str =
         r#"{"openai":{"models":{"gpt-test":{"cost":{"input":1.0,"output":2.0}}}}}"#;
+    const ZERO_LOADED_MODELS_DEV_BODY: &str = r#"{"openai":{"models":{"unpriced":{"modalities":{"input":[],"output":["text"]},"cost":{"input":1.0,"output":2.0}}}}}"#;
 
     fn accept_with_timeout(listener: &TcpListener) -> io::Result<TcpStream> {
         let deadline = Instant::now() + Duration::from_secs(5);
@@ -327,6 +328,54 @@ mod tests {
             let mut requests = Vec::new();
             for response in responses {
                 let mut stream = accept_with_timeout(&listener)?;
+                requests.push(read_request(&mut stream)?);
+                stream.write_all(response.as_bytes())?;
+            }
+            Ok(requests)
+        });
+        (url, handle)
+    }
+
+    fn accept_until_idle(
+        listener: &TcpListener,
+        idle_timeout: Duration,
+    ) -> io::Result<Option<TcpStream>> {
+        let deadline = Instant::now() + idle_timeout;
+        loop {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    stream.set_nonblocking(false)?;
+                    return Ok(Some(stream));
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= deadline {
+                        return Ok(None);
+                    }
+                    thread::sleep(Duration::from_millis(1));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn serve_responses_allowing_missing_tail(
+        responses: Vec<String>,
+    ) -> (String, thread::JoinHandle<io::Result<Vec<String>>>) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+        listener
+            .set_nonblocking(true)
+            .expect("make test server nonblocking");
+        let url = format!(
+            "http://{}/pricing.json",
+            listener.local_addr().expect("test server address")
+        );
+        let handle = thread::spawn(move || {
+            let mut requests = Vec::new();
+            for response in responses {
+                let Some(mut stream) = accept_until_idle(&listener, Duration::from_millis(250))?
+                else {
+                    break;
+                };
                 requests.push(read_request(&mut stream)?);
                 stream.write_all(response.as_bytes())?;
             }
@@ -518,6 +567,40 @@ mod tests {
         let cached = entry.read().expect("fresh cache entry");
         assert_eq!(cached.etag, "\"fresh\"");
         assert_eq!(cached.body, LITELLM_BODY);
+    }
+
+    #[test]
+    fn recovers_after_a_200_models_dev_body_loads_zero_entries_before_304() {
+        let fixture = Fixture::new();
+        let dir = fixture.path("http-cache");
+        let (url, server) = serve_responses_allowing_missing_tail(vec![
+            ok_response("\"poisoned\"", ZERO_LOADED_MODELS_DEV_BODY),
+            not_modified_response(),
+            ok_response("\"fresh\"", MODELS_DEV_BODY),
+        ]);
+
+        let first = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::ModelsDev)
+            .expect("structurally valid 200 should reach the loader");
+        assert_eq!(first, ZERO_LOADED_MODELS_DEV_BODY);
+        assert!(PricingEndpoint::ModelsDev.validates_shape(&first));
+        assert!(!PricingEndpoint::ModelsDev.validates(&first));
+
+        let second = fetch_json_with_cache_dir(&url, Some(&dir), PricingEndpoint::ModelsDev)
+            .expect("a zero-loaded cache body must be refreshed after 304");
+        let requests = server
+            .join()
+            .expect("test server")
+            .expect("server response");
+
+        assert_eq!(second, MODELS_DEV_BODY);
+        assert_eq!(requests.len(), 3, "200 -> 304 -> unconditional 200");
+        assert!(!requests[0].to_ascii_lowercase().contains("if-none-match"));
+        assert!(
+            requests[1]
+                .to_ascii_lowercase()
+                .contains("if-none-match: \"poisoned\"")
+        );
+        assert!(!requests[2].to_ascii_lowercase().contains("if-none-match"));
     }
 
     #[test]

--- a/rust/crates/ccusage/src/http.rs
+++ b/rust/crates/ccusage/src/http.rs
@@ -179,6 +179,9 @@ impl CacheEntry {
             return None;
         }
         let (etag, body) = raw.split_once('\n')?;
+        if body.len() as u64 > PRICING_FETCH_MAX_BYTES {
+            return None;
+        }
         let etag = etag.trim();
         if etag.is_empty()
             || etag.len() as u64 > CACHE_ETAG_MAX_BYTES
@@ -397,6 +400,24 @@ mod tests {
         );
         fs::write(&entry.path, "etag-without-newline").expect("overwrite cache");
         assert!(entry.read().is_none(), "a truncated entry must not be used");
+
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn cache_read_rejects_body_over_the_pricing_limit_after_the_etag() {
+        let dir = unique_test_dir("oversized-body");
+        let _ = fs::remove_dir_all(&dir);
+        let entry = CacheEntry::for_url(&dir, "https://example.com/pricing.json");
+
+        entry.write("etag", "small body");
+        let body = "x".repeat((PRICING_FETCH_MAX_BYTES + 1) as usize);
+        fs::write(&entry.path, format!("etag\n{body}")).expect("overwrite cache");
+
+        assert!(
+            entry.read().is_none(),
+            "the body limit must not include the ETag allowance"
+        );
 
         let _ = fs::remove_dir_all(&dir);
     }


### PR DESCRIPTION
## Summary\n\n- Add gzip-aware per-user HTTP caching for pricing requests.\n- Replace body and ETag files atomically under bounded decompression and body limits.\n- Reuse cached data only after endpoint-specific validation and recover once from a poisoned 304 cache.\n- Keep stale-on-error disabled.\n\n## Validation\n\n- Focused cache, concurrency, workspace, Clippy, Hawk, docs, and diff checks pass.\n\nFixes #1564

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pricing ETag cache refreshes so cached pricing is reused only when the server confirms it with a 304 and the body passes endpoint-specific validation.

- Adds gzip-aware per-user HTTP caching for pricing requests.
- Replaces body and ETag files atomically under bounded limits.
- Rejects cached bodies that exceed the decompressed pricing limit after ETag framing is removed.
- Reuses the loader's Models.dev token-pricing and nonzero-rate gate for cache revalidation.
- Recovers once from a poisoned cache when a 304 returns an invalid body.
- Enables the `gzip` feature on `ureq` and adds `flate2` as a dependency.
- Keeps stale-on-error disabled; transport failures never fall back to cached data.

Fixes #1564.

<sup>Written for commit 29f86cd1beaf85a4b0d3d2c15ee883555c7f0aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pricing data requests now support compressed responses, local caching, and conditional refreshes to reduce unnecessary downloads.
  * Pricing data can be reused safely through endpoint-specific cache entries.

* **Bug Fixes**
  * Invalid, incomplete, oversized, or unusable pricing data is rejected instead of being used.
  * Pricing updates fall back to an alternate source when the primary source cannot provide usable models.
  * Cached data is validated during refreshes and safely replaced when no longer usable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->