### PR TITLE
ci: check documentation links weekly with lychee

### DIFF
--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -1,0 +1,57 @@
+name: Check documentation links
+
+on:
+  schedule:
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: check-links-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Check external documentation links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --no-progress --scheme http --scheme https --root-dir .
+            --exclude-all-private --max-concurrency 4 --max-retries 2 --timeout 20
+            README.md 'docs/**/*.md'
+          # External hosts can reject automated requests even when a link works.
+          fail: false
+          output: reports/external-links.md
+      - uses: ./.github/actions/setup-nix-cache
+      - name: Install documentation build tools
+        run: nix profile install --inputs-from . nixpkgs#pnpm nixpkgs#nodejs nixpkgs#just
+      - run: pnpm install --frozen-lockfile
+      - name: Build documentation
+        run: just docs::build
+      - name: Check generated documentation links
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
+        with:
+          args: >-
+            --no-progress --offline --include-fragments
+            --root-dir docs/.vitepress/dist --fallback-extensions html --index-files index.html
+            'docs/.vitepress/dist/**/*.html'
+          # Collect the existing failures before making internal links a gate.
+          fail: false
+          output: reports/internal-links.md
+      - name: Upload link reports
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: link-check-reports
+          path: reports/*.md
+          if-no-files-found: error
+          retention-days: 14

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -26,6 +26,7 @@ jobs:
         with:
           args: >-
             --no-progress --scheme http --scheme https --root-dir .
+            --exclude-path "(^|/)(node_modules|\.vitepress)/"
             --exclude-all-private --max-concurrency 4 --max-retries 2 --timeout 20
             README.md 'docs/**/*.md'
           # External hosts can reject automated requests even when a link works.

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -39,14 +39,14 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Build documentation
         run: just docs::build
-      - name: Check generated documentation links
+      - name: Check local documentation links
         id: internal_links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
             --no-progress --offline --include-fragments
             --root-dir docs/.vitepress/dist --fallback-extensions html --index-files index.html
-            'docs/.vitepress/dist/**/*.html'
+            README.md 'docs/.vitepress/dist/**/*.html'
           # Collect the existing failures before making internal links a gate.
           fail: false
           output: reports/internal-links.md

--- a/.github/workflows/check-links.yaml
+++ b/.github/workflows/check-links.yaml
@@ -22,6 +22,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Check external documentation links
+        id: external_links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
@@ -39,6 +40,7 @@ jobs:
       - name: Build documentation
         run: just docs::build
       - name: Check generated documentation links
+        id: internal_links
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
           args: >-
@@ -56,3 +58,19 @@ jobs:
           path: reports/*.md
           if-no-files-found: error
           retention-days: 14
+      - name: Fail on checker execution errors
+        if: always()
+        env:
+          EXTERNAL_EXIT_CODE: ${{ steps.external_links.outputs.exit_code }}
+          INTERNAL_EXIT_CODE: ${{ steps.internal_links.outputs.exit_code }}
+        run: |
+          # Exit 2 reports link findings, which remain advisory.
+          for code in "$EXTERNAL_EXIT_CODE" "$INTERNAL_EXIT_CODE"; do
+            case "$code" in
+              0 | 2) ;;
+              *)
+                echo "::error::lychee did not complete normally (exit code: ${code:-missing})"
+                exit 1
+                ;;
+            esac
+          done


### PR DESCRIPTION
Adds a weekly (Monday 06:23 UTC) and manually dispatched lychee workflow to detect documentation link rot. It checks HTTP(S) links in README/docs separately from offline links and anchors in README and built VitePress HTML, including clean URLs and index pages. Dependency directories and build output are excluded from the Markdown scan.

Both scans publish advisory Markdown job summaries and a 14-day report artifact. Link findings (exit 2) do not block PRs; checker execution/configuration errors, missing outputs, and setup/build failures fail the workflow. The action is pinned to v2.9.0's commit (lychee v0.24.2), and build tools come from the existing Nix lock. External checks stay outside `nix flake check` because they depend on mutable remote services. The scheduled workflow becomes available after merge.

Validation: docs build, actionlint, offline zizmor, treefmt, and commit/push hooks passed. Ran both scans locally with lychee 0.24.2: the offline scan inspected 3,310 link occurrences and reported one existing missing JSON target; the external scan reported one 404 and one HTTP/2 error. These findings remain visible for follow-up. Verified that the final exit-code check accepts 0/2 and rejects 1/3/127/missing for each scan.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated weekly and on-demand checks validate external and internal documentation links, including links in the README.
  * Link-check reports are collected and uploaded for review.
  * Missing or invalid links remain advisory, while checker execution, input, or configuration errors now fail the workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->