### PR TITLE
feat(statusline): show the workspace git branch with --git-branch

### DIFF
--- a/apps/ccusage/config-schema.json
+++ b/apps/ccusage/config-schema.json
@@ -2087,6 +2087,12 @@
 											"markdownDescription": "Show statusline debug information.",
 											"type": "boolean"
 										},
+										"gitBranch": {
+											"default": false,
+											"description": "Show the current git branch of the workspace.",
+											"markdownDescription": "Show the current git branch of the workspace.",
+											"type": "boolean"
+										},
 										"modelLabelAliases": {
 											"additionalProperties": {
 												"type": "string"
@@ -2443,6 +2449,11 @@
 									"enum": ["auto", "calculate", "display"],
 									"markdownDescription": "Cost calculation mode.",
 									"type": "string"
+								},
+								"gitBranch": {
+									"description": "Show the current git branch of the workspace.",
+									"markdownDescription": "Show the current git branch of the workspace.",
+									"type": "boolean"
 								},
 								"modelLabelAliases": {
 									"additionalProperties": {
@@ -4656,6 +4667,12 @@
 									"default": false,
 									"description": "Show statusline debug information.",
 									"markdownDescription": "Show statusline debug information.",
+									"type": "boolean"
+								},
+								"gitBranch": {
+									"default": false,
+									"description": "Show the current git branch of the workspace.",
+									"markdownDescription": "Show the current git branch of the workspace.",
 									"type": "boolean"
 								},
 								"modelLabelAliases": {

--- a/docs/guide/statusline.md
+++ b/docs/guide/statusline.md
@@ -11,6 +11,7 @@ The `statusline` command provides a compact, real-time view of your Claude Code 
 - 🚀 **Current session block** - Cost and time remaining in your active 5-hour billing block
 - 🔥 **Burn rate** - Token consumption rate with visual indicators
 - 🤖 **Active model** - The Claude model you're currently using, with its reasoning effort level when available
+- 🌿 **Git branch** - The branch checked out in your workspace (opt-in via `--git-branch`)
 
 ## Setup
 
@@ -104,6 +105,22 @@ You can control how session costs are calculated and displayed:
 
 See [Cost Source Options](#cost-source-options) section for all available modes.
 
+### With Git Branch (Optional)
+
+You can show the git branch of the workspace Claude Code is running in:
+
+```json
+{
+	"statusLine": {
+		"type": "command",
+		"command": "bun x ccusage statusline --git-branch", // Add the current git branch
+		"padding": 0
+	}
+}
+```
+
+See [Git Branch](#git-branch) section for details.
+
 ## Output Format
 
 The statusline displays a compact, single-line summary:
@@ -124,9 +141,16 @@ The reasoning effort level next to the model name comes from Claude Code (2.1.11
 🤖 Opus 4.1 | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
 ```
 
+With `--git-branch`, the branch of the workspace repository follows the model:
+
+```text
+🤖 Fable 5 (high) | 🌿 main | 💰 $0.23 session / $1.23 today / $0.45 block (2h 45m left) | 🔥 $0.12/hr | 🧠 25,000 (12%)
+```
+
 ### Components Explained
 
 - **Model** (`🤖 Fable 5 (high)`): Currently active Claude model, followed by the reasoning effort level in parentheses (`low`, `medium`, `high`, `xhigh`, or `max`) when Claude Code provides it
+- **Git Branch** (`🌿 main`): Branch checked out in the workspace, shown only with `--git-branch` and only inside a git repository (see [Git Branch](#git-branch))
 - **Session Cost** (`💰 $0.23 session`): Cost for the current conversation session (see [Cost Source Options](#cost-source-options) for different calculation modes)
 - **Today's Cost** (`$1.23 today`): Total cost for the current day across all sessions
 - **Session Block** (`$0.45 block (2h 45m left)`): Current 5-hour block cost with remaining time
@@ -294,6 +318,45 @@ bun x ccusage statusline --visual-burn-rate emoji
 - 🟢 Normal (Green)
 - ⚠️ Moderate (Yellow)
 - 🚨 High (Red)
+
+### Git Branch
+
+Enable the `--git-branch` flag to show the branch checked out in the workspace
+Claude Code is running in. The segment appears right after the model:
+
+```bash
+bun x ccusage statusline --git-branch
+```
+
+```text
+🤖 Fable 5 (high) | 🌿 feature/login | 💰 ...
+```
+
+The workspace directory comes from the `workspace.current_dir` (or `cwd`)
+field Claude Code passes to the status line, so the branch follows the
+directory of the session rather than the shell you launched `claude` from.
+ccusage reads `.git/HEAD` directly instead of running `git`, which keeps the
+status line fast and works without a git binary on `PATH`. Worktrees and
+submodules are supported.
+
+- A checked-out branch shows its name: `🌿 main`
+- A detached `HEAD` shows the abbreviated commit hash in parentheses: `🌿 (a1b2c3d)`
+- Outside a git repository, the segment is omitted entirely
+
+The flag is off by default. Use `--no-git-branch` to override a configuration
+file that enables it. The equivalent configuration key is `gitBranch`:
+
+```json
+{
+	"commands": {
+		"statusline": {
+			"gitBranch": true
+		}
+	}
+}
+```
+
+See the [Configuration Guide](/guide/configuration) for more details.
 
 ### Model Label Aliases
 

--- a/rust/crates/ccusage-cli-parser/src/cli-help.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-help.json
@@ -399,7 +399,7 @@
 		},
 		{
 			"flags": "--git-branch",
-			"description": "Show the current git branch of the workspace",
+			"description": "Show the current git branch of the workspace (abbreviated commit when HEAD is detached)",
 			"default": "false"
 		},
 		{

--- a/rust/crates/ccusage-cli-parser/src/cli-help.json
+++ b/rust/crates/ccusage-cli-parser/src/cli-help.json
@@ -398,6 +398,15 @@
 			"default": "80"
 		},
 		{
+			"flags": "--git-branch",
+			"description": "Show the current git branch of the workspace",
+			"default": "false"
+		},
+		{
+			"flags": "--no-git-branch",
+			"description": "Negatable of --git-branch"
+		},
+		{
 			"flags": "-z, --timezone <timezone>",
 			"description": "Timezone for date grouping (IANA)"
 		},

--- a/rust/crates/ccusage-cli-parser/src/parser.rs
+++ b/rust/crates/ccusage-cli-parser/src/parser.rs
@@ -248,6 +248,8 @@ fn parse_command(
                                 "Invalid value for --context-medium-threshold".to_string()
                             })?
                     }
+                    "--git-branch" => args.git_branch = true,
+                    "--no-git-branch" => args.git_branch = false,
                     "-z" | "--timezone" => args.timezone = Some(parser.value_for("--timezone")?),
                     "--config" => args.config = Some(PathBuf::from(parser.value_for("--config")?)),
                     "--debug" => args.debug = true,

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__snapshots_representative_cli_parse_shapes.snap
@@ -600,6 +600,7 @@ expression: cases
         "contextMediumThreshold": 75,
         "costSource": "Both",
         "debug": true,
+        "gitBranch": true,
         "noCache": true,
         "noOffline": true,
         "offline": true,

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__statusline_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__statusline_help.snap
@@ -17,7 +17,7 @@ OPTIONS:
   --refresh-interval [refresh-interval]                 Refresh interval in seconds for cache expiry (default: 1)
   --context-low-threshold [context-low-threshold]       Context usage percentage below which status is shown in green (0-100) (default: 50)
   --context-medium-threshold [context-medium-threshold] Context usage percentage below which status is shown in yellow (0-100) (default: 80)
-  --git-branch                                          Show the current git branch of the workspace (default: false)
+  --git-branch                                          Show the current git branch of the workspace (abbreviated commit when HEAD is detached) (default: false)
   --no-git-branch                                       Negatable of --git-branch
   -z, --timezone <timezone>                             Timezone for date grouping (IANA)
   --config <config>                                     Path to configuration file (default: auto-discovery)

--- a/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__statusline_help.snap
+++ b/rust/crates/ccusage-cli-parser/src/snapshots/ccusage_cli_parser__tests__statusline_help.snap
@@ -1,6 +1,5 @@
 ---
-source: crates/ccusage/src/cli.rs
-assertion_line: 2062
+source: crates/ccusage-cli-parser/src/tests.rs
 expression: "help_text_for_args(&[\"ccusage\".to_string(), \"statusline\".to_string()])"
 ---
 Display compact status line for Claude Code hooks with hybrid time+file caching (Beta)
@@ -18,6 +17,8 @@ OPTIONS:
   --refresh-interval [refresh-interval]                 Refresh interval in seconds for cache expiry (default: 1)
   --context-low-threshold [context-low-threshold]       Context usage percentage below which status is shown in green (0-100) (default: 50)
   --context-medium-threshold [context-medium-threshold] Context usage percentage below which status is shown in yellow (0-100) (default: 80)
+  --git-branch                                          Show the current git branch of the workspace (default: false)
+  --no-git-branch                                       Negatable of --git-branch
   -z, --timezone <timezone>                             Timezone for date grouping (IANA)
   --config <config>                                     Path to configuration file (default: auto-discovery)
   -d, --debug                                           Show pricing mismatch information for debugging (default: false)

--- a/rust/crates/ccusage-cli-parser/src/tests.rs
+++ b/rust/crates/ccusage-cli-parser/src/tests.rs
@@ -187,6 +187,7 @@ fn command_snapshot(command: Option<Command>) -> Value {
             "refreshInterval": args.refresh_interval,
             "contextLowThreshold": args.context_low_threshold,
             "contextMediumThreshold": args.context_medium_threshold,
+            "gitBranch": args.git_branch,
             "config": args.config.as_ref().map(|path| path.to_string_lossy().to_string()),
             "debug": args.debug,
         }),
@@ -902,6 +903,7 @@ fn snapshots_representative_cli_parse_shapes() {
                 "45",
                 "--context-medium-threshold",
                 "75",
+                "--git-branch",
                 "--debug",
             ])),
         }),
@@ -1027,6 +1029,7 @@ fn parses_statusline_options() {
         "emoji-text",
         "--cost-source",
         "both",
+        "--git-branch",
     ]);
     let Some(Command::Statusline(args)) = cli.command else {
         panic!("expected statusline command");
@@ -1036,6 +1039,22 @@ fn parses_statusline_options() {
     assert_eq!(args.timezone.as_deref(), Some("Asia/Tokyo"));
     assert_eq!(args.visual_burn_rate, VisualBurnRate::EmojiText);
     assert_eq!(args.cost_source, CostSource::Both);
+    assert!(args.git_branch);
+}
+
+#[test]
+fn statusline_git_branch_is_off_by_default_and_negatable() {
+    let cli = parse(&["ccusage", "statusline"]);
+    let Some(Command::Statusline(args)) = cli.command else {
+        panic!("expected statusline command");
+    };
+    assert!(!args.git_branch);
+
+    let cli = parse(&["ccusage", "statusline", "--git-branch", "--no-git-branch"]);
+    let Some(Command::Statusline(args)) = cli.command else {
+        panic!("expected statusline command");
+    };
+    assert!(!args.git_branch);
 }
 
 #[test]

--- a/rust/crates/ccusage-cli/src/types.rs
+++ b/rust/crates/ccusage-cli/src/types.rs
@@ -161,6 +161,8 @@ pub struct StatuslineArgs {
     pub refresh_interval: u64,
     pub context_low_threshold: u8,
     pub context_medium_threshold: u8,
+    /// Show the current git branch of the workspace in the statusline.
+    pub git_branch: bool,
     pub timezone: Option<String>,
     pub config: Option<PathBuf>,
     pub debug: bool,
@@ -226,6 +228,7 @@ impl Default for StatuslineArgs {
             refresh_interval: 1,
             context_low_threshold: 50,
             context_medium_threshold: 80,
+            git_branch: false,
             timezone: None,
             config: None,
             debug: false,

--- a/rust/crates/ccusage-config/src/config.rs
+++ b/rust/crates/ccusage-config/src/config.rs
@@ -489,6 +489,9 @@ fn apply_config_to_statusline_args(args: &mut StatuslineArgs, config: &ConfigCon
         {
             args.context_medium_threshold = threshold;
         }
+        if let Some(git_branch) = options.git_branch {
+            args.git_branch = git_branch;
+        }
         if let Some(timezone) = options.timezone {
             args.timezone = Some(timezone);
         }
@@ -880,6 +883,7 @@ mod tests {
                         "refreshInterval": 3,
                         "contextLowThreshold": 45,
                         "contextMediumThreshold": 75,
+                        "gitBranch": true,
                         "timezone": "Asia/Tokyo",
                         "debug": true
                     }
@@ -901,6 +905,7 @@ mod tests {
         assert_eq!(statusline.refresh_interval, 3);
         assert_eq!(statusline.context_low_threshold, 45);
         assert_eq!(statusline.context_medium_threshold, 75);
+        assert!(statusline.git_branch);
         assert_eq!(statusline.timezone.as_deref(), Some("Asia/Tokyo"));
         assert!(statusline.debug);
     }

--- a/rust/crates/ccusage-config/src/config_schema.rs
+++ b/rust/crates/ccusage-config/src/config_schema.rs
@@ -499,6 +499,8 @@ pub struct StatuslineSpecificOptions {
     pub context_low_threshold: Option<u64>,
     /// Percentage threshold for medium context warning.
     pub context_medium_threshold: Option<u64>,
+    /// Show the current git branch of the workspace.
+    pub git_branch: Option<bool>,
     /// Timezone for date grouping (IANA).
     pub timezone: Option<String>,
     /// Show statusline debug information.
@@ -671,6 +673,7 @@ impl StatuslineSpecificOptions {
             refresh_interval: u64_option(map, "refreshInterval"),
             context_low_threshold: u64_option(map, "contextLowThreshold"),
             context_medium_threshold: u64_option(map, "contextMediumThreshold"),
+            git_branch: bool_option(map, "gitBranch"),
             timezone: string_option(map, "timezone"),
             debug: bool_option(map, "debug"),
             model_label_aliases: hashmap_option(map, "modelLabelAliases"),
@@ -911,6 +914,7 @@ fn add_schema_defaults(schema: &mut Value) {
             ("refreshInterval", json!(1)),
             ("contextLowThreshold", json!(50)),
             ("contextMediumThreshold", json!(80)),
+            ("gitBranch", json!(false)),
             ("debug", json!(false)),
         ],
     );
@@ -1104,6 +1108,7 @@ mod tests {
                 "contextMediumThreshold",
                 "costSource",
                 "debug",
+                "gitBranch",
                 "modelLabelAliases",
                 "noCache",
                 "noOffline",

--- a/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
+++ b/rust/crates/ccusage-config/src/snapshots/ccusage_config__config_schema__tests__snapshots_schema_agent_specific_option_edges.snap
@@ -46,6 +46,12 @@ expression: "json!({\n    \"rootRef\": schema[\"$ref\"], \"rootProperties\":\n  
         "markdownDescription": "Show statusline debug information.",
         "type": "boolean"
       },
+      "gitBranch": {
+        "default": false,
+        "description": "Show the current git branch of the workspace.",
+        "markdownDescription": "Show the current git branch of the workspace.",
+        "type": "boolean"
+      },
       "modelLabelAliases": {
         "additionalProperties": {
           "type": "string"

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -348,13 +348,7 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
     }
 
     if cache_enabled {
-        mark_statusline_cache_updating(
-            &cache_path,
-            &hook,
-            current_mtime,
-            git_branch.as_deref(),
-            initial_cache.as_ref(),
-        );
+        mark_statusline_cache_updating(&cache_path, &hook, current_mtime, initial_cache.as_ref());
     }
 
     let statusline_result = render_statusline(&hook, &args, &shared, git_branch.as_deref());
@@ -799,12 +793,14 @@ impl StatuslineCache {
         }
     }
 
-    fn updating(
-        hook: &StatuslineHook,
-        transcript_mtime: u64,
-        git_branch: Option<&str>,
-        previous: Option<&Self>,
-    ) -> Self {
+    /// Mark the entry as being refreshed by this process while keeping the
+    /// previous output available to concurrent invocations.
+    ///
+    /// `git_branch` stays the one `last_output` was rendered with, not the
+    /// branch being rendered now: the metadata must describe the retained
+    /// line, so a refresh that fails (which leaves `last_output` in place)
+    /// cannot relabel the previous branch's output as the current branch.
+    fn updating(hook: &StatuslineHook, transcript_mtime: u64, previous: Option<&Self>) -> Self {
         let now = now_millis();
         Self {
             date: format_cache_date(now),
@@ -818,7 +814,7 @@ impl StatuslineCache {
             transcript_mtime,
             is_updating: true,
             pid: Some(std::process::id()),
-            git_branch: git_branch.map(str::to_string),
+            git_branch: previous.and_then(|cache| cache.git_branch.clone()),
         }
     }
 }
@@ -882,12 +878,11 @@ fn mark_statusline_cache_updating(
     path: &Path,
     hook: &StatuslineHook,
     transcript_mtime: u64,
-    git_branch: Option<&str>,
     previous: Option<&StatuslineCache>,
 ) {
     write_statusline_cache(
         path,
-        StatuslineCache::updating(hook, transcript_mtime, git_branch, previous),
+        StatuslineCache::updating(hook, transcript_mtime, previous),
     );
 }
 
@@ -1233,6 +1228,40 @@ mod tests {
             statusline_workspace_dir(&hook),
             Some(PathBuf::from("/from/cwd"))
         );
+    }
+
+    #[test]
+    fn updating_statusline_cache_keeps_the_branch_of_the_retained_output() {
+        let hook = statusline_hook_fixture("/tmp/transcript.jsonl");
+        let previous = StatuslineCache::completed(
+            &hook,
+            "🤖 M | 🌿 main | 💰 ...".to_string(),
+            123,
+            Some("main".to_string()),
+            10_000,
+        );
+
+        // The refresh is rendering `feature`, but the retained line is main's.
+        let updating = StatuslineCache::updating(&hook, 456, Some(&previous));
+        assert_eq!(updating.last_output, previous.last_output);
+        assert_eq!(updating.git_branch.as_deref(), Some("main"));
+        assert!(updating.is_updating);
+
+        // Once the refresh is released without a new line (render failed), the
+        // entry still misses for `feature` and only serves `main` output as main.
+        let mut released = updating;
+        released.is_updating = false;
+        released.pid = None;
+        assert_eq!(
+            cached_statusline_output(&released, 456, Some("feature"), 10_500, 1),
+            None
+        );
+        assert_eq!(
+            cached_statusline_output(&released, 456, Some("main"), 10_500, 1),
+            Some("🤖 M | 🌿 main | 💰 ...")
+        );
+
+        assert_eq!(StatuslineCache::updating(&hook, 456, None).git_branch, None);
     }
 
     #[test]

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -327,6 +327,7 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
     let cache_path = statusline_cache_path(&hook.session_id);
     let transcript_path = Path::new(&hook.transcript_path);
     let current_mtime = transcript_mtime_ms(transcript_path).unwrap_or_default();
+    let git_branch = resolve_statusline_git_branch(&hook, &args);
     let initial_cache = if cache_enabled {
         read_statusline_cache(&cache_path)
     } else {
@@ -334,25 +335,42 @@ pub(crate) fn run_statusline(args: StatuslineArgs) -> Result<()> {
     };
 
     if let Some(cache) = initial_cache.as_ref()
-        && let Some(output) =
-            cached_statusline_output(cache, current_mtime, now_millis(), args.refresh_interval)
+        && let Some(output) = cached_statusline_output(
+            cache,
+            current_mtime,
+            git_branch.as_deref(),
+            now_millis(),
+            args.refresh_interval,
+        )
     {
         println!("{output}");
         return Ok(());
     }
 
     if cache_enabled {
-        mark_statusline_cache_updating(&cache_path, &hook, current_mtime, initial_cache.as_ref());
+        mark_statusline_cache_updating(
+            &cache_path,
+            &hook,
+            current_mtime,
+            git_branch.as_deref(),
+            initial_cache.as_ref(),
+        );
     }
 
-    let statusline_result = render_statusline(&hook, &args, &shared);
+    let statusline_result = render_statusline(&hook, &args, &shared, git_branch.as_deref());
     match statusline_result {
         Ok(statusline) => {
             println!("{statusline}");
             if cache_enabled {
                 write_statusline_cache(
                     &cache_path,
-                    StatuslineCache::completed(&hook, statusline, current_mtime, now_millis()),
+                    StatuslineCache::completed(
+                        &hook,
+                        statusline,
+                        current_mtime,
+                        git_branch,
+                        now_millis(),
+                    ),
                 );
             }
         }
@@ -415,6 +433,7 @@ fn render_statusline(
     hook: &StatuslineHook,
     args: &StatuslineArgs,
     shared: &SharedArgs,
+    git_branch: Option<&str>,
 ) -> Result<String> {
     let session_cost = match args.cost_source {
         CostSource::Cc => hook.cost.as_ref().map(|cost| cost.total_cost_usd),
@@ -528,14 +547,9 @@ fn render_statusline(
 
     let model_label = resolve_model_label(&args.model_label_aliases, &hook.model.display_name);
     let model_segment = format_model_segment(model_label, hook.effort.as_ref());
-    let git_segment = if args.git_branch {
-        statusline_workspace_dir(hook)
-            .and_then(|dir| git_branch_for_dir(&dir))
-            .map(|branch| format!(" | 🌿 {branch}"))
-            .unwrap_or_default()
-    } else {
-        String::new()
-    };
+    let git_segment = git_branch
+        .map(|branch| format!(" | 🌿 {branch}"))
+        .unwrap_or_default();
 
     Ok(format!(
         "🤖 {}{} | 💰 {} session / {} today / {}{} | 🧠 {}",
@@ -547,6 +561,20 @@ fn render_statusline(
         burn_rate_info,
         context_info.unwrap_or_else(|| "N/A".to_string())
     ))
+}
+
+/// Resolve the git branch label for the statusline, or `None` when the
+/// segment is disabled or the workspace is not inside a repository.
+///
+/// Resolved before the cache check rather than during rendering: it costs a
+/// few file reads, and it has to take part in cache validity so a cached line
+/// neither hides a newly enabled segment nor keeps showing the previous
+/// branch after a checkout.
+fn resolve_statusline_git_branch(hook: &StatuslineHook, args: &StatuslineArgs) -> Option<String> {
+    if !args.git_branch {
+        return None;
+    }
+    statusline_workspace_dir(hook).and_then(|dir| git_branch_for_dir(&dir))
 }
 
 /// Resolve the directory whose git repository the statusline reports.
@@ -739,6 +767,11 @@ struct StatuslineCache {
     #[serde(rename = "isUpdating", default)]
     is_updating: bool,
     pid: Option<u32>,
+    /// Branch label rendered into `last_output`, `None` when the segment was
+    /// off or the workspace was outside a repository. Missing in caches written
+    /// by older versions, which deserializes as `None`.
+    #[serde(rename = "gitBranch", default)]
+    git_branch: Option<String>,
 }
 
 impl StatuslineCache {
@@ -746,6 +779,7 @@ impl StatuslineCache {
         hook: &StatuslineHook,
         last_output: String,
         transcript_mtime: u64,
+        git_branch: Option<String>,
         last_update_time: u64,
     ) -> Self {
         Self {
@@ -756,10 +790,16 @@ impl StatuslineCache {
             transcript_mtime,
             is_updating: false,
             pid: None,
+            git_branch,
         }
     }
 
-    fn updating(hook: &StatuslineHook, transcript_mtime: u64, previous: Option<&Self>) -> Self {
+    fn updating(
+        hook: &StatuslineHook,
+        transcript_mtime: u64,
+        git_branch: Option<&str>,
+        previous: Option<&Self>,
+    ) -> Self {
         let now = now_millis();
         Self {
             date: format_cache_date(now),
@@ -773,23 +813,26 @@ impl StatuslineCache {
             transcript_mtime,
             is_updating: true,
             pid: Some(std::process::id()),
+            git_branch: git_branch.map(str::to_string),
         }
     }
 }
 
-fn cached_statusline_output(
-    cache: &StatuslineCache,
+fn cached_statusline_output<'a>(
+    cache: &'a StatuslineCache,
     current_mtime: u64,
+    git_branch: Option<&str>,
     now: u64,
     refresh_interval: u64,
-) -> Option<&str> {
+) -> Option<&'a str> {
     if cache.last_output.is_empty() {
         return None;
     }
     let expired =
         now.saturating_sub(cache.last_update_time) >= refresh_interval.saturating_mul(1000);
     let file_modified = cache.transcript_mtime != current_mtime;
-    if expired || file_modified {
+    let branch_changed = cache.git_branch.as_deref() != git_branch;
+    if expired || file_modified || branch_changed {
         if cache.is_updating && cache.pid.is_some_and(process_is_alive) {
             return Some(cache.last_output.as_str());
         }
@@ -834,11 +877,12 @@ fn mark_statusline_cache_updating(
     path: &Path,
     hook: &StatuslineHook,
     transcript_mtime: u64,
+    git_branch: Option<&str>,
     previous: Option<&StatuslineCache>,
 ) {
     write_statusline_cache(
         path,
-        StatuslineCache::updating(hook, transcript_mtime, previous),
+        StatuslineCache::updating(hook, transcript_mtime, git_branch, previous),
     );
 }
 
@@ -1086,7 +1130,7 @@ mod tests {
             cwd: None,
             workspace: None,
         };
-        let output = render_statusline(&hook, &args, &shared).unwrap();
+        let output = render_statusline(&hook, &args, &shared, None).unwrap();
         assert!(output.contains("💰 $0.40 session"), "{output}");
     }
 
@@ -1196,14 +1240,17 @@ mod tests {
             git_branch: true,
             ..StatuslineArgs::default()
         };
-        let output = render_statusline(&hook, &enabled, &shared).unwrap();
+        let branch = resolve_statusline_git_branch(&hook, &enabled);
+        assert_eq!(branch.as_deref(), Some("feature/statusline"));
+        let output = render_statusline(&hook, &enabled, &shared, branch.as_deref()).unwrap();
         assert!(
             output.starts_with("🤖 Test model | 🌿 feature/statusline | 💰 "),
             "{output}"
         );
 
         let disabled = StatuslineArgs::default();
-        let output = render_statusline(&hook, &disabled, &shared).unwrap();
+        assert_eq!(resolve_statusline_git_branch(&hook, &disabled), None);
+        let output = render_statusline(&hook, &disabled, &shared, None).unwrap();
         assert!(!output.contains("🌿"), "{output}");
     }
 
@@ -1326,10 +1373,11 @@ mod tests {
             transcript_mtime: 123,
             is_updating: false,
             pid: None,
+            git_branch: None,
         };
 
         assert_eq!(
-            cached_statusline_output(&cache, 123, 10_500, 1),
+            cached_statusline_output(&cache, 123, None, 10_500, 1),
             Some("cached status")
         );
     }
@@ -1344,9 +1392,66 @@ mod tests {
             transcript_mtime: 123,
             is_updating: false,
             pid: None,
+            git_branch: None,
         };
 
-        assert_eq!(cached_statusline_output(&cache, 456, 10_500, 1), None);
+        assert_eq!(cached_statusline_output(&cache, 456, None, 10_500, 1), None);
+    }
+
+    #[test]
+    fn invalidates_statusline_cache_when_git_branch_changes() {
+        let mut cache = StatuslineCache {
+            date: "2026-01-01T00:00:00.000Z".to_string(),
+            last_output: "🤖 M | 🌿 main | 💰 ...".to_string(),
+            last_update_time: 10_000,
+            transcript_path: "/tmp/transcript.jsonl".to_string(),
+            transcript_mtime: 123,
+            is_updating: false,
+            pid: None,
+            git_branch: Some("main".to_string()),
+        };
+
+        // Same branch, fresh cache, unchanged transcript: still served.
+        assert_eq!(
+            cached_statusline_output(&cache, 123, Some("main"), 10_500, 1),
+            Some("🤖 M | 🌿 main | 💰 ...")
+        );
+        // Checked out another branch since the cache was written.
+        assert_eq!(
+            cached_statusline_output(&cache, 123, Some("feature"), 10_500, 1),
+            None
+        );
+        // Segment turned off since the cache was written.
+        assert_eq!(cached_statusline_output(&cache, 123, None, 10_500, 1), None);
+
+        // Cache from a run without the segment (or an older version) must not
+        // hide a newly enabled branch.
+        cache.git_branch = None;
+        assert_eq!(
+            cached_statusline_output(&cache, 123, Some("main"), 10_500, 1),
+            None
+        );
+    }
+
+    #[test]
+    fn statusline_cache_round_trips_git_branch_and_tolerates_older_caches() {
+        let hook = statusline_hook_fixture("/tmp/transcript.jsonl");
+        let cache = StatuslineCache::completed(
+            &hook,
+            "🤖 M | 🌿 main | 💰 ...".to_string(),
+            123,
+            Some("main".to_string()),
+            10_000,
+        );
+        let json = serde_json::to_string(&cache).unwrap();
+        let parsed: StatuslineCache = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.git_branch.as_deref(), Some("main"));
+
+        let older: StatuslineCache = serde_json::from_str(
+            r#"{"date":"2026-01-01T00:00:00.000Z","lastOutput":"cached","lastUpdateTime":10000,"transcriptPath":"/tmp/transcript.jsonl","transcriptMtime":123}"#,
+        )
+        .unwrap();
+        assert_eq!(older.git_branch, None);
     }
 
     #[test]
@@ -1359,10 +1464,11 @@ mod tests {
             transcript_mtime: 123,
             is_updating: true,
             pid: Some(std::process::id()),
+            git_branch: None,
         };
 
         assert_eq!(
-            cached_statusline_output(&cache, 456, 20_000, 1),
+            cached_statusline_output(&cache, 456, None, 20_000, 1),
             Some("stale status")
         );
     }

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -528,16 +528,84 @@ fn render_statusline(
 
     let model_label = resolve_model_label(&args.model_label_aliases, &hook.model.display_name);
     let model_segment = format_model_segment(model_label, hook.effort.as_ref());
+    let git_segment = if args.git_branch {
+        statusline_workspace_dir(hook)
+            .and_then(|dir| git_branch_for_dir(&dir))
+            .map(|branch| format!(" | 🌿 {branch}"))
+            .unwrap_or_default()
+    } else {
+        String::new()
+    };
 
     Ok(format!(
-        "🤖 {} | 💰 {} session / {} today / {}{} | 🧠 {}",
+        "🤖 {}{} | 💰 {} session / {} today / {}{} | 🧠 {}",
         model_segment,
+        git_segment,
         session_display,
         format_currency(today_cost),
         block_info,
         burn_rate_info,
         context_info.unwrap_or_else(|| "N/A".to_string())
     ))
+}
+
+/// Resolve the directory whose git repository the statusline reports.
+///
+/// Prefers the workspace directory Claude Code reports for the session, then
+/// the hook's `cwd`, and finally the process working directory so older Claude
+/// Code versions that omit both fields still resolve a branch.
+fn statusline_workspace_dir(hook: &StatuslineHook) -> Option<PathBuf> {
+    hook.workspace
+        .as_ref()
+        .and_then(|workspace| workspace.current_dir.as_deref())
+        .or(hook.cwd.as_deref())
+        .filter(|dir| !dir.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| env::current_dir().ok())
+}
+
+/// Format the git branch segment of the statusline.
+///
+/// Walks up from `dir` to the nearest `.git` entry and reads `HEAD` directly
+/// instead of spawning `git`, so the statusline stays fast and works without
+/// a git binary on `PATH`. Worktrees and submodules, whose `.git` is a file
+/// pointing at the real git directory, are followed. A symbolic `HEAD` yields
+/// the branch name; a detached `HEAD` yields the abbreviated commit hash in
+/// parentheses. Returns `None` outside a git repository.
+fn git_branch_for_dir(dir: &Path) -> Option<String> {
+    let git_dir = find_git_dir(dir)?;
+    let head = fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+    if let Some(reference) = head.strip_prefix("ref:") {
+        let reference = reference.trim();
+        let branch = reference.strip_prefix("refs/heads/").unwrap_or(reference);
+        return (!branch.is_empty()).then(|| branch.to_string());
+    }
+    if head.is_empty() {
+        return None;
+    }
+    let short: String = head.chars().take(7).collect();
+    Some(format!("({short})"))
+}
+
+/// Locate the git directory that owns `dir`, following `.git` files written
+/// by `git worktree` and submodules (`gitdir: <path>`).
+fn find_git_dir(dir: &Path) -> Option<PathBuf> {
+    dir.ancestors().find_map(|ancestor| {
+        let dot_git = ancestor.join(".git");
+        let metadata = fs::metadata(&dot_git).ok()?;
+        if metadata.is_dir() {
+            return Some(dot_git);
+        }
+        let content = fs::read_to_string(&dot_git).ok()?;
+        let target = content.trim().strip_prefix("gitdir:")?.trim();
+        let target = Path::new(target);
+        Some(if target.is_absolute() {
+            target.to_path_buf()
+        } else {
+            ancestor.join(target)
+        })
+    })
 }
 
 fn statusline_today_shared(
@@ -812,6 +880,16 @@ struct StatuslineHook {
     cost: Option<HookCost>,
     context_window: Option<HookContext>,
     effort: Option<HookEffort>,
+    /// Working directory of the Claude Code process.
+    cwd: Option<String>,
+    /// Workspace directories reported by Claude Code.
+    workspace: Option<HookWorkspace>,
+}
+
+#[derive(Debug, Deserialize)]
+struct HookWorkspace {
+    /// Directory the session is currently operating in.
+    current_dir: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1005,9 +1083,144 @@ mod tests {
                 context_window_size: 200_000,
             }),
             effort: None,
+            cwd: None,
+            workspace: None,
         };
         let output = render_statusline(&hook, &args, &shared).unwrap();
         assert!(output.contains("💰 $0.40 session"), "{output}");
+    }
+
+    #[test]
+    fn git_branch_reads_symbolic_head_from_git_directory() {
+        let fixture = fs_fixture!({
+            ".git/HEAD": "ref: refs/heads/feature/git-branch\n",
+        });
+
+        assert_eq!(
+            git_branch_for_dir(fixture.root()).as_deref(),
+            Some("feature/git-branch")
+        );
+    }
+
+    #[test]
+    fn git_branch_walks_up_to_the_enclosing_repository() {
+        let fixture = fs_fixture!({
+            ".git/HEAD": "ref: refs/heads/main\n",
+            "src/nested/.keep": "",
+        });
+
+        assert_eq!(
+            git_branch_for_dir(&fixture.path("src/nested")).as_deref(),
+            Some("main")
+        );
+    }
+
+    #[test]
+    fn git_branch_follows_worktree_gitdir_file() {
+        let fixture = fs_fixture!({
+            "main/.git/HEAD": "ref: refs/heads/main\n",
+            "main/.git/worktrees/wt/HEAD": "ref: refs/heads/worktree-branch\n",
+            "wt/.git": "gitdir: ../main/.git/worktrees/wt\n",
+        });
+
+        assert_eq!(
+            git_branch_for_dir(&fixture.path("wt")).as_deref(),
+            Some("worktree-branch")
+        );
+    }
+
+    #[test]
+    fn git_branch_shows_abbreviated_hash_when_head_is_detached() {
+        let fixture = fs_fixture!({
+            ".git/HEAD": "0123456789abcdef0123456789abcdef01234567\n",
+        });
+
+        assert_eq!(
+            git_branch_for_dir(fixture.root()).as_deref(),
+            Some("(0123456)")
+        );
+    }
+
+    #[test]
+    fn git_branch_is_absent_outside_a_repository() {
+        let fixture = fs_fixture!({
+            "src/.keep": "",
+        });
+
+        // A temp dir under a git checkout would still resolve, so only assert
+        // that nothing is found when no ancestor carries `.git`.
+        let has_git_ancestor = fixture
+            .root()
+            .ancestors()
+            .any(|dir| dir.join(".git").exists());
+        if !has_git_ancestor {
+            assert_eq!(git_branch_for_dir(&fixture.path("src")), None);
+        }
+    }
+
+    #[test]
+    fn statusline_workspace_dir_prefers_workspace_current_dir_over_cwd() {
+        let mut hook = statusline_hook_fixture("transcript.jsonl");
+        hook.cwd = Some("/from/cwd".to_string());
+        hook.workspace = Some(HookWorkspace {
+            current_dir: Some("/from/workspace".to_string()),
+        });
+        assert_eq!(
+            statusline_workspace_dir(&hook),
+            Some(PathBuf::from("/from/workspace"))
+        );
+
+        hook.workspace = None;
+        assert_eq!(
+            statusline_workspace_dir(&hook),
+            Some(PathBuf::from("/from/cwd"))
+        );
+    }
+
+    #[test]
+    fn statusline_shows_git_branch_segment_only_when_enabled() {
+        let fixture = fs_fixture!({
+            "repo/.git/HEAD": "ref: refs/heads/feature/statusline\n",
+            "transcript.jsonl": r#"{"type":"assistant","message":{"usage":{"input_tokens":1000}}}"#,
+        });
+        let _env = EnvVarGuard::set("CLAUDE_CONFIG_DIR", fixture.root());
+        let mut hook =
+            statusline_hook_fixture(fixture.path("transcript.jsonl").to_string_lossy().as_ref());
+        hook.cwd = Some(fixture.path("repo").to_string_lossy().into_owned());
+        let shared = SharedArgs {
+            offline: true,
+            ..SharedArgs::default()
+        };
+
+        let enabled = StatuslineArgs {
+            git_branch: true,
+            ..StatuslineArgs::default()
+        };
+        let output = render_statusline(&hook, &enabled, &shared).unwrap();
+        assert!(
+            output.starts_with("🤖 Test model | 🌿 feature/statusline | 💰 "),
+            "{output}"
+        );
+
+        let disabled = StatuslineArgs::default();
+        let output = render_statusline(&hook, &disabled, &shared).unwrap();
+        assert!(!output.contains("🌿"), "{output}");
+    }
+
+    fn statusline_hook_fixture(transcript_path: &str) -> StatuslineHook {
+        StatuslineHook {
+            session_id: "session".to_string(),
+            transcript_path: transcript_path.to_string(),
+            model: HookModel {
+                id: None,
+                display_name: "Test model".to_string(),
+            },
+            cost: None,
+            context_window: None,
+            effort: None,
+            cwd: None,
+            workspace: None,
+        }
     }
 
     #[test]

--- a/rust/crates/ccusage/src/commands/mod.rs
+++ b/rust/crates/ccusage/src/commands/mod.rs
@@ -583,11 +583,16 @@ fn resolve_statusline_git_branch(hook: &StatuslineHook, args: &StatuslineArgs) -
 /// the hook's `cwd`, and finally the process working directory so older Claude
 /// Code versions that omit both fields still resolve a branch.
 fn statusline_workspace_dir(hook: &StatuslineHook) -> Option<PathBuf> {
-    hook.workspace
-        .as_ref()
-        .and_then(|workspace| workspace.current_dir.as_deref())
-        .or(hook.cwd.as_deref())
-        .filter(|dir| !dir.is_empty())
+    fn non_empty(dir: Option<&str>) -> Option<&str> {
+        dir.filter(|dir| !dir.is_empty())
+    }
+    let workspace_dir = non_empty(
+        hook.workspace
+            .as_ref()
+            .and_then(|workspace| workspace.current_dir.as_deref()),
+    );
+    workspace_dir
+        .or_else(|| non_empty(hook.cwd.as_deref()))
         .map(PathBuf::from)
         .or_else(|| env::current_dir().ok())
 }
@@ -1215,6 +1220,15 @@ mod tests {
         );
 
         hook.workspace = None;
+        assert_eq!(
+            statusline_workspace_dir(&hook),
+            Some(PathBuf::from("/from/cwd"))
+        );
+
+        // An empty workspace directory must not shadow a usable cwd.
+        hook.workspace = Some(HookWorkspace {
+            current_dir: Some(String::new()),
+        });
         assert_eq!(
             statusline_workspace_dir(&hook),
             Some(PathBuf::from("/from/cwd"))


### PR DESCRIPTION
Adds an opt-in `--git-branch` flag to `ccusage statusline` that shows the branch checked out in the session's workspace, right after the model segment:

```text
🤖 Fable 5.1 (xhigh) | 🌿 feat/statusline-git-branch | 💰 $3.21 session / $58.57 today / $58.57 block (1h 48m left) | 🔥 $18.61/hr | 🧠 160,000 (16%)
```

Claude Code already passes `workspace.current_dir` / `cwd` in the status line hook JSON, but ccusage ignored it. When juggling several worktrees or branches it is easy to lose track of which one a session is on, and the status line is the natural place to show it.

## What changed

- `StatuslineHook` now reads `cwd` and `workspace.current_dir`. The branch is resolved by walking up to the nearest `.git` and reading `HEAD` directly instead of spawning `git`, so the per-second refresh stays cheap and it works without git on `PATH`. `gitdir:` files from worktrees and submodules are followed. A detached HEAD renders as `(abc1234)`; outside a repository the segment is omitted.
- New `--git-branch` / `--no-git-branch` flags, a `gitBranch` config key, help text, and the regenerated `apps/ccusage/config-schema.json`.
- `docs/guide/statusline.md` gains a Git Branch section.

The flag defaults to off, so existing output is unchanged.

## Testing

- `cargo test --workspace` (517 passed), `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` on the touched crates.
- Unit tests cover a symbolic HEAD, walking up to the enclosing repository, worktree `gitdir:` files, a detached HEAD, `workspace.current_dir` taking precedence over `cwd`, and the rendered segment with the flag on and off.
- Ran the release binary against a real Claude Code hook payload in a normal checkout, a worktree, a nested directory inside a worktree, a detached HEAD, and a non-repo directory, then wired it into my own `settings.json`.
- Not run: the Nix-based `just fmt` / `just typecheck` recipes (no Nix on this machine), so treefmt may still want to touch the JSON or Markdown formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `--git-branch` flag to `ccusage statusline` so you can see which branch the session's workspace is on, right after the model segment. `ccusage` previously ignored the workspace directory that Claude Code passes in the statusline hook, making it easy to lose track of the active branch when juggling worktrees or branches.

- Branch resolution reads `.git/HEAD` directly instead of spawning `git`, keeping the per-second refresh cheap and working without git on `PATH`. It prefers `workspace.current_dir`, falls back to `cwd` when that is missing or empty, then to the process working directory.
- Worktrees and submodules are followed via their `gitdir:` file; a detached HEAD renders as `(abc1234)` and the segment is omitted outside a repository.
- Adds `--git-branch` / `--no-git-branch` flags and a `gitBranch` config key; the flag defaults to off so existing output is unchanged, and branch changes invalidate the cache.
- The cache stores the branch its output was rendered with, so a failed refresh can't serve the old branch's line as the current one.

<sup>Written for commit 6a40a761b2291477e6f16c14be31edd867067e8f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Git branch segment to the statusline, disabled by default.
  * Added `--git-branch` and `--no-git-branch` command-line options.
  * Added configuration support for enabling or disabling Git branch display.
  * Git branch detection supports repositories, worktrees, submodules, parent repositories, and detached HEAD states.
  * Detached HEAD displays an abbreviated commit; statusline output updates when the active branch changes.

* **Documentation**
  * Added setup instructions, output examples, and configuration details for the Git branch statusline component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->