### PR TITLE
fix(antigravity): preserve Gemini Flash effort variants

### DIFF
--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -1376,38 +1376,14 @@ mod tests {
 
     #[test]
     fn normalizes_newer_gemini_model_placeholders_and_ids() {
-        assert_eq!(
-            model_name_from_id(1318),
-            "gemini-3.8-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1298),
-            "gemini-3.7-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1299),
-            "gemini-3.7-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1300),
-            "gemini-3.7-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1071),
-            "gemini-3.6-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1072),
-            "gemini-3.6-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1073),
-            "gemini-3.6-flash".to_string()
-        );
-        assert_eq!(
-            model_name_from_id(1050),
-            "gemini-3.1-flash-lite".to_string()
-        );
+        assert_eq!(model_name_from_id(1318), "gemini-3.8-flash".to_string());
+        assert_eq!(model_name_from_id(1298), "gemini-3.7-flash".to_string());
+        assert_eq!(model_name_from_id(1299), "gemini-3.7-flash".to_string());
+        assert_eq!(model_name_from_id(1300), "gemini-3.7-flash".to_string());
+        assert_eq!(model_name_from_id(1071), "gemini-3.6-flash".to_string());
+        assert_eq!(model_name_from_id(1072), "gemini-3.6-flash".to_string());
+        assert_eq!(model_name_from_id(1073), "gemini-3.6-flash".to_string());
+        assert_eq!(model_name_from_id(1050), "gemini-3.1-flash-lite".to_string());
         assert_eq!(
             normalize_antigravity_model("model_placeholder_m318"),
             Some("gemini-3.8-flash".to_string())

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -866,7 +866,6 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         "model_openai_gpt_oss_120b_medium" => "gpt-oss-120b-medium",
         "gemini-pro-default" | "gemini-pro-agent" => "gemini-3.1-pro",
         "gemini-3.7-flash-control" => "gemini-3.7-flash",
-        "gemini 3.6 flash (low)" => "gemini-3.6-flash",
         "gemini-3-flash-agent"
         | "gemini-3-flash-agent-a"
         | "gemini-3-flash-agent-b"
@@ -1253,7 +1252,7 @@ mod tests {
     use super::{
         API_PROVIDER_GOOGLE_GEMINI, ProtoField, ProtoValue, field_bytes, field_bytes_all,
         field_text, field_varint, missing_antigravity_pricing, model_candidates,
-        parse_step_metadata,
+        model_name_from_id, normalize_antigravity_model, parse_step_metadata,
     };
     use crate::{PricingMap, TokenUsageRaw, cli::CostMode};
 

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -1383,7 +1383,10 @@ mod tests {
         assert_eq!(model_name_from_id(1071), "gemini-3.6-flash".to_string());
         assert_eq!(model_name_from_id(1072), "gemini-3.6-flash".to_string());
         assert_eq!(model_name_from_id(1073), "gemini-3.6-flash".to_string());
-        assert_eq!(model_name_from_id(1050), "gemini-3.1-flash-lite".to_string());
+        assert_eq!(
+            model_name_from_id(1050),
+            "gemini-3.1-flash-lite".to_string()
+        );
         assert_eq!(
             normalize_antigravity_model("model_placeholder_m318"),
             Some("gemini-3.8-flash".to_string())

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -817,8 +817,9 @@ fn model_name_from_id(model_id: u64) -> String {
         340 | 341 => "claude-4.5-haiku".to_string(),
         342 => "model_openai_gpt_oss_120b_medium".to_string(),
         1318 => "gemini-3.8-flash".to_string(),
-        1298 | 1300 => "gemini-3.7-flash".to_string(),
-        1071 | 1073 | 1050 => "gemini-3.6-flash".to_string(),
+        1298..=1300 => "gemini-3.7-flash".to_string(),
+        1071..=1073 => "gemini-3.6-flash".to_string(),
+        1050 => "gemini-3.1-flash-lite".to_string(),
         1_000.. => format!("model_placeholder_m{}", model_id - 1_000),
         _ => format!("antigravity-model-{model_id}"),
     }
@@ -835,7 +836,6 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         .map_or(lower.as_str(), |index| lower[..index].trim());
     let normalized = match base {
         "gemini 3.8 flash" | "gemini 3.8 flash thinking" => "gemini-3.8-flash",
-        "gemini 3.8 pro" | "gemini 3.8 pro thinking" => "gemini-3.8-pro",
         "gemini 3.7 flash" | "gemini 3.7 flash thinking" => "gemini-3.7-flash",
         "gemini 3.7 pro" | "gemini 3.7 pro thinking" => "gemini-3.7-pro",
         "gemini 3.6 flash" | "gemini 3 flash" => "gemini-3.6-flash",
@@ -848,10 +848,13 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         "gemini 1.5 flash" => "gemini-1.5-flash",
         "gemini 1.5 pro" => "gemini-1.5-pro",
         "model_placeholder_m318" => "gemini-3.8-flash",
-        "model_placeholder_m298" | "model_placeholder_m300" => "gemini-3.7-flash",
-        "model_placeholder_m71" | "model_placeholder_m73" | "model_placeholder_m50" => {
-            "gemini-3.6-flash"
-        }
+        "model_placeholder_m298"
+        | "model_placeholder_m299"
+        | "model_placeholder_m300" => "gemini-3.7-flash",
+        "model_placeholder_m71"
+        | "model_placeholder_m72"
+        | "model_placeholder_m73" => "gemini-3.6-flash",
+        "model_placeholder_m50" => "gemini-3.1-flash-lite",
         "model_placeholder_m26" => "claude-opus-4-6",
         "model_placeholder_m35" => "claude-sonnet-4-6",
         "model_placeholder_m36" | "model_placeholder_m37" | "model_placeholder_m16" => {
@@ -1382,12 +1385,24 @@ mod tests {
             "gemini-3.7-flash".to_string()
         );
         assert_eq!(
+            model_name_from_id(1299),
+            "gemini-3.7-flash".to_string()
+        );
+        assert_eq!(
             model_name_from_id(1300),
             "gemini-3.7-flash".to_string()
         );
         assert_eq!(
+            model_name_from_id(1072),
+            "gemini-3.6-flash".to_string()
+        );
+        assert_eq!(
             model_name_from_id(1073),
             "gemini-3.6-flash".to_string()
+        );
+        assert_eq!(
+            model_name_from_id(1050),
+            "gemini-3.1-flash-lite".to_string()
         );
         assert_eq!(
             normalize_antigravity_model("model_placeholder_m318"),
@@ -1398,12 +1413,24 @@ mod tests {
             Some("gemini-3.7-flash".to_string())
         );
         assert_eq!(
+            normalize_antigravity_model("model_placeholder_m299"),
+            Some("gemini-3.7-flash".to_string())
+        );
+        assert_eq!(
             normalize_antigravity_model("model_placeholder_m300"),
             Some("gemini-3.7-flash".to_string())
         );
         assert_eq!(
+            normalize_antigravity_model("model_placeholder_m72"),
+            Some("gemini-3.6-flash".to_string())
+        );
+        assert_eq!(
             normalize_antigravity_model("model_placeholder_m73"),
             Some("gemini-3.6-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m50"),
+            Some("gemini-3.1-flash-lite".to_string())
         );
         assert_eq!(
             normalize_antigravity_model("gemini 3.8 flash"),

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -848,12 +848,12 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         "gemini 1.5 flash" => "gemini-1.5-flash",
         "gemini 1.5 pro" => "gemini-1.5-pro",
         "model_placeholder_m318" => "gemini-3.8-flash",
-        "model_placeholder_m298"
-        | "model_placeholder_m299"
-        | "model_placeholder_m300" => "gemini-3.7-flash",
-        "model_placeholder_m71"
-        | "model_placeholder_m72"
-        | "model_placeholder_m73" => "gemini-3.6-flash",
+        "model_placeholder_m298" | "model_placeholder_m299" | "model_placeholder_m300" => {
+            "gemini-3.7-flash"
+        }
+        "model_placeholder_m71" | "model_placeholder_m72" | "model_placeholder_m73" => {
+            "gemini-3.6-flash"
+        }
         "model_placeholder_m50" => "gemini-3.1-flash-lite",
         "model_placeholder_m26" => "claude-opus-4-6",
         "model_placeholder_m35" => "claude-sonnet-4-6",
@@ -1393,6 +1393,10 @@ mod tests {
             "gemini-3.7-flash".to_string()
         );
         assert_eq!(
+            model_name_from_id(1071),
+            "gemini-3.6-flash".to_string()
+        );
+        assert_eq!(
             model_name_from_id(1072),
             "gemini-3.6-flash".to_string()
         );
@@ -1419,6 +1423,10 @@ mod tests {
         assert_eq!(
             normalize_antigravity_model("model_placeholder_m300"),
             Some("gemini-3.7-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m71"),
+            Some("gemini-3.6-flash".to_string())
         );
         assert_eq!(
             normalize_antigravity_model("model_placeholder_m72"),

--- a/rust/adapters/antigravity/src/parser.rs
+++ b/rust/adapters/antigravity/src/parser.rs
@@ -816,6 +816,9 @@ fn model_name_from_id(model_id: u64) -> String {
         333 | 334 => "claude-4.5-sonnet".to_string(),
         340 | 341 => "claude-4.5-haiku".to_string(),
         342 => "model_openai_gpt_oss_120b_medium".to_string(),
+        1318 => "gemini-3.8-flash".to_string(),
+        1298 | 1300 => "gemini-3.7-flash".to_string(),
+        1071 | 1073 | 1050 => "gemini-3.6-flash".to_string(),
         1_000.. => format!("model_placeholder_m{}", model_id - 1_000),
         _ => format!("antigravity-model-{model_id}"),
     }
@@ -831,6 +834,8 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         .find('(')
         .map_or(lower.as_str(), |index| lower[..index].trim());
     let normalized = match base {
+        "gemini 3.8 flash" | "gemini 3.8 flash thinking" => "gemini-3.8-flash",
+        "gemini 3.8 pro" | "gemini 3.8 pro thinking" => "gemini-3.8-pro",
         "gemini 3.7 flash" | "gemini 3.7 flash thinking" => "gemini-3.7-flash",
         "gemini 3.7 pro" | "gemini 3.7 pro thinking" => "gemini-3.7-pro",
         "gemini 3.6 flash" | "gemini 3 flash" => "gemini-3.6-flash",
@@ -842,6 +847,11 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         "gemini 2.0 pro" => "gemini-2.0-pro",
         "gemini 1.5 flash" => "gemini-1.5-flash",
         "gemini 1.5 pro" => "gemini-1.5-pro",
+        "model_placeholder_m318" => "gemini-3.8-flash",
+        "model_placeholder_m298" | "model_placeholder_m300" => "gemini-3.7-flash",
+        "model_placeholder_m71" | "model_placeholder_m73" | "model_placeholder_m50" => {
+            "gemini-3.6-flash"
+        }
         "model_placeholder_m26" => "claude-opus-4-6",
         "model_placeholder_m35" => "claude-sonnet-4-6",
         "model_placeholder_m36" | "model_placeholder_m37" | "model_placeholder_m16" => {
@@ -855,6 +865,8 @@ fn normalize_antigravity_model(raw: &str) -> Option<String> {
         "model_placeholder_m20" => "gemini-3.5-flash-medium",
         "model_openai_gpt_oss_120b_medium" => "gpt-oss-120b-medium",
         "gemini-pro-default" | "gemini-pro-agent" => "gemini-3.1-pro",
+        "gemini-3.7-flash-control" => "gemini-3.7-flash",
+        "gemini 3.6 flash (low)" => "gemini-3.6-flash",
         "gemini-3-flash-agent"
         | "gemini-3-flash-agent-a"
         | "gemini-3-flash-agent-b"
@@ -1358,5 +1370,49 @@ mod tests {
 
         assert!(result.is_ok());
         assert!(result.unwrap().is_some());
+    }
+
+    #[test]
+    fn normalizes_newer_gemini_model_placeholders_and_ids() {
+        assert_eq!(
+            model_name_from_id(1318),
+            "gemini-3.8-flash".to_string()
+        );
+        assert_eq!(
+            model_name_from_id(1298),
+            "gemini-3.7-flash".to_string()
+        );
+        assert_eq!(
+            model_name_from_id(1300),
+            "gemini-3.7-flash".to_string()
+        );
+        assert_eq!(
+            model_name_from_id(1073),
+            "gemini-3.6-flash".to_string()
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m318"),
+            Some("gemini-3.8-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m298"),
+            Some("gemini-3.7-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m300"),
+            Some("gemini-3.7-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("model_placeholder_m73"),
+            Some("gemini-3.6-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("gemini 3.8 flash"),
+            Some("gemini-3.8-flash".to_string())
+        );
+        assert_eq!(
+            normalize_antigravity_model("gemini-3.7-flash-control"),
+            Some("gemini-3.7-flash".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

Map Antigravity's current Gemini Flash model IDs and placeholders to the exact model names exposed by `agy`, preserving the High, Medium, and Low effort variants in reports.

Pricing now tries the exact variant and its provider-prefixed forms first, honors explicit model aliases, then falls back to the corresponding base model when the pricing catalog has no variant-specific entry. Exact lookup prevents a sibling effort variant from being used accidentally.

## Verified mappings

| Internal ID | Placeholder | Reported model |
| --- | --- | --- |
| `1318` | `model_placeholder_m318` | `gemini-3.8-flash-high` |
| `1319` | `model_placeholder_m319` | `gemini-3.8-flash-medium` |
| `1320` | `model_placeholder_m320` | `gemini-3.8-flash-low` |
| `1298` | `model_placeholder_m298` | `gemini-3.7-flash-high` |
| `1299` | `model_placeholder_m299` | `gemini-3.7-flash-medium` |
| `1300` | `model_placeholder_m300` | `gemini-3.7-flash-low` |
| `1071` | `model_placeholder_m71` | `gemini-3.6-flash-high` |
| `1072` | `model_placeholder_m72` | `gemini-3.6-flash-medium` |
| `1073` | `model_placeholder_m73` | `gemini-3.6-flash-low` |

The mappings were verified by invoking every listed model with the current Antigravity CLI and reading the generated SQLite conversations. Parenthesized display names such as `Gemini 3.8 Flash (High)` are normalized to the same stable IDs.

Unverified mappings from the earlier draft, including Gemini 3.1 Flash Lite and `gemini-3.7-flash-control`, are intentionally excluded.

## Validation

- `cargo test --manifest-path rust/Cargo.toml -p ccusage-adapter-antigravity` (28 passed)
- `cargo clippy --manifest-path rust/Cargo.toml -p ccusage-adapter-antigravity --all-targets -- -D warnings`
- `just hawk` (0 findings)
- Pre-push hooks: clippy, treefmt, gitleaks, Cargo tests
- Real-data smoke test: all nine generated sessions report the exact effort variant and a non-zero offline cost


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for distinct Gemini Flash effort variants: high, medium, and low.
  * Effort variants remain visible in normalized model names.
  * Cost calculations can use base-model pricing when separate variant pricing is unavailable.
  * Provider-specific pricing is preferred when available, with improved model and alias matching.

* **Documentation**
  * Updated Antigravity guidance to explain stable model IDs, visible effort variants, and base-model pricing fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->