### PR TITLE
fix(pi): return zero totals for empty reports

### DIFF
--- a/rust/adapters/pi/src/report.rs
+++ b/rust/adapters/pi/src/report.rs
@@ -14,7 +14,7 @@ pub fn report_from_rows(rows: &[crate::UsageSummary], kind: AgentReportKind) -> 
         .collect::<Vec<_>>();
     json!({
         rows_key(kind): rows_json,
-        "totals": if rows.is_empty() { Value::Null } else { totals_json(rows) },
+        "totals": totals_json(rows),
     })
 }
 
@@ -70,5 +70,24 @@ fn rows_key(kind: AgentReportKind) -> &'static str {
         AgentReportKind::Weekly => "weekly",
         AgentReportKind::Monthly => "monthly",
         AgentReportKind::Session => "sessions",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_report_has_zero_totals_object() {
+        let report = report_from_rows(&[], AgentReportKind::Daily);
+
+        assert_eq!(report["daily"], json!([]));
+        assert!(report["totals"].is_object());
+        assert_eq!(report["totals"]["inputTokens"], json!(0));
+        assert_eq!(report["totals"]["outputTokens"], json!(0));
+        assert_eq!(report["totals"]["cacheCreationTokens"], json!(0));
+        assert_eq!(report["totals"]["cacheReadTokens"], json!(0));
+        assert_eq!(report["totals"]["totalTokens"], json!(0));
+        assert_eq!(report["totals"]["totalCost"].as_f64(), Some(0.0));
     }
 }


### PR DESCRIPTION
Keeps the Pi JSON report shape stable when a selected period has no rows by returning the shared zero-valued totals object instead of null. This branch is rebuilt from current main, so the PR contains exactly one adapter file.

Testing:
- cargo fmt --manifest-path rust/Cargo.toml --all -- --check
- cargo test --manifest-path rust/Cargo.toml -p ccusage-adapter-pi --features ccusage-core/fetch-litellm-pricing empty_report_has_zero_totals_object (1 passed)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Pi adapter report so a selected period with no usage rows returns a zero-valued totals object instead of `null`, keeping the JSON response shape consistent for consumers. Adds a regression test covering that empty report shape.

<sup>Written for commit 5c57e5df7cee38ac6202e1def525a14c3a2f8268. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reports now consistently include a totals summary, even when no rows are available.
  * Empty reports display zero token and cost values instead of an empty result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->