### PR TITLE
fix: enforce issue product scope

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -8,8 +8,8 @@ body:
       value: |
         **Before you start:** Read [CONTRIBUTING.md](https://github.com/ccusage/ccusage/blob/main/CONTRIBUTING.md).
 
-        Issues from new contributors are assessed by an automated gate. Clear, actionable reports remain
-        open; spam, duplicates, invalid reports, and clearly out-of-scope reports may be closed.
+        Issues from new contributors are assessed by an automated gate. Bugs and regressions in currently
+        supported behavior are kept open or sent to maintainer review; they are not automatically closed.
 
         Keep this short, concrete, and written in your own voice.
 

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -9,7 +9,7 @@ body:
         **Before you start:** Read [CONTRIBUTING.md](https://github.com/ccusage/ccusage/blob/main/CONTRIBUTING.md).
 
         New optional capabilities are closed by default unless a maintainer explicitly accepts the change
-        through the maintenance workflow. Being clear or easy to implement does not by itself make a
+        through the Issue Gate workflow. Being clear or easy to implement does not by itself make a
         proposal accepted scope.
 
         Use the bug report form when currently supported behavior is broken.

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,7 +1,6 @@
 name: Contribution Proposal
 description: Propose a change or feature before opening a PR
-labels:
-  - enhancement
+labels: []
 body:
   - type: markdown
     attributes:

--- a/.github/ISSUE_TEMPLATE/contribution.yml
+++ b/.github/ISSUE_TEMPLATE/contribution.yml
@@ -1,14 +1,18 @@
 name: Contribution Proposal
 description: Propose a change or feature before opening a PR
-labels: []
+labels:
+  - enhancement
 body:
   - type: markdown
     attributes:
       value: |
         **Before you start:** Read [CONTRIBUTING.md](https://github.com/ccusage/ccusage/blob/main/CONTRIBUTING.md).
 
-        New contributions are assessed by an automated gate. Clear, actionable proposals remain open;
-        spam, duplicates, invalid reports, and clearly out-of-scope work may be closed.
+        New optional capabilities are closed by default unless a maintainer explicitly accepts the change
+        through the maintenance workflow. Being clear or easy to implement does not by itself make a
+        proposal accepted scope.
+
+        Use the bug report form when currently supported behavior is broken.
 
         Keep this short, concrete, and written in your own voice.
 

--- a/.github/scripts/contribution-gate.nu
+++ b/.github/scripts/contribution-gate.nu
@@ -4,7 +4,7 @@
 use ./contribution-gate/access.nu [issue-access pr-access]
 use ./contribution-gate/coauthor.nu [verify-coauthor]
 use ./contribution-gate/context.nu [issue-context]
-use ./contribution-gate/mutations.nu [issue-verdict pr-verdict]
+use ./contribution-gate/mutations.nu [issue-verdict pr-verdict restore-protected-issue]
 use ./contribution-gate/requests.nu [
     issue-implementation-guard
     issue-implementation-request
@@ -21,6 +21,7 @@ def main [operation: string]: nothing -> nothing {
         'issue-request' => issue-request
         'pr-request' => pr-request
         'issue-verdict' => issue-verdict
+        'restore-protected-issue' => restore-protected-issue
         'pr-verdict' => pr-verdict
         'issue-implementation-guard' => issue-implementation-guard
         'issue-implementation-request' => issue-implementation-request

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -140,6 +140,9 @@ def test-prompt-rendering []: nothing -> nothing {
     expect 'keeps maintainer acceptance outside the model verdict' (
         $issue_prompt | str contains "Explicit maintainer acceptance is handled only by the workflow's manual implementation override"
     ) true
+    expect 'gives feature requests a safe fallback when closure is disabled' (
+        $issue_prompt | str contains 'only when close is allowed; otherwise choose needs_human'
+    ) true
     expect 'does not treat old triage labels as acceptance' (
         $issue_prompt | str contains 'labels such as triage:maintainable'
     ) true
@@ -684,6 +687,9 @@ def test-contribution-gate-comment []: nothing -> nothing {
     ) true
     expect 'does not invite an unaccepted core implementation PR' (
         $feature_comment | str contains 'Please do not open a core implementation PR unless a maintainer explicitly accepts this request.'
+    ) true
+    expect 'ends the feature comment with the normalized decision' (
+        $feature_comment | str trim | str ends-with 'Decision: **closed by the contribution gate**.'
     ) true
 }
 

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -4,7 +4,7 @@
 use ./contribution-gate/coauthor.nu [coauthor-validation]
 use ./contribution-gate/context.nu [issue-context-record]
 use ./contribution-gate/core.nu [parse-issue-number]
-use ./contribution-gate/mutations.nu [is-contribution-gate-comment]
+use ./contribution-gate/mutations.nu [is-contribution-gate-comment issue-comment]
 use ./contribution-gate/verdict.nu [issue-verdict-record]
 use ./contribution-gate/requests.nu [
     CLOSING_PULL_REQUEST_QUERY
@@ -120,6 +120,32 @@ def test-prompt-rendering []: nothing -> nothing {
         ($rendered | str contains '{{')
         false
     )
+
+    let issue_prompt = render-prompt 'issue-judge.md' {
+        ISSUE_NUMBER: '42'
+        REPOSITORY: 'ccusage/ccusage'
+        AUTHOR_STATUS: 'new'
+        CLOSE_ALLOWED: 'true'
+    }
+    expect 'distinguishes supported behavior from new capabilities' [
+        (
+            $issue_prompt
+            | str contains 'Already-supported options, formats, platforms, and integrations remain maintenance obligations'
+        )
+        (
+            $issue_prompt
+            | str contains 'Being clear, easy, useful, or similar to an existing feature does not make it accepted product scope'
+        )
+    ] [true true]
+    expect 'keeps maintainer acceptance outside the model verdict' (
+        $issue_prompt | str contains "Explicit maintainer acceptance is handled only by the workflow's manual implementation override"
+    ) true
+    expect 'does not treat old triage labels as acceptance' (
+        $issue_prompt | str contains 'labels such as triage:maintainable'
+    ) true
+    expect 'renders every issue judge placeholder' (
+        $issue_prompt | str contains '{{'
+    ) false
 }
 
 def test-existing-implementation-pull-request []: nothing -> nothing {
@@ -508,7 +534,7 @@ def test-issue-number []: nothing -> nothing {
 }
 
 def test-forced-issue-implementation []: nothing -> nothing {
-    let result = '{"decision":"close","priority":"priority:low","implementation":"none","reason":"The request is low impact."}'
+    let result = '{"decision":"close","priority":"priority:low","implementation":"none","issue_kind":"feature_request","reason":"The request is low impact."}'
     let automatic_verdict = issue-verdict-record $result false
     let verdict = issue-verdict-record $result false --force-implementation
 
@@ -541,6 +567,98 @@ def test-forced-issue-implementation []: nothing -> nothing {
     ) false
 }
 
+def test-issue-product-scope-policy []: nothing -> nothing {
+    let feature = '{"decision":"keep_open","priority":"priority:medium","implementation":"none","issue_kind":"feature_request","reason":"This adds another optional output format."}'
+    let feature_verdict = issue-verdict-record $feature true
+    (expect
+        'closes an unaccepted feature request'
+        $feature_verdict.decision
+        close
+    )
+    expect 'assigns low priority to an unaccepted feature request' (
+        $feature_verdict.priority
+    ) 'priority:low'
+    expect 'does not implement an unaccepted feature request' (
+        $feature_verdict.implementation
+    ) none
+    expect 'marks an unaccepted feature request as excluded' (
+        $feature_verdict.triage_label
+    ) 'triage:excluded'
+
+    let protected_feature = issue-verdict-record $feature false
+    expect 'fails open when an unaccepted feature cannot be closed safely' (
+        $protected_feature.decision
+    ) needs_human
+    expect 'marks a protected feature for maintainer review' (
+        $protected_feature.triage_label
+    ) 'triage:needs-review'
+
+    let regression = '{"decision":"keep_open","priority":"priority:high","implementation":"create_pr","issue_kind":"supported_behavior_bug","reason":"A documented timezone option no longer works."}'
+    let regression_verdict = issue-verdict-record $regression true
+    (expect
+        'keeps a supported behavior regression open'
+        $regression_verdict.decision
+        keep_open
+    )
+    expect 'allows a focused implementation for a high-priority regression' (
+        $regression_verdict.implementation
+    ) create_pr
+    expect 'does not assign a triage disposition to an accepted regression' (
+        $regression_verdict.triage_label
+    ) null
+
+    let unsafe_regression = '{"decision":"close","priority":"priority:high","implementation":"none","issue_kind":"supported_behavior_bug","reason":"The report appears difficult to reproduce."}'
+    let unsafe_regression_verdict = issue-verdict-record $unsafe_regression true
+    expect 'does not automatically close a supported behavior bug' (
+        $unsafe_regression_verdict.decision
+    ) needs_human
+    expect 'sends a proposed bug closure to maintainer review' (
+        $unsafe_regression_verdict.triage_label
+    ) 'triage:needs-review'
+
+    let security = '{"decision":"close","priority":"priority:critical","implementation":"none","issue_kind":"security","reason":"The report needs private reproduction details."}'
+    let security_verdict = issue-verdict-record $security true
+    expect 'does not automatically close a security report' (
+        $security_verdict.decision
+    ) needs_human
+
+    let other = '{"decision":"close","priority":"priority:low","implementation":"none","issue_kind":"other","reason":"The report appears to be a duplicate."}'
+    let other_verdict = issue-verdict-record $other true
+    (expect
+        'does not automatically close a non-feature issue'
+        $other_verdict.decision
+        needs_human
+    )
+
+    let forced_verdict = issue-verdict-record $feature false --force-implementation
+    expect 'lets an explicit implementation request override feature scope' (
+        $forced_verdict.decision
+    ) keep_open
+    expect 'implements a manually forced feature request' (
+        $forced_verdict.implementation
+    ) create_pr
+    expect 'clears automatic triage labels for a forced implementation' (
+        $forced_verdict.triage_label
+    ) null
+
+    for invalid in [
+        '{"decision":"keep_open","priority":"priority:medium","implementation":"none","reason":"Missing kind."}'
+        '{"decision":"keep_open","priority":"priority:medium","implementation":"none","issue_kind":"unknown","reason":"Unknown kind."}'
+    ] {
+        let result = try {
+            issue-verdict-record $invalid true
+            'accepted'
+        } catch {
+            'rejected'
+        }
+        (expect
+            'rejects an incomplete or invalid product-scope verdict'
+            $result
+            'rejected'
+        )
+    }
+}
+
 def test-contribution-gate-comment []: nothing -> nothing {
     let comment = {
         user: {login: 'github-actions[bot]'}
@@ -555,6 +673,18 @@ def test-contribution-gate-comment []: nothing -> nothing {
     expect 'rejects a comment without the marker' (
         is-contribution-gate-comment ($comment | upsert body 'Automated result.')
     ) false
+
+    let feature = '{"decision":"keep_open","priority":"priority:medium","implementation":"none","issue_kind":"feature_request","reason":"This adds another optional output format."}'
+    let feature_comment = issue-comment (issue-verdict-record $feature true)
+    expect 'thanks the author when excluding a feature request' (
+        $feature_comment | str contains 'Thanks for the proposal.'
+    ) true
+    expect 'explains the supported behavior boundary' (
+        $feature_comment | str contains 'rather than a bug or regression in currently supported behavior'
+    ) true
+    expect 'does not invite an unaccepted core implementation PR' (
+        $feature_comment | str contains 'Please do not open a core implementation PR unless a maintainer explicitly accepts this request.'
+    ) true
 }
 
 def main [] {
@@ -567,6 +697,7 @@ def main [] {
     test-issue-context
     test-issue-number
     test-forced-issue-implementation
+    test-issue-product-scope-policy
     test-contribution-gate-comment
     print 'contribution-gate Nushell tests passed.'
 }

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -2,7 +2,7 @@
 #! nix shell --inputs-from ../.. nixpkgs#nushell --command nu
 
 use ./contribution-gate/coauthor.nu [coauthor-validation]
-use ./contribution-gate/context.nu [issue-context-record]
+use ./contribution-gate/context.nu [issue-context-record issue-protection-record]
 use ./contribution-gate/core.nu [parse-issue-number]
 use ./contribution-gate/mutations.nu [is-contribution-gate-comment issue-comment]
 use ./contribution-gate/verdict.nu [issue-verdict-record]
@@ -460,6 +460,12 @@ def test-implementation-publication []: nothing -> nothing {
 }
 
 def test-issue-context []: nothing -> nothing {
+    expect 'derives independent closure and implementation protection' (
+        issue-protection-record {
+            labels: [{name: bug} {name: security}]
+        }
+    ) {protected_from_close: true, implementation_blocked: true}
+
     expect 'normalizes an open issue' (
         issue-context-record 42 {
             number: 42

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -466,7 +466,40 @@ def test-issue-context []: nothing -> nothing {
             state: open
             user: {login: alice id: 99}
         }
-    ) {number: 42, author: alice, author_id: 99}
+    ) {
+        number: 42
+        author: alice
+        author_id: 99
+        protected_from_close: false
+    }
+
+    expect 'protects a bug label from automatic closure' (
+        issue-context-record 42 {
+            number: 42
+            state: open
+            user: {login: alice id: 99}
+            labels: [{name: bug}]
+        }
+    ) {
+        number: 42
+        author: alice
+        author_id: 99
+        protected_from_close: true
+    }
+
+    expect 'does not treat a generic enhancement label as closure protection' (
+        issue-context-record 42 {
+            number: 42
+            state: open
+            user: {login: alice id: 99}
+            labels: [enhancement]
+        }
+    ) {
+        number: 42
+        author: alice
+        author_id: 99
+        protected_from_close: false
+    }
 
     let invalid_records = [
         {
@@ -596,6 +629,17 @@ def test-issue-product-scope-policy []: nothing -> nothing {
         $protected_feature.triage_label
     ) 'triage:needs-review'
 
+    let labeled_feature = issue-verdict-record $feature true true
+    expect 'does not close an issue protected by a trusted label' (
+        $labeled_feature.decision
+    ) needs_human
+    expect 'does not implement an issue protected from closure' (
+        $labeled_feature.implementation
+    ) none
+    expect 'marks a trusted-label conflict for maintainer review' (
+        $labeled_feature.triage_label
+    ) 'triage:needs-review'
+
     let regression = '{"decision":"keep_open","priority":"priority:high","implementation":"create_pr","issue_kind":"supported_behavior_bug","reason":"A documented timezone option no longer works."}'
     let regression_verdict = issue-verdict-record $regression true
     (expect
@@ -628,13 +672,25 @@ def test-issue-product-scope-policy []: nothing -> nothing {
         $security_verdict.triage_label
     ) 'triage:needs-review'
 
-    let other = '{"decision":"close","priority":"priority:low","implementation":"none","issue_kind":"other","reason":"The report appears to be a duplicate."}'
+    let security_implementation = '{"decision":"keep_open","priority":"priority:critical","implementation":"create_pr","issue_kind":"security","reason":"A sensitive path may expose credentials."}'
+    let security_implementation_verdict = issue-verdict-record $security_implementation true
+    expect 'does not automatically implement a security report' (
+        $security_implementation_verdict.implementation
+    ) none
+    expect 'always sends security reports to maintainer review' (
+        $security_implementation_verdict.decision
+    ) needs_human
+
+    let other = '{"decision":"keep_open","priority":"priority:high","implementation":"create_pr","issue_kind":"other","reason":"The report appears to be a support request."}'
     let other_verdict = issue-verdict-record $other true
     (expect
         'does not automatically close a non-feature issue'
         $other_verdict.decision
         needs_human
     )
+    expect 'does not automatically implement an uncategorized issue' (
+        $other_verdict.implementation
+    ) none
 
     let forced_verdict = issue-verdict-record $feature false --force-implementation
     expect 'lets an explicit implementation request override feature scope' (

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -603,9 +603,9 @@ def test-issue-product-scope-policy []: nothing -> nothing {
     expect 'allows a focused implementation for a high-priority regression' (
         $regression_verdict.implementation
     ) create_pr
-    expect 'does not assign a triage disposition to an accepted regression' (
+    expect 'marks an accepted regression as maintainable' (
         $regression_verdict.triage_label
-    ) null
+    ) 'triage:maintainable'
 
     let unsafe_regression = '{"decision":"close","priority":"priority:high","implementation":"none","issue_kind":"supported_behavior_bug","reason":"The report appears difficult to reproduce."}'
     let unsafe_regression_verdict = issue-verdict-record $unsafe_regression true
@@ -637,9 +637,9 @@ def test-issue-product-scope-policy []: nothing -> nothing {
     expect 'implements a manually forced feature request' (
         $forced_verdict.implementation
     ) create_pr
-    expect 'clears automatic triage labels for a forced implementation' (
+    expect 'marks a forced implementation as maintainable' (
         $forced_verdict.triage_label
-    ) null
+    ) 'triage:maintainable'
 
     for invalid in [
         '{"decision":"keep_open","priority":"priority:medium","implementation":"none","reason":"Missing kind."}'

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -624,6 +624,9 @@ def test-issue-product-scope-policy []: nothing -> nothing {
     expect 'does not automatically close a security report' (
         $security_verdict.decision
     ) needs_human
+    expect 'marks a security report for maintainer review' (
+        $security_verdict.triage_label
+    ) 'triage:needs-review'
 
     let other = '{"decision":"close","priority":"priority:low","implementation":"none","issue_kind":"other","reason":"The report appears to be a duplicate."}'
     let other_verdict = issue-verdict-record $other true

--- a/.github/scripts/contribution-gate.test.nu
+++ b/.github/scripts/contribution-gate.test.nu
@@ -471,6 +471,7 @@ def test-issue-context []: nothing -> nothing {
         author: alice
         author_id: 99
         protected_from_close: false
+        implementation_blocked: false
     }
 
     expect 'protects a bug label from automatic closure' (
@@ -485,6 +486,7 @@ def test-issue-context []: nothing -> nothing {
         author: alice
         author_id: 99
         protected_from_close: true
+        implementation_blocked: false
     }
 
     expect 'does not treat a generic enhancement label as closure protection' (
@@ -499,6 +501,22 @@ def test-issue-context []: nothing -> nothing {
         author: alice
         author_id: 99
         protected_from_close: false
+        implementation_blocked: false
+    }
+
+    expect 'blocks automatic implementation for a security label' (
+        issue-context-record 42 {
+            number: 42
+            state: open
+            user: {login: alice id: 99}
+            labels: [{name: security}]
+        }
+    ) {
+        number: 42
+        author: alice
+        author_id: 99
+        protected_from_close: true
+        implementation_blocked: true
     }
 
     let invalid_records = [
@@ -653,6 +671,14 @@ def test-issue-product-scope-policy []: nothing -> nothing {
     expect 'marks an accepted regression as maintainable' (
         $regression_verdict.triage_label
     ) 'triage:maintainable'
+
+    let mislabeled_security = issue-verdict-record $regression true true true
+    expect 'blocks implementation when trusted labels conflict with the model kind' (
+        $mislabeled_security.implementation
+    ) none
+    expect 'sends an implementation-blocking label conflict to maintainer review' (
+        $mislabeled_security.decision
+    ) needs_human
 
     let unsafe_regression = '{"decision":"close","priority":"priority:high","implementation":"none","issue_kind":"supported_behavior_bug","reason":"The report appears difficult to reproduce."}'
     let unsafe_regression_verdict = issue-verdict-record $unsafe_regression true

--- a/.github/scripts/contribution-gate/context.nu
+++ b/.github/scripts/contribution-gate/context.nu
@@ -1,5 +1,28 @@
 use ./core.nu [gh-api-json issue-number repository write-output]
 
+const PROTECTED_FROM_CLOSE_LABELS = [
+    bug
+    security
+    'triage:maintainable'
+    'triage:needs-review'
+]
+
+def issue-label-names [issue: record]: nothing -> list<string> {
+    $issue
+    | get --optional labels
+    | default []
+    | each {|label|
+        match ($label | describe) {
+            string => ($label | str trim)
+            $type if ($type | str starts-with 'record') => (
+                $label | get --optional name | default '' | into string | str trim
+            )
+            _ => ''
+        }
+    }
+    | where {|label| $label | is-not-empty }
+}
+
 export def issue-context-record [requested_number: int, issue: record]: nothing -> record {
     if $requested_number <= 0 {
         error make {msg: 'Issue number must be positive'}
@@ -25,7 +48,17 @@ export def issue-context-record [requested_number: int, issue: record]: nothing 
         error make {msg: $"Issue #($requested_number) has an invalid author ID"}
     }
 
-    {number: $actual_number, author: $author, author_id: $author_id}
+    let protected_from_close = (
+        issue-label-names $issue
+        | any {|label| $label in $PROTECTED_FROM_CLOSE_LABELS }
+    )
+
+    {
+        number: $actual_number
+        author: $author
+        author_id: $author_id
+        protected_from_close: $protected_from_close
+    }
 }
 
 export def require-open-issue []: nothing -> record {

--- a/.github/scripts/contribution-gate/context.nu
+++ b/.github/scripts/contribution-gate/context.nu
@@ -28,6 +28,14 @@ def issue-label-names [issue: record]: nothing -> list<string> {
     | where {|label| $label | is-not-empty }
 }
 
+export def issue-protection-record [issue: record]: nothing -> record {
+    let labels = issue-label-names $issue
+    {
+        protected_from_close: ($labels | any {|label| $label in $PROTECTED_FROM_CLOSE_LABELS })
+        implementation_blocked: ($labels | any {|label| $label in $IMPLEMENTATION_BLOCKING_LABELS })
+    }
+}
+
 export def issue-context-record [requested_number: int, issue: record]: nothing -> record {
     if $requested_number <= 0 {
         error make {msg: 'Issue number must be positive'}
@@ -53,21 +61,14 @@ export def issue-context-record [requested_number: int, issue: record]: nothing 
         error make {msg: $"Issue #($requested_number) has an invalid author ID"}
     }
 
-    let protected_from_close = (
-        issue-label-names $issue
-        | any {|label| $label in $PROTECTED_FROM_CLOSE_LABELS }
-    )
-    let implementation_blocked = (
-        issue-label-names $issue
-        | any {|label| $label in $IMPLEMENTATION_BLOCKING_LABELS }
-    )
+    let protection = issue-protection-record $issue
 
     {
         number: $actual_number
         author: $author
         author_id: $author_id
-        protected_from_close: $protected_from_close
-        implementation_blocked: $implementation_blocked
+        protected_from_close: $protection.protected_from_close
+        implementation_blocked: $protection.implementation_blocked
     }
 }
 

--- a/.github/scripts/contribution-gate/context.nu
+++ b/.github/scripts/contribution-gate/context.nu
@@ -7,6 +7,11 @@ const PROTECTED_FROM_CLOSE_LABELS = [
     'triage:needs-review'
 ]
 
+const IMPLEMENTATION_BLOCKING_LABELS = [
+    security
+    'triage:needs-review'
+]
+
 def issue-label-names [issue: record]: nothing -> list<string> {
     $issue
     | get --optional labels
@@ -52,12 +57,17 @@ export def issue-context-record [requested_number: int, issue: record]: nothing 
         issue-label-names $issue
         | any {|label| $label in $PROTECTED_FROM_CLOSE_LABELS }
     )
+    let implementation_blocked = (
+        issue-label-names $issue
+        | any {|label| $label in $IMPLEMENTATION_BLOCKING_LABELS }
+    )
 
     {
         number: $actual_number
         author: $author
         author_id: $author_id
         protected_from_close: $protected_from_close
+        implementation_blocked: $implementation_blocked
     }
 }
 

--- a/.github/scripts/contribution-gate/core.nu
+++ b/.github/scripts/contribution-gate/core.nu
@@ -6,6 +6,7 @@ export const PRIORITY_LABELS = [
 ]
 
 export const IMPLEMENTATION_PRIORITIES = ['priority:critical' 'priority:high']
+export const TRIAGE_LABELS = ['triage:excluded' 'triage:needs-review']
 export const COLLABORATOR_PERMISSIONS = [admin maintain write]
 export const COMMENT_MARKER = '<!-- pullfrog-contribution-gate -->'
 

--- a/.github/scripts/contribution-gate/core.nu
+++ b/.github/scripts/contribution-gate/core.nu
@@ -6,7 +6,14 @@ export const PRIORITY_LABELS = [
 ]
 
 export const IMPLEMENTATION_PRIORITIES = ['priority:critical' 'priority:high']
-export const TRIAGE_LABELS = ['triage:excluded' 'triage:needs-review']
+
+export const TRIAGE_LABELS = [
+    'triage:resolved'
+    'triage:maintainable'
+    'triage:excluded'
+    'triage:needs-review'
+]
+
 export const COLLABORATOR_PERMISSIONS = [admin maintain write]
 export const COMMENT_MARKER = '<!-- pullfrog-contribution-gate -->'
 

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -273,8 +273,9 @@ def report-failure [
 export def issue-verdict []: nothing -> nothing {
     let repo = repository
     let number = issue-number
-    require-open-issue | ignore
+    let issue = require-open-issue
     let close_allowed = (required-env CLOSE_ALLOWED) == 'true'
+    let protected_from_close = $issue.protected_from_close
     let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
     let outcome = optional-env JUDGE_OUTCOME failure
     let result = optional-env RESULT ''
@@ -287,9 +288,9 @@ export def issue-verdict []: nothing -> nothing {
 
     let verdict = (try {
         if $force_implementation {
-            issue-verdict-record $result $close_allowed --force-implementation
+            issue-verdict-record $result $close_allowed $protected_from_close --force-implementation
         } else {
-            issue-verdict-record $result $close_allowed
+            issue-verdict-record $result $close_allowed $protected_from_close
         }
     } catch { null })
     if $verdict == null {

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -1,6 +1,7 @@
 use ./core.nu [
     COMMENT_MARKER
     PRIORITY_LABELS
+    TRIAGE_LABELS
     comment-body
     format-gh-error
     gh-api-body
@@ -16,7 +17,7 @@ use ./core.nu [
 use ./context.nu [require-open-issue]
 use ./verdict.nu [issue-verdict-record pr-verdict-record]
 
-def ensure-priority-label [repo: string, label: string, color: string]: nothing -> nothing {
+def ensure-label [repo: string, label: string, color: string]: nothing -> nothing {
     let endpoint = $"repos/($repo)/labels/($label)"
     let result = (gh-api-complete [$endpoint])
     if $result.exit_code == 0 {
@@ -31,14 +32,49 @@ def ensure-priority-label [repo: string, label: string, color: string]: nothing 
     gh-api-body POST $"repos/($repo)/labels" {name: $label, color: $color} | ignore
 }
 
-def ensure-priority-labels [repo: string]: nothing -> nothing {
+def ensure-gate-labels [repo: string]: nothing -> nothing {
     [
         {name: 'priority:critical', color: b60205}
         {name: 'priority:high', color: d93f0b}
         {name: 'priority:medium', color: fbca04}
         {name: 'priority:low', color: 0e8a16}
+        {name: 'triage:excluded', color: cfd3d7}
+        {name: 'triage:needs-review', color: d4c5f9}
     ]
-    | each {|label| ensure-priority-label $repo $label.name $label.color }
+    | each {|label| ensure-label $repo $label.name $label.color }
+    | ignore
+}
+
+def apply-triage-label [repo: string, number: int, triage_label]: nothing -> nothing {
+    let labels = (
+        gh-api-json [
+            '--paginate'
+            '--slurp'
+            $"repos/($repo)/issues/($number)/labels?per_page=100"
+        ]
+        | flatten
+    )
+
+    if $triage_label != null {
+        require-open-issue | ignore
+        (gh-api-body
+            POST
+            $"repos/($repo)/issues/($number)/labels"
+            {
+                labels: [$triage_label]
+            }
+        ) | ignore
+    }
+
+    $labels
+    | where {|label|
+        let name = $label | get --optional name
+        ($name in $TRIAGE_LABELS) and $name != $triage_label
+    }
+    | each {|label|
+        require-open-issue | ignore
+        gh-api-delete $"repos/($repo)/issues/($number)/labels/($label.name)"
+    }
     | ignore
 }
 
@@ -166,27 +202,47 @@ export def upsert-comment [
 
 def close-issue [repo: string, number: int]: nothing -> nothing {
     require-open-issue | ignore
-    gh-api-body PATCH $"repos/($repo)/issues/($number)" {state: closed} | ignore
+    gh-api-body PATCH $"repos/($repo)/issues/($number)" {
+        state: closed
+        state_reason: not_planned
+    } | ignore
 }
 
 def close-pr [repo: string, number: int]: nothing -> nothing {
     gh-api-body PATCH $"repos/($repo)/pulls/($number)" {state: closed} | ignore
 }
 
-def issue-comment [verdict: record]: nothing -> string {
+export def issue-comment [verdict: record]: nothing -> string {
     let outcome = match $verdict.decision {
         close => 'closed by the contribution gate'
         needs_human => 'left open for maintainer review'
         _ if $verdict.implementation == 'create_pr' => 'kept open; Pullfrog will attempt a focused implementation PR'
         _ => 'kept open'
     }
-    comment-body $COMMENT_MARKER ([
-        $"Pullfrog triage: **($verdict.priority)**"
-        ''
-        $verdict.reason
-        ''
-        $"Decision: **($outcome)**."
-    ] | str join "\n")
+    let details = if $verdict.triage_label == 'triage:excluded' {
+        [
+            $"Pullfrog triage: **($verdict.priority)**"
+            ''
+            'Thanks for the proposal.'
+            ''
+            $verdict.reason
+            ''
+            'To keep the core CLI maintainable, new capabilities require explicit maintainer acceptance. Please do not open a core implementation PR unless a maintainer explicitly accepts this request. A fork or external wrapper remains welcome.'
+        ]
+    } else {
+        [
+            $"Pullfrog triage: **($verdict.priority)**"
+            ''
+            $verdict.reason
+        ]
+    }
+    comment-body $COMMENT_MARKER ((
+        $details
+        | append [
+            ''
+            $"Decision: **($outcome)**."
+        ]
+    ) | str join "\n")
 }
 
 def pr-comment [verdict: record]: nothing -> string {
@@ -242,8 +298,9 @@ export def issue-verdict []: nothing -> nothing {
         exit 1
     }
 
-    ensure-priority-labels $repo
+    ensure-gate-labels $repo
     apply-priority-label $repo $number $verdict.priority
+    apply-triage-label $repo $number $verdict.triage_label
     upsert-comment $repo $number (issue-comment $verdict) --require-open-issue
     if $verdict.decision == 'close' and $close_allowed {
         close-issue $repo $number

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -315,7 +315,7 @@ export def issue-verdict []: nothing -> nothing {
 
     ensure-gate-labels $repo
     apply-priority-label $repo $number $verdict.priority
-    if $verdict.decision == 'close' {
+    if $verdict.decision == 'close' or $verdict.implementation == 'create_pr' {
         apply-triage-label $repo $number $verdict.triage_label --preserve-protected
     } else {
         apply-triage-label $repo $number $verdict.triage_label

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -250,7 +250,7 @@ export def restore-protected-issue []: nothing -> nothing {
     # GitHub cannot condition a close PATCH on labels, so this serialized label event repairs the final API race.
     gh-api-body PATCH $"repos/($repo)/issues/($number)" {state: open} | ignore
     ensure-gate-labels $repo
-    apply-triage-label $repo $number 'triage:needs-review' --preserve-protected
+    apply-triage-label $repo $number 'triage:needs-review'
     let body = comment-body $COMMENT_MARKER 'A trusted bug, security, or maintainer-review label was added during automatic closure. The issue was reopened for maintainer review.'
     upsert-comment $repo $number $body --require-open-issue
 }
@@ -367,7 +367,7 @@ export def issue-verdict []: nothing -> nothing {
                     $current_issue.implementation_blocked
             )
             apply-priority-label $repo $number $protected_verdict.priority
-            apply-triage-label $repo $number $protected_verdict.triage_label --preserve-protected
+            apply-triage-label $repo $number $protected_verdict.triage_label
             upsert-comment $repo $number (issue-comment $protected_verdict) --require-open-issue
             $protected_verdict
         }

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -47,7 +47,12 @@ def ensure-gate-labels [repo: string]: nothing -> nothing {
     | ignore
 }
 
-def apply-triage-label [repo: string, number: int, triage_label]: nothing -> nothing {
+def apply-triage-label [
+    repo: string
+    number: int
+    triage_label
+    --preserve-protected
+]: nothing -> nothing {
     let labels = (
         gh-api-json [
             '--paginate'
@@ -71,7 +76,11 @@ def apply-triage-label [repo: string, number: int, triage_label]: nothing -> not
     $labels
     | where {|label|
         let name = $label | get --optional name
-        ($name in $TRIAGE_LABELS) and $name != $triage_label
+        let protected = (
+            $preserve_protected
+            and ($name in ['triage:maintainable' 'triage:needs-review'])
+        )
+        ($name in $TRIAGE_LABELS) and $name != $triage_label and not $protected
     }
     | each {|label|
         require-open-issue | ignore
@@ -202,12 +211,16 @@ export def upsert-comment [
     }
 }
 
-def close-issue [repo: string, number: int]: nothing -> nothing {
-    require-open-issue | ignore
+def close-issue [repo: string, number: int]: nothing -> bool {
+    let issue = require-open-issue
+    if $issue.protected_from_close {
+        return false
+    }
     gh-api-body PATCH $"repos/($repo)/issues/($number)" {
         state: closed
         state_reason: not_planned
     } | ignore
+    true
 }
 
 def close-pr [repo: string, number: int]: nothing -> nothing {
@@ -276,6 +289,7 @@ export def issue-verdict []: nothing -> nothing {
     let issue = require-open-issue
     let close_allowed = (required-env CLOSE_ALLOWED) == 'true'
     let protected_from_close = $issue.protected_from_close
+    let implementation_blocked = $issue.implementation_blocked
     let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
     let outcome = optional-env JUDGE_OUTCOME failure
     let result = optional-env RESULT ''
@@ -288,9 +302,9 @@ export def issue-verdict []: nothing -> nothing {
 
     let verdict = (try {
         if $force_implementation {
-            issue-verdict-record $result $close_allowed $protected_from_close --force-implementation
+            issue-verdict-record $result $close_allowed $protected_from_close $implementation_blocked --force-implementation
         } else {
-            issue-verdict-record $result $close_allowed $protected_from_close
+            issue-verdict-record $result $close_allowed $protected_from_close $implementation_blocked
         }
     } catch { null })
     if $verdict == null {
@@ -301,15 +315,37 @@ export def issue-verdict []: nothing -> nothing {
 
     ensure-gate-labels $repo
     apply-priority-label $repo $number $verdict.priority
-    apply-triage-label $repo $number $verdict.triage_label
-    upsert-comment $repo $number (issue-comment $verdict) --require-open-issue
-    if $verdict.decision == 'close' and $close_allowed {
-        close-issue $repo $number
+    if $verdict.decision == 'close' {
+        apply-triage-label $repo $number $verdict.triage_label --preserve-protected
+    } else {
+        apply-triage-label $repo $number $verdict.triage_label
     }
-    write-output decision $verdict.decision
-    write-output priority $verdict.priority
-    write-output reason $verdict.reason
-    write-output implementation $verdict.implementation
+    upsert-comment $repo $number (issue-comment $verdict) --require-open-issue
+
+    let final_verdict = if $verdict.decision == 'close' and $close_allowed {
+        if (close-issue $repo $number) {
+            $verdict
+        } else {
+            let current_issue = require-open-issue
+            let protected_verdict = (
+                issue-verdict-record
+                    $result
+                    $close_allowed
+                    $current_issue.protected_from_close
+                    $current_issue.implementation_blocked
+            )
+            apply-priority-label $repo $number $protected_verdict.priority
+            apply-triage-label $repo $number $protected_verdict.triage_label
+            upsert-comment $repo $number (issue-comment $protected_verdict) --require-open-issue
+            $protected_verdict
+        }
+    } else {
+        $verdict
+    }
+    write-output decision $final_verdict.decision
+    write-output priority $final_verdict.priority
+    write-output reason $final_verdict.reason
+    write-output implementation $final_verdict.implementation
 }
 
 export def pr-verdict []: nothing -> nothing {

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -240,10 +240,8 @@ export def issue-comment [verdict: record]: nothing -> string {
     }
     comment-body $COMMENT_MARKER ((
         $details
-        | append [
-            ''
-            $"Decision: **($outcome)**."
-        ]
+        | append ''
+        | append $"Decision: **($outcome)**."
     ) | str join "\n")
 }
 

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -34,12 +34,14 @@ def ensure-label [repo: string, label: string, color: string]: nothing -> nothin
 
 def ensure-gate-labels [repo: string]: nothing -> nothing {
     [
-        {name: 'priority:critical', color: b60205}
-        {name: 'priority:high', color: d93f0b}
-        {name: 'priority:medium', color: fbca04}
-        {name: 'priority:low', color: 0e8a16}
-        {name: 'triage:excluded', color: cfd3d7}
-        {name: 'triage:needs-review', color: d4c5f9}
+        {name: 'priority:critical', color: 'b60205'}
+        {name: 'priority:high', color: 'd93f0b'}
+        {name: 'priority:medium', color: 'fbca04'}
+        {name: 'priority:low', color: '0e8a16'}
+        {name: 'triage:resolved', color: '0e8a16'}
+        {name: 'triage:maintainable', color: '1d76db'}
+        {name: 'triage:excluded', color: 'cfd3d7'}
+        {name: 'triage:needs-review', color: 'd4c5f9'}
     ]
     | each {|label| ensure-label $repo $label.name $label.color }
     | ignore

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -14,7 +14,7 @@ use ./core.nu [
     required-env
     write-output
 ]
-use ./context.nu [require-open-issue]
+use ./context.nu [issue-protection-record require-open-issue]
 use ./verdict.nu [issue-verdict-record pr-verdict-record]
 
 def ensure-label [repo: string, label: string, color: string]: nothing -> nothing {
@@ -223,6 +223,30 @@ def close-issue [repo: string, number: int]: nothing -> bool {
     true
 }
 
+export def restore-protected-issue []: nothing -> nothing {
+    let repo = repository
+    let number = issue-number
+    let issue = gh-api-json [$"repos/($repo)/issues/($number)"]
+    let protection = issue-protection-record $issue
+    let closed_by = $issue | get --optional closed_by.login
+    let should_restore = (
+        $protection.protected_from_close
+        and (($issue | get --optional state) == 'closed')
+        and (($issue | get --optional state_reason) == 'not_planned')
+        and $closed_by == 'github-actions[bot]'
+    )
+    if not $should_restore {
+        return
+    }
+
+    # GitHub cannot condition a close PATCH on labels, so this serialized label event repairs the final API race.
+    gh-api-body PATCH $"repos/($repo)/issues/($number)" {state: open} | ignore
+    ensure-gate-labels $repo
+    apply-triage-label $repo $number 'triage:needs-review' --preserve-protected
+    let body = comment-body $COMMENT_MARKER 'A trusted bug, security, or maintainer-review label was added during automatic closure. The issue was reopened for maintainer review.'
+    upsert-comment $repo $number $body --require-open-issue
+}
+
 def close-pr [repo: string, number: int]: nothing -> nothing {
     gh-api-body PATCH $"repos/($repo)/pulls/($number)" {state: closed} | ignore
 }
@@ -335,7 +359,7 @@ export def issue-verdict []: nothing -> nothing {
                     $current_issue.implementation_blocked
             )
             apply-priority-label $repo $number $protected_verdict.priority
-            apply-triage-label $repo $number $protected_verdict.triage_label
+            apply-triage-label $repo $number $protected_verdict.triage_label --preserve-protected
             upsert-comment $repo $number (issue-comment $protected_verdict) --require-open-issue
             $protected_verdict
         }

--- a/.github/scripts/contribution-gate/mutations.nu
+++ b/.github/scripts/contribution-gate/mutations.nu
@@ -220,7 +220,15 @@ def close-issue [repo: string, number: int]: nothing -> bool {
         state: closed
         state_reason: not_planned
     } | ignore
-    true
+    sleep 2sec
+    let closed_issue = gh-api-json [$"repos/($repo)/issues/($number)"]
+    let protection = issue-protection-record $closed_issue
+    if $protection.protected_from_close {
+        restore-protected-issue
+        false
+    } else {
+        true
+    }
 }
 
 export def restore-protected-issue []: nothing -> nothing {

--- a/.github/scripts/contribution-gate/prompts/issue-judge.md
+++ b/.github/scripts/contribution-gate/prompts/issue-judge.md
@@ -22,11 +22,12 @@ Choose exactly one priority: priority:critical, priority:high, priority:medium, 
 Choose decision keep_open, close, or needs_human.
 
 - For a feature_request, choose close, priority:low, and implementation none only when close is allowed; otherwise choose needs_human. Explain politely why the optional capability is outside current core maintenance scope.
-- For supported_behavior_bug or security, never choose close. Choose keep_open when actionable, otherwise needs_human.
+- For supported_behavior_bug, never choose close. Choose keep_open when actionable, otherwise needs_human.
+- For security, always choose needs_human and implementation none so disclosure and remediation stay under maintainer control.
 - For maintenance or documentation, keep bounded work open and use needs_human when product scope is unclear.
 - For other, choose needs_human when closure appears appropriate. The deterministic gate does not allow model-directed closure of non-feature issues.
 - Never choose close when close is not allowed.
 
-Choose implementation create_pr only when the issue is clear, safe, repository-scoped, accepted by the rules above, and priority is critical or high. Otherwise choose none. When uncertain, choose needs_human and leave the issue open.
+Choose implementation create_pr only for supported_behavior_bug, maintenance, or documentation when the issue is clear, safe, repository-scoped, accepted by the rules above, and priority is critical or high. Otherwise choose none. When uncertain, choose needs_human and leave the issue open.
 
 Keep the reason concise, specific, factual, and in simple English. For a feature_request, describe the concrete maintenance or product-scope boundary; do not invite a core PR. Do not include secrets or reproduce large user-provided text.

--- a/.github/scripts/contribution-gate/prompts/issue-judge.md
+++ b/.github/scripts/contribution-gate/prompts/issue-judge.md
@@ -7,7 +7,7 @@ Use Pullfrog issue tools to fetch the complete issue body, comments, events, and
 
 Return a verdict only; do not call close_current, reopen_current, create_issue_comment, add_labels, remove_labels, create_pull_request, git, or shell tools. Do not modify files, run untrusted code, or push anything.
 
-Classify issue_kind as exactly one of:
+Return issue_kind in your verdict, choosing exactly one of:
 
 - supported_behavior_bug: current documented or shipped behavior is broken or has regressed. Already-supported options, formats, platforms, and integrations remain maintenance obligations even if a similar feature would not be accepted today.
 - security: a credible security or data-loss risk.

--- a/.github/scripts/contribution-gate/prompts/issue-judge.md
+++ b/.github/scripts/contribution-gate/prompts/issue-judge.md
@@ -21,7 +21,7 @@ Do not infer acceptance from the issue author's request, implementation feasibil
 Choose exactly one priority: priority:critical, priority:high, priority:medium, or priority:low.
 Choose decision keep_open, close, or needs_human.
 
-- For a feature_request, choose close, priority:low, and implementation none. Explain politely why the optional capability is outside current core maintenance scope.
+- For a feature_request, choose close, priority:low, and implementation none only when close is allowed; otherwise choose needs_human. Explain politely why the optional capability is outside current core maintenance scope.
 - For supported_behavior_bug or security, never choose close. Choose keep_open when actionable, otherwise needs_human.
 - For maintenance or documentation, keep bounded work open and use needs_human when product scope is unclear.
 - For other, choose needs_human when closure appears appropriate. The deterministic gate does not allow model-directed closure of non-feature issues.

--- a/.github/scripts/contribution-gate/prompts/issue-judge.md
+++ b/.github/scripts/contribution-gate/prompts/issue-judge.md
@@ -1,4 +1,4 @@
-You are the conservative contribution-gate judge for this repository.
+You are the product-scope and safety judge for this repository.
 
 Evaluate issue #{{ISSUE_NUMBER}} in {{REPOSITORY}}.
 The author status is {{AUTHOR_STATUS}}. Close is allowed only when the author status is new: {{CLOSE_ALLOWED}}.
@@ -7,9 +7,26 @@ Use Pullfrog issue tools to fetch the complete issue body, comments, events, and
 
 Return a verdict only; do not call close_current, reopen_current, create_issue_comment, add_labels, remove_labels, create_pull_request, git, or shell tools. Do not modify files, run untrusted code, or push anything.
 
+Classify issue_kind as exactly one of:
+
+- supported_behavior_bug: current documented or shipped behavior is broken or has regressed. Already-supported options, formats, platforms, and integrations remain maintenance obligations even if a similar feature would not be accepted today.
+- security: a credible security or data-loss risk.
+- maintenance: bounded upkeep, compatibility, performance, packaging, or dependency work without a new user-facing capability.
+- documentation: incorrect or missing documentation for current behavior.
+- feature_request: a new command, flag, output mode, formatting choice, configuration knob, integration, customization, or other optional capability. Being clear, easy, useful, or similar to an existing feature does not make it accepted product scope.
+- other: reports that do not fit the categories above, including spam, duplicates, support questions, or invalid reports.
+
+Do not infer acceptance from the issue author's request, implementation feasibility, old audit comments, or labels such as triage:maintainable. Explicit maintainer acceptance is handled only by the workflow's manual implementation override, outside your verdict.
+
 Choose exactly one priority: priority:critical, priority:high, priority:medium, or priority:low.
 Choose decision keep_open, close, or needs_human.
-Only choose close when the issue is clearly spam, invalid, a duplicate, explicitly wontfix, or entirely out of scope. A low priority or incomplete but potentially useful report should stay open or need human review. Never close an issue when close is not allowed.
-Choose implementation create_pr only when the issue is clear, safe, repository-scoped, and priority is critical or high. Otherwise choose none.
-When uncertain, choose needs_human and leave the issue open.
-Keep the reason concise, factual, and in simple English. Do not include secrets or reproduce large user-provided text.
+
+- For a feature_request, choose close, priority:low, and implementation none. Explain politely why the optional capability is outside current core maintenance scope.
+- For supported_behavior_bug or security, never choose close. Choose keep_open when actionable, otherwise needs_human.
+- For maintenance or documentation, keep bounded work open and use needs_human when product scope is unclear.
+- For other, choose needs_human when closure appears appropriate. The deterministic gate does not allow model-directed closure of non-feature issues.
+- Never choose close when close is not allowed.
+
+Choose implementation create_pr only when the issue is clear, safe, repository-scoped, accepted by the rules above, and priority is critical or high. Otherwise choose none. When uncertain, choose needs_human and leave the issue open.
+
+Keep the reason concise, specific, factual, and in simple English. For a feature_request, describe the concrete maintenance or product-scope boundary; do not invite a core PR. Do not include secrets or reproduce large user-provided text.

--- a/.github/scripts/contribution-gate/requests.nu
+++ b/.github/scripts/contribution-gate/requests.nu
@@ -577,9 +577,29 @@ export def issue-implementation-guard []: nothing -> nothing {
     write-output skip 'true'
 }
 
+def implementation-publication-state [force_implementation: bool]: nothing -> record {
+    let issue = require-open-issue
+    {
+        issue: $issue
+        blocked: ((not $force_implementation) and $issue.implementation_blocked)
+    }
+}
+
+def report-publication-blocked [repo: string, number: int]: nothing -> nothing {
+    let body = comment-body $COMMENT_MARKER 'Automatic implementation publication was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
+    upsert-comment $repo $number $body --require-open-issue
+    write-output skip 'true'
+}
+
 export def publish-implementation []: nothing -> nothing {
     let repo = repository
-    let issue = require-open-issue
+    let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
+    let initial_state = implementation-publication-state $force_implementation
+    let issue = $initial_state.issue
+    if $initial_state.blocked {
+        report-publication-blocked $repo $issue.number
+        return
+    }
     let existing = existing-issue-pull-request $repo $issue.number
     if $existing != null {
         print $"Skipping publication because open PR #($existing.number) already targets issue #($issue.number)."
@@ -636,18 +656,26 @@ export def publish-implementation []: nothing -> nothing {
     ]
     setup-git-auth
 
-    require-open-issue | ignore
+    let pre_push_state = implementation-publication-state $force_implementation
+    if $pre_push_state.blocked {
+        report-publication-blocked $repo $issue.number
+        return
+    }
     git-run [push --set-upstream origin $"HEAD:refs/heads/($branch)"]
 
     let pre_create = (with-failure-cleanup
         {||
-            require-open-issue | ignore
+            let publication_state = implementation-publication-state $force_implementation
+            if $publication_state.blocked {
+                return {existing: null, body: null, blocked: true}
+            }
             let existing = existing-issue-pull-request $repo $issue.number
             if $existing != null {
-                {existing: $existing, body: null}
+                {existing: $existing, body: null, blocked: false}
             } else {
                 {
                     existing: null
+                    blocked: false
                     body: (implementation-pull-request-body
                         (required-env IMPLEMENTATION_MARKER)
                         $result.body
@@ -658,15 +686,23 @@ export def publish-implementation []: nothing -> nothing {
         }
         {|| git-run [push origin --delete $branch] }
     )
+    if $pre_create.blocked {
+        git-run [push origin --delete $branch]
+        report-publication-blocked $repo $issue.number
+        return
+    }
     if $pre_create.existing != null {
         git-run [push origin --delete $branch]
         print $"Skipping publication because open PR #($pre_create.existing.number) now targets issue #($issue.number)."
         write-output skip 'true'
         return
     }
-    let pull_number = (with-failure-cleanup
+    let publication = (with-failure-cleanup
         {||
-            require-open-issue | ignore
+            let publication_state = implementation-publication-state $force_implementation
+            if $publication_state.blocked {
+                return {blocked: true, pull_number: null}
+            }
             let created = gh-api-body POST $"repos/($repo)/pulls" {
                 title: $title
                 head: $branch
@@ -677,19 +713,31 @@ export def publish-implementation []: nothing -> nothing {
             if ($pull_number | describe) != 'int' or $pull_number <= 0 {
                 error make {msg: 'GitHub returned an invalid implementation pull request'}
             }
-            $pull_number
+            {blocked: false, pull_number: $pull_number}
         }
         {|| discard-unvalidated-publication $repo $branch }
     )
+    if $publication.blocked {
+        git-run [push origin --delete $branch]
+        report-publication-blocked $repo $issue.number
+        return
+    }
+    let pull_number = $publication.pull_number
     let reconciliation = try {
-        require-open-issue | ignore
+        let publication_state = implementation-publication-state $force_implementation
         let closing_pull_requests = closing-pull-requests $repo $issue.number
         {
+            blocked: $publication_state.blocked
             competing: (competing-closing-pull-request $closing_pull_requests $pull_number)
         }
     } catch {
         discard-created-pull-request $repo $pull_number $branch
         error make {msg: 'Could not reconcile competing pull requests after publication; the workflow-created pull request was closed'}
+    }
+    if $reconciliation.blocked {
+        discard-created-pull-request $repo $pull_number $branch
+        report-publication-blocked $repo $issue.number
+        return
     }
     let competing = $reconciliation.competing
     if $competing != null {

--- a/.github/scripts/contribution-gate/requests.nu
+++ b/.github/scripts/contribution-gate/requests.nu
@@ -6,6 +6,7 @@ use ./core.nu [
     gh-api-body
     gh-api-json
     issue-number
+    optional-env
     repository
     required-env
     write-output
@@ -530,6 +531,14 @@ export def issue-implementation-request []: nothing -> nothing {
         write-output implementation none
         return
     }
+    let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
+    let current_issue = require-open-issue
+    if (not $force_implementation) and $current_issue.implementation_blocked {
+        let body = comment-body $COMMENT_MARKER 'Automatic implementation was not started because a trusted security or maintainer-review label requires explicit maintainer approval.'
+        upsert-comment $repo $number $body --require-open-issue
+        write-output implementation none
+        return
+    }
     let implementation_marker = $"<!-- pullfrog-accepted-issue: #($number) request-(random uuid) -->"
     let coauthor_trailer = $"Co-authored-by: ($issue_author) <($coauthor_email)>"
     let implementation_branch = (implementation-branch
@@ -552,6 +561,13 @@ export def issue-implementation-request []: nothing -> nothing {
 export def issue-implementation-guard []: nothing -> nothing {
     let repo = repository
     let issue = require-open-issue
+    let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
+    if (not $force_implementation) and $issue.implementation_blocked {
+        let body = comment-body $COMMENT_MARKER 'Automatic implementation was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
+        upsert-comment $repo $issue.number $body --require-open-issue
+        write-output skip 'true'
+        return
+    }
     let existing = existing-issue-pull-request $repo $issue.number
     if $existing == null {
         write-output skip 'false'

--- a/.github/scripts/contribution-gate/requests.nu
+++ b/.github/scripts/contribution-gate/requests.nu
@@ -570,6 +570,13 @@ export def issue-implementation-guard []: nothing -> nothing {
     }
     let existing = existing-issue-pull-request $repo $issue.number
     if $existing == null {
+        let final_issue = require-open-issue
+        if (not $force_implementation) and $final_issue.implementation_blocked {
+            let body = comment-body $COMMENT_MARKER 'Automatic implementation was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
+            upsert-comment $repo $final_issue.number $body --require-open-issue
+            write-output skip 'true'
+            return
+        }
         write-output skip 'false'
         return
     }

--- a/.github/scripts/contribution-gate/requests.nu
+++ b/.github/scripts/contribution-gate/requests.nu
@@ -563,8 +563,7 @@ export def issue-implementation-guard []: nothing -> nothing {
     let issue = require-open-issue
     let force_implementation = (optional-env FORCE_IMPLEMENTATION 'false') == 'true'
     if (not $force_implementation) and $issue.implementation_blocked {
-        let body = comment-body $COMMENT_MARKER 'Automatic implementation was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
-        upsert-comment $repo $issue.number $body --require-open-issue
+        print $"Skipping implementation because trusted labels require explicit maintainer approval for issue #($issue.number)."
         write-output skip 'true'
         return
     }
@@ -572,8 +571,7 @@ export def issue-implementation-guard []: nothing -> nothing {
     if $existing == null {
         let final_issue = require-open-issue
         if (not $force_implementation) and $final_issue.implementation_blocked {
-            let body = comment-body $COMMENT_MARKER 'Automatic implementation was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
-            upsert-comment $repo $final_issue.number $body --require-open-issue
+            print $"Skipping implementation because trusted labels require explicit maintainer approval for issue #($final_issue.number)."
             write-output skip 'true'
             return
         }
@@ -592,9 +590,8 @@ def implementation-publication-state [force_implementation: bool]: nothing -> re
     }
 }
 
-def report-publication-blocked [repo: string, number: int]: nothing -> nothing {
-    let body = comment-body $COMMENT_MARKER 'Automatic implementation publication was stopped because a trusted security or maintainer-review label requires explicit maintainer approval.'
-    upsert-comment $repo $number $body --require-open-issue
+def report-publication-blocked [number: int]: nothing -> nothing {
+    print $"Skipping implementation publication because trusted labels require explicit maintainer approval for issue #($number)."
     write-output skip 'true'
 }
 
@@ -604,7 +601,7 @@ export def publish-implementation []: nothing -> nothing {
     let initial_state = implementation-publication-state $force_implementation
     let issue = $initial_state.issue
     if $initial_state.blocked {
-        report-publication-blocked $repo $issue.number
+        report-publication-blocked $issue.number
         return
     }
     let existing = existing-issue-pull-request $repo $issue.number
@@ -665,7 +662,7 @@ export def publish-implementation []: nothing -> nothing {
 
     let pre_push_state = implementation-publication-state $force_implementation
     if $pre_push_state.blocked {
-        report-publication-blocked $repo $issue.number
+        report-publication-blocked $issue.number
         return
     }
     git-run [push --set-upstream origin $"HEAD:refs/heads/($branch)"]
@@ -695,7 +692,7 @@ export def publish-implementation []: nothing -> nothing {
     )
     if $pre_create.blocked {
         git-run [push origin --delete $branch]
-        report-publication-blocked $repo $issue.number
+        report-publication-blocked $issue.number
         return
     }
     if $pre_create.existing != null {
@@ -726,7 +723,7 @@ export def publish-implementation []: nothing -> nothing {
     )
     if $publication.blocked {
         git-run [push origin --delete $branch]
-        report-publication-blocked $repo $issue.number
+        report-publication-blocked $issue.number
         return
     }
     let pull_number = $publication.pull_number
@@ -743,7 +740,7 @@ export def publish-implementation []: nothing -> nothing {
     }
     if $reconciliation.blocked {
         discard-created-pull-request $repo $pull_number $branch
-        report-publication-blocked $repo $issue.number
+        report-publication-blocked $issue.number
         return
     }
     let competing = $reconciliation.competing

--- a/.github/scripts/contribution-gate/requests.nu
+++ b/.github/scripts/contribution-gate/requests.nu
@@ -731,8 +731,8 @@ export def publish-implementation []: nothing -> nothing {
     }
     let pull_number = $publication.pull_number
     let reconciliation = try {
-        let publication_state = implementation-publication-state $force_implementation
         let closing_pull_requests = closing-pull-requests $repo $issue.number
+        let publication_state = implementation-publication-state $force_implementation
         {
             blocked: $publication_state.blocked
             competing: (competing-closing-pull-request $closing_pull_requests $pull_number)

--- a/.github/scripts/contribution-gate/verdict.nu
+++ b/.github/scripts/contribution-gate/verdict.nu
@@ -99,7 +99,7 @@ export def issue-verdict-record [result: string, close_allowed: bool, --force-im
     } else if $verdict.decision == 'close' and $issue_kind == 'feature_request' {
         'triage:excluded'
     } else {
-        null
+        'triage:maintainable'
     }
     $verdict | insert triage_label $triage_label
 }

--- a/.github/scripts/contribution-gate/verdict.nu
+++ b/.github/scripts/contribution-gate/verdict.nu
@@ -1,5 +1,14 @@
 use ./core.nu [IMPLEMENTATION_PRIORITIES PRIORITY_LABELS]
 
+const ISSUE_KINDS = [
+    supported_behavior_bug
+    security
+    maintenance
+    documentation
+    feature_request
+    other
+]
+
 def parse-required-enum [verdict: record, field: string, allowed: list<string>]: nothing -> string {
     let value = $verdict | get --optional $field
     if ($value | describe) != 'string' or not ($value in $allowed) {
@@ -37,38 +46,62 @@ export def issue-verdict-record [result: string, close_allowed: bool, --force-im
     let decision = parse-required-enum $raw decision [keep_open close needs_human]
     let priority = parse-required-enum $raw priority $PRIORITY_LABELS
     let implementation = parse-required-enum $raw implementation [create_pr none]
+    let issue_kind = parse-required-enum $raw issue_kind $ISSUE_KINDS
     let reason = parse-reason $raw
     let verdict = {
         decision: $decision
         priority: $priority
         implementation: $implementation
+        issue_kind: $issue_kind
         reason: $reason
     }
 
-    # The workflow, rather than the model, owns the hard safety constraints for
-    # automatic closure and implementation.
-    let verdict = if not $close_allowed {
-        let verdict = if $verdict.decision == 'close' {
-            $verdict
-            | update decision needs_human
-            | update reason $"Automatic closure is disabled because author permissions could not be verified; maintainer review is required. ($verdict.reason)"
-        } else {
-            $verdict
-        }
-        $verdict | update implementation none
-    } else {
-        $verdict
-    }
-    if $force_implementation {
+    # Explicit maintainer action is the only path that bypasses automatic product scope.
+    let verdict = if $force_implementation {
         $verdict
         | update decision keep_open
         | update implementation create_pr
         | update reason $"A maintainer explicitly requested an implementation attempt. ($reason)"
-    } else if ($verdict.decision != 'keep_open') or (not ($verdict.priority in $IMPLEMENTATION_PRIORITIES)) {
-        $verdict | update implementation none
+    } else if $issue_kind == 'feature_request' {
+        $verdict
+        | update decision close
+        | update priority 'priority:low'
+        | update implementation none
+        | update reason $"This is a new optional capability rather than a bug or regression in currently supported behavior. ($reason)"
+    } else if $decision == 'close' {
+        $verdict
+        | update decision needs_human
+        | update implementation none
+        | update reason $"Only new feature requests may be closed automatically; maintainer review is required for this issue. ($reason)"
     } else {
         $verdict
     }
+
+    # The workflow independently verifies whether this author may be auto-closed.
+    let verdict = if (not $close_allowed) and $verdict.decision == 'close' {
+        $verdict
+        | update decision needs_human
+        | update reason $"Automatic closure is disabled because author permissions could not be verified; maintainer review is required. ($verdict.reason)"
+    } else {
+        $verdict
+    }
+
+    let verdict = if (not $force_implementation) and (not $close_allowed) {
+        $verdict | update implementation none
+    } else if (not $force_implementation) and (($verdict.decision != 'keep_open') or (not ($verdict.priority in $IMPLEMENTATION_PRIORITIES))) {
+        $verdict
+        | update implementation none
+    } else {
+        $verdict
+    }
+    let triage_label = if $verdict.decision == 'needs_human' {
+        'triage:needs-review'
+    } else if $verdict.decision == 'close' and $issue_kind == 'feature_request' {
+        'triage:excluded'
+    } else {
+        null
+    }
+    $verdict | insert triage_label $triage_label
 }
 
 export def pr-verdict-record [result: string, close_allowed: bool]: nothing -> record {

--- a/.github/scripts/contribution-gate/verdict.nu
+++ b/.github/scripts/contribution-gate/verdict.nu
@@ -51,6 +51,7 @@ export def issue-verdict-record [
     result: string
     close_allowed: bool
     protected_from_close: bool = false
+    implementation_blocked: bool = false
     --force-implementation
 ]: nothing -> record {
     let raw = parse-result $result
@@ -104,6 +105,15 @@ export def issue-verdict-record [
         | update decision needs_human
         | update implementation none
         | update reason $"Automatic closure is disabled by the issue's trusted labels; maintainer review is required. ($verdict.reason)"
+    } else {
+        $verdict
+    }
+
+    let verdict = if (not $force_implementation) and $implementation_blocked {
+        $verdict
+        | update decision needs_human
+        | update implementation none
+        | update reason $"Automatic implementation is disabled by the issue's trusted labels; maintainer review is required. ($verdict.reason)"
     } else {
         $verdict
     }

--- a/.github/scripts/contribution-gate/verdict.nu
+++ b/.github/scripts/contribution-gate/verdict.nu
@@ -9,6 +9,12 @@ const ISSUE_KINDS = [
     other
 ]
 
+const AUTO_IMPLEMENTATION_KINDS = [
+    supported_behavior_bug
+    maintenance
+    documentation
+]
+
 def parse-required-enum [verdict: record, field: string, allowed: list<string>]: nothing -> string {
     let value = $verdict | get --optional $field
     if ($value | describe) != 'string' or not ($value in $allowed) {
@@ -41,7 +47,12 @@ def parse-result [result: string]: nothing -> record {
     }
 }
 
-export def issue-verdict-record [result: string, close_allowed: bool, --force-implementation]: nothing -> record {
+export def issue-verdict-record [
+    result: string
+    close_allowed: bool
+    protected_from_close: bool = false
+    --force-implementation
+]: nothing -> record {
     let raw = parse-result $result
     let decision = parse-required-enum $raw decision [keep_open close needs_human]
     let priority = parse-required-enum $raw priority $PRIORITY_LABELS
@@ -68,11 +79,31 @@ export def issue-verdict-record [result: string, close_allowed: bool, --force-im
         | update priority 'priority:low'
         | update implementation none
         | update reason $"This is a new optional capability rather than a bug or regression in currently supported behavior. ($reason)"
+    } else if $issue_kind == 'security' {
+        $verdict
+        | update decision needs_human
+        | update implementation none
+        | update reason $"Security-sensitive reports always require maintainer review. ($reason)"
+    } else if $issue_kind == 'other' {
+        $verdict
+        | update decision needs_human
+        | update implementation none
+        | update reason $"This issue is outside the automatic implementation categories and requires maintainer review. ($reason)"
     } else if $decision == 'close' {
         $verdict
         | update decision needs_human
         | update implementation none
         | update reason $"Only new feature requests may be closed automatically; maintainer review is required for this issue. ($reason)"
+    } else {
+        $verdict
+    }
+
+    # A repository-controlled label protects known bugs and reviewed issues even if the model misclassifies them.
+    let verdict = if (not $force_implementation) and $protected_from_close and $verdict.decision == 'close' {
+        $verdict
+        | update decision needs_human
+        | update implementation none
+        | update reason $"Automatic closure is disabled by the issue's trusted labels; maintainer review is required. ($verdict.reason)"
     } else {
         $verdict
     }
@@ -86,7 +117,9 @@ export def issue-verdict-record [result: string, close_allowed: bool, --force-im
         $verdict
     }
 
-    let verdict = if (not $force_implementation) and (not $close_allowed) {
+    let verdict = if (not $force_implementation) and (not ($issue_kind in $AUTO_IMPLEMENTATION_KINDS)) {
+        $verdict | update implementation none
+    } else if (not $force_implementation) and (not $close_allowed) {
         $verdict | update implementation none
     } else if (not $force_implementation) and (($verdict.decision != 'keep_open') or (not ($verdict.priority in $IMPLEMENTATION_PRIORITIES))) {
         $verdict

--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -432,6 +432,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           ISSUE_NUMBER: ${{ needs.triage.outputs.issue_number }}
+          FORCE_IMPLEMENTATION: ${{ inputs.force_implementation == true }}
           IMPLEMENTATION_BASE_SHA: ${{ needs.implement.outputs.base_sha }}
           IMPLEMENTATION_BRANCH: ${{ needs.apply.outputs.implementation_branch }}
           IMPLEMENTATION_MARKER: ${{ needs.apply.outputs.implementation_marker }}

--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -97,7 +97,7 @@ jobs:
             {
               "type": "object",
               "additionalProperties": false,
-              "required": ["decision", "priority", "implementation", "reason"],
+              "required": ["decision", "priority", "implementation", "issue_kind", "reason"],
               "properties": {
                 "decision": {
                   "type": "string",
@@ -110,6 +110,10 @@ jobs:
                 "implementation": {
                   "type": "string",
                   "enum": ["create_pr", "none"]
+                },
+                "issue_kind": {
+                  "type": "string",
+                  "enum": ["supported_behavior_bug", "security", "maintenance", "documentation", "feature_request", "other"]
                 },
                 "reason": {
                   "type": "string",

--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -177,6 +177,7 @@ jobs:
           ISSUE_NUMBER: ${{ needs.triage.outputs.issue_number }}
           ISSUE_AUTHOR: ${{ needs.triage.outputs.issue_author }}
           ISSUE_AUTHOR_ID: ${{ needs.triage.outputs.issue_author_id }}
+          FORCE_IMPLEMENTATION: ${{ inputs.force_implementation == true }}
         run: nu .github/scripts/contribution-gate.nu issue-implementation-request
 
   implement:
@@ -226,6 +227,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           ISSUE_NUMBER: ${{ needs.triage.outputs.issue_number }}
+          FORCE_IMPLEMENTATION: ${{ inputs.force_implementation == true }}
         run: nu .github/scripts/contribution-gate.nu issue-implementation-guard
 
       - name: Ask Pullfrog to implement the issue

--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -4,6 +4,7 @@ on:
   issues:
     types:
       - opened
+      - labeled
   workflow_dispatch:
     inputs:
       issue_number:
@@ -26,7 +27,40 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  restore-protected:
+    if: >-
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      (github.event.label.name == 'bug' ||
+       github.event.label.name == 'security' ||
+       github.event.label.name == 'triage:maintainable' ||
+       github.event.label.name == 'triage:needs-review')
+    runs-on: ubuntu-slim
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout the base repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Set up Nushell
+        uses: hustcer/setup-nu@9215c80adb545a85c419d5085b76eb6d082f49e7 # v3.27
+        with:
+          version: 0.114.1
+
+      - name: Restore an issue protected during automatic closure
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: nu .github/scripts/contribution-gate.nu restore-protected-issue
+
   triage:
+    if: github.event_name == 'workflow_dispatch' || github.event.action == 'opened'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:

--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -30,11 +30,7 @@ jobs:
   restore-protected:
     if: >-
       github.event_name == 'issues' &&
-      github.event.action == 'labeled' &&
-      (github.event.label.name == 'bug' ||
-       github.event.label.name == 'security' ||
-       github.event.label.name == 'triage:maintainable' ||
-       github.event.label.name == 'triage:needs-review')
+      github.event.action == 'labeled'
     runs-on: ubuntu-slim
     permissions:
       contents: read


### PR DESCRIPTION
Classifies incoming issues as supported-behavior bugs, security reports, maintenance, documentation, feature requests, or other. New optional capabilities are closed as low-priority not-planned work with a careful English explanation, while every non-feature closure fails open for maintainer review; only the manual implementation workflow can override product scope.

The gate also reconciles triage labels and updates the issue forms so contributors see the policy before filing.

Testing:
- direnv exec . nu .github/scripts/contribution-gate.test.nu
- direnv exec . actionlint .github/workflows/issue-gate.yaml
- direnv exec . zizmor .github/workflows/issue-gate.yaml
- pre-commit and pre-push hooks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces issue product scope in the contribution gate: feature requests are auto-closed only when they don't carry a trusted label, and every other proposed closure fails open for maintainer review. The manual Issue Gate override remains the sole scope override, and issue templates now tell contributors that new optional capabilities are closed by default.

**Changes**

- Adds a required `issue_kind` field covering supported behavior bugs, security, maintenance, documentation, feature requests, and other.
- Auto-closes only `feature_request` issues with low priority and a `not_planned` state reason; feature requests fall back to `needs_human` when closure is disabled, and all other candidate closures become `needs_human`.
- Re-fetches trusted labels (`bug`, `security`, `triage:maintainable`, `triage:needs-review`) before closing, immediately after the close mutation, before the implementation handoff, and at each publication stage (including after the competing-PR lookup); labels added mid-run override the model verdict, and `security` and `triage:needs-review` block automatic implementation. A `labeled` event reopens a bot-closed issue when a trusted label lands during the close window; workflow-created branches or PRs from a blocked run are removed unless the run was forced, and read-only guard jobs log and skip instead of commenting.
- Reconciles triage labels as mutually exclusive: `triage:excluded` for auto-closed features, `triage:needs-review` for human review (including all security reports), and `triage:maintainable` for accepted or manually forced issues; an aborted or repaired protected close settles on a single `triage:needs-review`.
- Updates the bug and contribution templates so contributors see the policy before filing.

<sup>Written for commit 96d40e35d9b7597cade9b0e61cdea385819663f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated issue templates with clearer guidance for bug reports, regressions, security concerns, supported behavior, and feature proposals.
  * Feature proposals now receive enhancement labeling and require explicit maintainer acceptance.

* **Bug Fixes**
  * Improved issue evaluation across bugs, security issues, maintenance, documentation, feature requests, and other reports.
  * Protected bug, security, and maintainer-reviewed issues from automatic closure.
  * Security and uncategorized reports now require maintainer review and are not automatically implemented.
  * Issue triage now applies clearer status labels and appropriate closure reasons.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->