### PR TITLE
fix(pi): return zero totals for empty reports

### DIFF
--- a/rust/crates/ccusage/src/adapter/pi/report.rs
+++ b/rust/crates/ccusage/src/adapter/pi/report.rs
@@ -16,7 +16,7 @@ pub(crate) fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKi
         .collect::<Vec<_>>();
     json!({
         rows_key(kind): rows_json,
-        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+        "totals": totals_json(rows),
     })
 }
 
@@ -72,5 +72,24 @@ fn rows_key(kind: AgentReportKind) -> &'static str {
         AgentReportKind::Weekly => "weekly",
         AgentReportKind::Monthly => "monthly",
         AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_report_has_zero_totals_object() {
+        let report = report_from_rows(&[], AgentReportKind::Daily);
+
+        assert_eq!(report["daily"], json!([]));
+        assert!(report["totals"].is_object());
+        assert_eq!(report["totals"]["inputTokens"], json!(0));
+        assert_eq!(report["totals"]["outputTokens"], json!(0));
+        assert_eq!(report["totals"]["cacheCreationTokens"], json!(0));
+        assert_eq!(report["totals"]["cacheReadTokens"], json!(0));
+        assert_eq!(report["totals"]["totalTokens"], json!(0));
+        assert_eq!(report["totals"]["totalCost"].as_f64(), Some(0.0));
     }
 }


### PR DESCRIPTION
Keeps the Pi JSON report shape stable when a selected period has no rows by returning the shared zero-valued totals object instead of null.

Testing:
- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo test --manifest-path rust/Cargo.toml -p ccusage empty_report_has_zero_totals_object (1 passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Returns zero-valued totals for empty Pi reports so the JSON response shape stays consistent. Previously, empty reports set `totals` to `null`; now they use the same zero totals object as populated reports. Refs #832 and #1480.

<sup>Written for commit 8bdd615eec7ac78c116003eefc7010b17f649242. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

