### PR TITLE
fix(issue-gate): avoid parsing status suffix

### DIFF
--- a/.github/scripts/contribution-gate/coauthor.nu
+++ b/.github/scripts/contribution-gate/coauthor.nu
@@ -141,5 +141,5 @@ export def verify-coauthor []: nothing -> nothing {
         | str join "\n"
         error make {msg: $"Issue-author co-author verification failed for PR #($pull_request.number):\n($summary)"}
     }
-    print $"Verified issue-author attribution on PR #($pull_request.number) across ($commits | length) commit(s)."
+    print $"Verified issue-author attribution on PR #($pull_request.number) across ($commits | length) commits."
 }


### PR DESCRIPTION
## Summary

- replace the parenthesized plural suffix in the Nushell success message
- prevent Nushell from evaluating `(s)` as a command after co-author verification succeeds

## Context

Issue Gate successfully created PR #1714 and verified the issue author's trailer and GitHub identity, but the final status message failed with `Command s not found`.

## Validation

- `nu --ide-check 10 .github/scripts/contribution-gate/coauthor.nu`
- `nu .github/scripts/contribution-gate.test.nu`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Issue Gate's success message no longer fails with `Command s not found`. Nushell was parsing the `(s)` suffix in `commit(s)` as a command, so the message now uses `commits` instead.

<sup>Written for commit 57cd3df1b531279846758babb7b81419a5e0cd55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the contribution verification success message to use clearer “commits” wording when reporting verified commit counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->