### PR TITLE
fix(nix): silence agent skill sync hook

### DIFF
--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -104,7 +104,7 @@ in
             just install
           fi
 
-          ${lib.getExe config.packages.syncAgentSkills}
+          ${lib.getExe config.packages.syncAgentSkills} >/dev/null
           ${config.pre-commit.shellHook}
         ''
         + gitWtHook;


### PR DESCRIPTION
Dev shell initialization now discards the agent-skills installer success output, so entering the shell no longer prints its generated destination. Installer diagnostics remain on stderr, including unsafe destination errors.

Testing:
- nix-instantiate --parse nix/dev-shell.nix
- treefmt --no-cache --fail-on-change nix/dev-shell.nix
- nix develop with isolated AGENT_SKILLS_ROOT (success output suppressed; unsafe destination stderr retained)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the agent-skills sync hook in the Nix dev shell so entering the shell no longer prints the installer's generated destination. The installer still writes diagnostics to stderr, including unsafe destination errors.

<sup>Written for commit 77a497cd1cd10869127c219b60c1d4d1370afa72. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced unnecessary terminal output during development environment setup.
  * Skill synchronization continues to run silently in the background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->