### PR TITLE
fix(pullfrog): avoid stale checkout credentials

### DIFF
--- a/.github/workflows/pullfrog.yml
+++ b/.github/workflows/pullfrog.yml
@@ -25,12 +25,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 1
+          persist-credentials: false
       - name: Setup Nix
         uses: ./.github/actions/setup-nix-cache
       - name: Run agent
         uses: pullfrog/pullfrog@c4d0ca6f15d12382ddd20d2010bc596b405f42f0 # v0.1.60
         with:
           prompt: ${{ inputs.prompt }}
+          push: restricted
+          shell: restricted
         env:
           # add at least one provider API key
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

- stop actions/checkout from persisting the read-only workflow token
- let Pullfrog use its short-lived GitHub App token for branch pushes
- explicitly restrict Pullfrog to feature-branch pushes and restricted shell access

## Context

Pullfrog completed the implementations for issues #1698 and #1710, but both runs failed to push because Git authenticated as github-actions[bot] with the checkout job's read-only token. The Pullfrog runtime had already acquired a short-lived contents:write token, so widening GITHUB_TOKEN permissions is unnecessary.

## Validation

- actionlint .github/workflows/pullfrog.yml
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Pullfrog's checkout credentials so branch pushes no longer fail with the read-only token left by `actions/checkout`.

- Disables credential persistence so Pullfrog uses its own short-lived write token for pushes.
- Enables restricted push and shell modes to limit Pullfrog's permissions.
- Unblocks Pullfrog implementations for #1698 and #1710.

<sup>Written for commit 8ad2af49bc217bc22d6ccbaae7bd19ad3b35a3c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated workflow execution settings to restrict repository write access and shell capabilities.
  * Disabled credential persistence during workflow checkout for improved security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->