### PR TITLE
fix(nix): use agent-skills quiet shell hook

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,22 +2,45 @@
   "nodes": {
     "agent-skills": {
       "inputs": {
+        "blueprint": "blueprint",
         "home-manager": "home-manager",
         "nixpkgs": [
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1783839654,
-        "narHash": "sha256-rn5DkeQ9PBaJTZl9juBtPnVawyN4B83tyz1VpiinQFo=",
+        "lastModified": 1788359763,
+        "narHash": "sha256-fSf98BvLBbAPeBiI14hxH0pw0ewb5RGtQxcm0vANkSM=",
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
-        "rev": "8326df98cf494dc515db99affa9ea9d2bd6666b6",
+        "rev": "260294fa7b7b8083006a959f1b36be77b24912dc",
         "type": "github"
       },
       "original": {
         "owner": "Kyure-A",
         "repo": "agent-skills-nix",
+        "type": "github"
+      }
+    },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "agent-skills",
+          "nixpkgs"
+        ],
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
         "type": "github"
       }
     },
@@ -27,7 +50,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems",
+        "systems": "systems_2",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
@@ -143,11 +166,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783222121,
-        "narHash": "sha256-E/ElL373TO8lQ2aMvYyzN+k4xkVaUGoRqoa8AtM71tI=",
+        "lastModified": 1785531816,
+        "narHash": "sha256-vkMnV0JIyw+g/NmcfoajlGaAO+9a0ezia+FZohQJrik=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "a1645f40777620c4bd2b6d854b290c2fc354a266",
+        "rev": "bf9ce9fec78f95f374e8dd3b503863a3ec128ebe",
         "type": "github"
       },
       "original": {
@@ -270,6 +293,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1776166891,
         "narHash": "sha256-bI8yrEGjrohR5hkQox7UrxDH7XqrYMwI8SL/LrJ1+S8=",

--- a/nix/agent-skills.nix
+++ b/nix/agent-skills.nix
@@ -37,11 +37,13 @@ in
           structure = "link";
         };
       };
-      installLocalHook = agentLib.mkShellHook {
-        inherit pkgs bundle;
-        targets = localTargets;
-        quiet = true;
-      };
+      installLocalHook = lib.trim (
+        agentLib.mkShellHook {
+          inherit pkgs bundle;
+          targets = localTargets;
+          quiet = true;
+        }
+      );
       syncAgentSkills = pkgs.writeShellApplication {
         name = "sync-agent-skills";
         text = ''
@@ -52,7 +54,7 @@ in
             echo "Remove it before syncing Nix-managed agent skills." >&2
             exit 1
           fi
-          ${installLocalHook}
+          ${installLocalHook} "$@"
         '';
       };
     in

--- a/nix/agent-skills.nix
+++ b/nix/agent-skills.nix
@@ -37,13 +37,13 @@ in
           structure = "link";
         };
       };
-      installLocal = agentLib.mkLocalInstallScript {
+      installLocalHook = agentLib.mkShellHook {
         inherit pkgs bundle;
         targets = localTargets;
+        quiet = true;
       };
       syncAgentSkills = pkgs.writeShellApplication {
         name = "sync-agent-skills";
-        runtimeInputs = [ installLocal ];
         text = ''
           root="''${AGENT_SKILLS_ROOT:-$PWD}"
           target="$root/.claude/skills"
@@ -52,7 +52,7 @@ in
             echo "Remove it before syncing Nix-managed agent skills." >&2
             exit 1
           fi
-          exec skills-install-local "$@"
+          ${installLocalHook}
         '';
       };
     in

--- a/nix/dev-shell.nix
+++ b/nix/dev-shell.nix
@@ -104,7 +104,7 @@ in
             just install
           fi
 
-          ${lib.getExe config.packages.syncAgentSkills} >/dev/null
+          ${lib.getExe config.packages.syncAgentSkills}
           ${config.pre-commit.shellHook}
         ''
         + gitWtHook;


### PR DESCRIPTION
Use agent-skills-nixs
quiet
shell
hook
for
the
dev-shell
skill
sync,
preserving
warnings
and
errors
without
redirecting
the
sync
commands stdout. Update the locked agent-skills-nix input to the current upstream master revision and its required Blueprint/Home Manager lock entries.

Testing:
- nix flake check --no-build
- nix build --no-link .#checks.aarch64-darwin.agent-skills .#checks.aarch64-darwin.treefmt
- nix fmt -- --fail-on-change
- commit and push hooks (treefmt, gitleaks, scope; push-time checks skipped unrelated files)
- disposable sync-wrapper run: zero stdout/stderr and Claude skills symlink created

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the dev-shell agent-skills sync to agent-skills-nix's quiet shell hook, so warnings and errors are preserved without redirecting stdout, and sync arguments are now passed through. Updates the locked agent-skills-nix input to the current upstream master revision along with its required Blueprint and Home Manager lock entries.

<sup>Written for commit 734f2ac0af85f96b152c98f8a7708b6bff21a8e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Developer Experience**
  * Streamlined agent-skill synchronization during local development shell setup.
  * Synchronization output is now visible, making progress and issues easier to identify.
  * Existing command-line arguments continue to be supported during synchronization.

* **Chores**
  * Simplified the local setup flow while preserving synchronization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->