### PR TITLE
fix(issue-gate): capture local agent commits

### DIFF
--- a/.github/workflows/issue-gate.yaml
+++ b/.github/workflows/issue-gate.yaml
@@ -308,11 +308,15 @@ jobs:
           }
 
           let head = git-complete [rev-parse HEAD]
-          if $head.exit_code != 0 or ($head.stdout | str trim) != $env.BASE_SHA {
-              error make {msg: 'Pullfrog must leave the checked-out base commit unchanged'}
+          if $head.exit_code != 0 {
+              error make {msg: $"Could not resolve Pullfrog HEAD: ($head.stderr | str trim)"}
           }
+          let head_sha = $head.stdout | str trim
 
           if $result.implementation == 'none' {
+              if $head_sha != $env.BASE_SHA {
+                  error make {msg: 'Pullfrog declined implementation after creating local commits'}
+              }
               let status = git-complete [status --porcelain]
               if $status.exit_code != 0 or ($status.stdout | str trim | is-not-empty) {
                   error make {msg: 'Pullfrog declined implementation after changing the working tree'}
@@ -327,6 +331,11 @@ jobs:
                   error make {msg: 'Pullfrog returned invalid implementation PR metadata'}
               }
 
+              let ancestry = git-complete [merge-base --is-ancestor $env.BASE_SHA $head_sha]
+              if $ancestry.exit_code != 0 {
+                  error make {msg: 'Pullfrog HEAD must descend from the checked-out base commit'}
+              }
+
               let untracked_result = git-complete [ls-files --others --exclude-standard '-z']
               if $untracked_result.exit_code != 0 {
                   error make {msg: $"Could not inspect untracked files: ($untracked_result.stderr | str trim)"}
@@ -339,7 +348,7 @@ jobs:
                   git-run [add --intent-to-add -- ...$untracked]
               }
 
-              let changed_paths_result = git-complete [diff --name-only '-z' HEAD --]
+              let changed_paths_result = git-complete [diff --name-only '-z' $env.BASE_SHA --]
               if $changed_paths_result.exit_code != 0 {
                   error make {msg: $"Could not inspect changed paths: ($changed_paths_result.stderr | str trim)"}
               }
@@ -348,16 +357,16 @@ jobs:
                   error make {msg: 'Pullfrog implementation must change between 1 and 100 files'}
               }
 
-              let changed = git-complete [diff --quiet HEAD --]
+              let changed = git-complete [diff --quiet $env.BASE_SHA --]
               if $changed.exit_code == 0 {
                   error make {msg: 'Pullfrog reported a prepared implementation without any changes'}
               }
               if $changed.exit_code != 1 {
                   error make {msg: $"Could not inspect implementation changes: ($changed.stderr | str trim)"}
               }
-              git-run [diff --check HEAD --]
+              git-run [diff --check $env.BASE_SHA --]
 
-              let patch = git-complete [diff --binary --full-index HEAD --]
+              let patch = git-complete [diff --binary --full-index $env.BASE_SHA --]
               if $patch.exit_code != 0 {
                   error make {msg: $"Could not create the implementation patch: ($patch.stderr | str trim)"}
               }


### PR DESCRIPTION
## Summary

- allow Pullfrog to create local commits while push remains disabled
- require the resulting HEAD to descend from the recorded base commit
- build the bounded publication artifact from the complete base-relative tree diff
- continue rejecting changes when Pullfrog reports no implementation

## Context

The Issue Gate rerun for #1710 completed implementation and tests, then failed while preparing the artifact because Pullfrog created a local commit. Push was correctly denied, but the gate incorrectly required HEAD to remain exactly at the base commit and therefore could not serialize the completed work.

The publisher still receives only a size- and path-count-bounded patch. Agent commit metadata and history are not published.

## Validation

- actionlint .github/workflows/issue-gate.yaml
- Nushell 0.114.1 smoke test with a real base commit and descendant local commit
- verified the base-relative diff contains only .github/workflows/issue-gate.yaml and produces a non-empty binary patch
- git diff --check


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Issue Gate so Pullfrog can create local commits while push stays disabled, and the publication artifact is built from the complete base-relative tree diff.

- Requires Pullfrog HEAD to descend from the recorded base commit instead of matching it exactly.
- Rejects runs where Pullfrog declines implementation after creating local commits or changing the working tree.
- Generates the bounded patch from `BASE_SHA` rather than `HEAD`, covering local agent commits.
- Preserves the existing size and path-count limits on the published artifact; agent commit metadata is not published.

<sup>Written for commit 444a2dff0109d667a8e140ceb9e646d8bb84f51e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved implementation validation to ensure declined changes remain based on the original commit.
  - Ensured prepared changes are correctly verified against the recorded base version.
  - Updated change detection and patch generation to use the appropriate base revision for more reliable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->