### PR TITLE
fix(claude): keep entries whose usage.iterations[].model is null

### DIFF
--- a/rust/adapters/claude/src/lib.rs
+++ b/rust/adapters/claude/src/lib.rs
@@ -511,6 +511,7 @@ fn is_valid_usage_entry(data: &UsageEntry) -> bool {
 }
 
 pub(crate) fn has_unsupported_null_field(line: &[u8]) -> bool {
+    let iterations = iterations_span(line);
     let mut offset = 0;
     while let Some(relative_index) = memmem::find(&line[offset..], b":null") {
         let null_index = offset + relative_index;
@@ -525,15 +526,57 @@ pub(crate) fn has_unsupported_null_field(line: &[u8]) -> bool {
             while field_start > 0 && line[field_start] != b'"' {
                 field_start -= 1;
             }
-            if line.get(field_start) == Some(&b'"')
-                && is_unsupported_nullable_field(&line[field_start + 1..field_end])
-            {
-                return true;
+            if line.get(field_start) == Some(&b'"') {
+                let field = &line[field_start + 1..field_end];
+                // `message.usage.iterations[].model` is `Option<String>` in `UsageIteration`,
+                // so a null there is fine; only `message.model` (outside the array) is not.
+                let nested_iteration_model = field == b"model"
+                    && iterations
+                        .as_ref()
+                        .is_some_and(|span| span.contains(&null_index));
+                if !nested_iteration_model && is_unsupported_nullable_field(field) {
+                    return true;
+                }
             }
         }
         offset = null_index + b":null".len();
     }
     false
+}
+
+/// Byte range of the `"iterations":[...]` array body, found without parsing the line: the
+/// scan skips string contents (with escapes) and tracks bracket depth until the array closes.
+/// Claude Code writes compact JSON, so the marker carries no whitespace, like `"usage":{`.
+fn iterations_span(line: &[u8]) -> Option<std::ops::Range<usize>> {
+    const MARKER: &[u8] = br#""iterations":["#;
+    let start = memmem::find(line, MARKER)? + MARKER.len();
+    let mut depth = 1usize;
+    let mut in_string = false;
+    let mut escaped = false;
+    for (index, &byte) in line[start..].iter().enumerate() {
+        if in_string {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                in_string = false;
+            }
+            continue;
+        }
+        match byte {
+            b'"' => in_string = true,
+            b'[' | b'{' => depth += 1,
+            b']' | b'}' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(start..start + index);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
 }
 
 fn is_unsupported_nullable_field(field: &[u8]) -> bool {
@@ -711,6 +754,55 @@ mod tests {
         assert!(!has_unsupported_null_field(
             br#"{"message":{"content":null,"usage":{"input_tokens":0}}}"#
         ));
+    }
+
+    #[test]
+    fn allows_null_iteration_model_but_still_rejects_other_nulls() {
+        // Claude Code 2.1.266+ writes `"model":null` for the main-model iteration of Fable 5.1
+        // entries; `UsageIteration.model` is optional, so the line must be kept.
+        assert!(!has_unsupported_null_field(
+            br#"{"message":{"model":"claude-fable-5-1","usage":{"input_tokens":2,"output_tokens":289,"iterations":[{"type":"message","model":null,"input_tokens":2,"output_tokens":289}]}}}"#
+        ));
+        // A missing iteration model and an empty iterations array are unchanged.
+        assert!(!has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"input_tokens":2,"iterations":[{"type":"message","input_tokens":2}]}}}"#
+        ));
+        assert!(!has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"input_tokens":2,"iterations":[]}}}"#
+        ));
+        // Strings inside the array may contain brackets or escaped quotes without ending the span.
+        assert!(!has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"iterations":[{"type":"ad]vi\"sor}","model":null,"input_tokens":1}]}}}"#
+        ));
+        // `message.model` null is still rejected, before or after the iterations array.
+        assert!(has_unsupported_null_field(
+            br#"{"message":{"model":null,"usage":{"iterations":[{"type":"message","model":"m"}]}}}"#
+        ));
+        assert!(has_unsupported_null_field(
+            br#"{"message":{"usage":{"iterations":[{"type":"message","model":"m"}]},"model":null}}"#
+        ));
+        // Other unsupported nulls inside the array are still rejected.
+        assert!(has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"iterations":[{"type":"message","model":null,"cache_read_input_tokens":null}]}}}"#
+        ));
+    }
+
+    #[test]
+    fn counts_entries_whose_iteration_model_is_null() {
+        let fixture = fs_fixture!({
+            "projects/project-a/session-a/chat.jsonl": r#"{"type":"assistant","timestamp":"2026-09-12T04:38:42.296Z","version":"2.1.268","sessionId":"session-a","requestId":"req_1","message":{"id":"msg_1","model":"claude-fable-5-1","role":"assistant","usage":{"input_tokens":2,"cache_creation_input_tokens":55866,"cache_read_input_tokens":0,"output_tokens":289,"iterations":[{"type":"message","model":null,"input_tokens":2,"output_tokens":289,"cache_creation_input_tokens":55866,"cache_read_input_tokens":0}]}}}"#,
+        });
+
+        let loaded = read_usage_file(
+            &fixture.path("projects/project-a/session-a/chat.jsonl"),
+            None,
+            CostMode::Calculate,
+            Some(&PricingMap::default()),
+        );
+
+        assert_eq!(loaded.entries.len(), 1);
+        assert_eq!(loaded.entries[0].model.as_deref(), Some("claude-fable-5-1"));
+        assert_eq!(loaded.entries[0].data.message.usage.output_tokens, 289);
     }
 
     #[test]

--- a/rust/adapters/claude/src/lib.rs
+++ b/rust/adapters/claude/src/lib.rs
@@ -510,6 +510,9 @@ fn is_valid_usage_entry(data: &UsageEntry) -> bool {
     true
 }
 
+/// Mirrors the TypeScript loader's schema: a line whose known non-nullable field is `null`
+/// is skipped before deserialisation. `message.usage.iterations[].model` is the one exception,
+/// because `UsageIteration.model` is optional and Claude Code writes it as `null`.
 pub(crate) fn has_unsupported_null_field(line: &[u8]) -> bool {
     let iterations = iterations_span(line);
     let mut offset = 0;
@@ -544,39 +547,120 @@ pub(crate) fn has_unsupported_null_field(line: &[u8]) -> bool {
     false
 }
 
-/// Byte range of the `"iterations":[...]` array body, found without parsing the line: the
-/// scan skips string contents (with escapes) and tracks bracket depth until the array closes.
-/// Claude Code writes compact JSON, so the marker carries no whitespace, like `"usage":{`.
+/// Byte range of the `iterations` array body that sits directly in a `usage` object, found
+/// without deserialising the line. Every `"usage"` key whose value is an object is walked key
+/// by key at that object's own level (string contents and escapes are skipped, JSON whitespace
+/// is tolerated), so an `iterations` array nested elsewhere in the line — in another object,
+/// deeper inside `usage`, or as text inside a string — never matches. Key names are compared as
+/// raw bytes, like the `"usage":{` marker the loader already relies on.
 fn iterations_span(line: &[u8]) -> Option<std::ops::Range<usize>> {
-    const MARKER: &[u8] = br#""iterations":["#;
-    let start = memmem::find(line, MARKER)? + MARKER.len();
-    let mut depth = 1usize;
-    let mut in_string = false;
-    let mut escaped = false;
-    for (index, &byte) in line[start..].iter().enumerate() {
-        if in_string {
-            if escaped {
-                escaped = false;
-            } else if byte == b'\\' {
-                escaped = true;
-            } else if byte == b'"' {
-                in_string = false;
-            }
+    const USAGE_KEY: &[u8] = br#""usage""#;
+    let mut offset = 0;
+    while let Some(found) = memmem::find(&line[offset..], USAGE_KEY) {
+        let key_end = offset + found + USAGE_KEY.len();
+        offset = key_end;
+        let Some(body) = expect_after_whitespace(line, key_end, b':')
+            .and_then(|index| expect_after_whitespace(line, index, b'{'))
+        else {
             continue;
+        };
+        if let Some(span) = iterations_in_object(line, body) {
+            return Some(span);
         }
+    }
+    None
+}
+
+/// Walks the members of the object whose body starts at `start` and returns the body range of
+/// the first `iterations` member whose value is an array. Values of other members are skipped
+/// whole, so nothing inside them can match.
+fn iterations_in_object(line: &[u8], start: usize) -> Option<std::ops::Range<usize>> {
+    let mut index = skip_whitespace(line, start);
+    loop {
+        match line.get(index)? {
+            b'}' => return None,
+            b'"' => {}
+            _ => return None,
+        }
+        let key_end = string_end(line, index + 1)?;
+        let key = &line[index + 1..key_end];
+        let value = expect_after_whitespace(line, key_end + 1, b':')?;
+        let value = skip_whitespace(line, value);
+        let value_end = match line.get(value)? {
+            b'[' if key == b"iterations" => {
+                return Some(value + 1..container_end(line, value + 1)?);
+            }
+            b'[' | b'{' => container_end(line, value + 1)?,
+            b'"' => string_end(line, value + 1)?,
+            _ => {
+                let mut end = value;
+                while line
+                    .get(end)
+                    .is_some_and(|byte| !matches!(byte, b',' | b'}'))
+                {
+                    end += 1;
+                }
+                end - 1
+            }
+        };
+        index = skip_whitespace(line, value_end + 1);
+        match line.get(index)? {
+            b',' => index = skip_whitespace(line, index + 1),
+            b'}' => return None,
+            _ => return None,
+        }
+    }
+}
+
+/// Index of the bracket that closes the array or object whose body starts at `start`.
+fn container_end(line: &[u8], start: usize) -> Option<usize> {
+    let mut depth = 1usize;
+    let mut index = start;
+    while let Some(&byte) = line.get(index) {
         match byte {
-            b'"' => in_string = true,
+            b'"' => index = string_end(line, index + 1)?,
             b'[' | b'{' => depth += 1,
             b']' | b'}' => {
                 depth -= 1;
                 if depth == 0 {
-                    return Some(start..start + index);
+                    return Some(index);
                 }
             }
             _ => {}
         }
+        index += 1;
     }
     None
+}
+
+/// Index of the quote that closes the string whose contents start at `start`.
+fn string_end(line: &[u8], start: usize) -> Option<usize> {
+    let mut index = start;
+    while let Some(&byte) = line.get(index) {
+        match byte {
+            b'\\' => index += 1,
+            b'"' => return Some(index),
+            _ => {}
+        }
+        index += 1;
+    }
+    None
+}
+
+fn skip_whitespace(line: &[u8], mut index: usize) -> usize {
+    while line
+        .get(index)
+        .is_some_and(|byte| matches!(byte, b' ' | b'\t' | b'\n' | b'\r'))
+    {
+        index += 1;
+    }
+    index
+}
+
+/// Index just past `expected` when it is the next non-whitespace byte at or after `start`.
+fn expect_after_whitespace(line: &[u8], start: usize, expected: u8) -> Option<usize> {
+    let index = skip_whitespace(line, start);
+    (line.get(index) == Some(&expected)).then_some(index + 1)
 }
 
 fn is_unsupported_nullable_field(field: &[u8]) -> bool {
@@ -756,10 +840,11 @@ mod tests {
         ));
     }
 
+    /// Claude Code 2.1.266+ writes `"model":null` for the main-model iteration of Fable 5.1
+    /// entries; `UsageIteration.model` is optional, so those lines must be kept while every
+    /// other unsupported null keeps being rejected.
     #[test]
     fn allows_null_iteration_model_but_still_rejects_other_nulls() {
-        // Claude Code 2.1.266+ writes `"model":null` for the main-model iteration of Fable 5.1
-        // entries; `UsageIteration.model` is optional, so the line must be kept.
         assert!(!has_unsupported_null_field(
             br#"{"message":{"model":"claude-fable-5-1","usage":{"input_tokens":2,"output_tokens":289,"iterations":[{"type":"message","model":null,"input_tokens":2,"output_tokens":289}]}}}"#
         ));
@@ -787,6 +872,41 @@ mod tests {
         ));
     }
 
+    /// The exemption is scoped to the `iterations` member of a `usage` object: whitespace
+    /// around the member is fine, but a same-named array elsewhere in the line, an `iterations`
+    /// member nested deeper inside `usage`, or the key as text inside a string never qualifies.
+    #[test]
+    fn scopes_the_iteration_model_exemption_to_the_usage_object() {
+        // JSON whitespace between the key, the colon and the array is tolerated.
+        assert!(!has_unsupported_null_field(
+            br#"{"message": {"model": "m", "usage" : { "input_tokens": 2, "iterations" : [ {"type": "message", "model": null} ] }}}"#
+        ));
+        // An earlier `iterations` array in another object does not stand in for the real one.
+        assert!(!has_unsupported_null_field(
+            br#"{"toolUseResult":{"iterations":[{"model":"x"}]},"message":{"model":"m","usage":{"iterations":[{"type":"message","model":null}]}}}"#
+        ));
+        assert!(has_unsupported_null_field(
+            br#"{"toolUseResult":{"iterations":[{"model":null}]},"message":{"model":"m","usage":{"input_tokens":1}}}"#
+        ));
+        // A `usage` member that is not an object is skipped in favour of the real one.
+        assert!(!has_unsupported_null_field(
+            br#"{"usage":"n/a","message":{"model":"m","usage":{"iterations":[{"type":"message","model":null}]}}}"#
+        ));
+        // Only a direct member of `usage` counts, not one nested deeper inside it.
+        assert!(has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"server_tool_use":{"iterations":[{"model":null}]},"input_tokens":1}}}"#
+        ));
+        // The key as text inside a string value is not a member.
+        assert!(has_unsupported_null_field(
+            br#"{"message":{"content":"\"usage\":{\"iterations\":[","model":null,"usage":{"input_tokens":1}}}"#
+        ));
+        // Members before `iterations` may hold nested containers and strings with brackets.
+        assert!(!has_unsupported_null_field(
+            br#"{"message":{"model":"m","usage":{"cache_creation":{"ephemeral_5m_input_tokens":0},"server_tool_use":{"web_search_requests":0},"inference_geo":"[not]{available}","iterations":[{"type":"message","model":null}]}}}"#
+        ));
+    }
+
+    /// The repro line from #1710 loads as one Fable 5.1 entry with its own token counts.
     #[test]
     fn counts_entries_whose_iteration_model_is_null() {
         let fixture = fs_fixture!({


### PR DESCRIPTION
Fixes #1710

## What

Since Claude Code 2.1.266, Fable 5.1 assistant entries carry `"model": null` in the main-model item of `message.usage.iterations`. `has_unsupported_null_field` scans the raw line for `:null` with no notion of nesting, so that nested null was treated like a null `message.model` and the whole line was skipped before deserialisation. `daily`, `session` and `blocks` silently lost every Fable 5.1 entry.

## Fix

`UsageIteration.model` is already `Option<String>`, so a null there is valid. The scanner now locates the `"iterations":[...]` byte span (skipping string contents and escapes, tracking bracket depth) and exempts `model` nulls inside it. Everything else is unchanged: a null `message.model` before or after the array and token-count nulls inside the array are still rejected. `daily.rs` shares the function, so both loaders are covered.

## Tests

- `allows_null_iteration_model_but_still_rejects_other_nulls`: null iteration model, missing model, empty array, strings containing brackets / escaped quotes, `message.model` null before and after the array, other nulls inside the array.
- `counts_entries_whose_iteration_model_is_null`: the repro line from #1710 loads as one `claude-fable-5-1` entry.

## Verification on real data (macOS, Claude Code 2.1.266)

- Repro line from the issue: stock 20.0.20 → `daily: []`; patched → 56,157 tokens under `claude-fable-5-1`.
- One real Fable 5.1 session file on its own: stock → nothing; patched → 28.2M tokens.
- Full `~/.claude`, today: stock 3.18M tokens (Fable output 5,596); patched 66.1M tokens (Fable output 331,854). Opus 5 numbers are identical on both, so nothing else changed.

Ran `cargo fmt --check`, `cargo clippy -p ccusage-adapter-claude --all-targets -- -D warnings` and `cargo test --workspace`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1710 by keeping Claude entries whose `message.usage.iterations[].model` is null, so `daily`, `session`, and `blocks` no longer lose Fable 5.1 usage written by Claude Code 2.1.266+.

- Parses each nullable line once and shares that parse between null validation and typed deserialization, in both Claude loaders.
- Exempts only the direct `iterations` array of `message.usage` (and `data.message.message.usage` for AgentProgress); same-named arrays elsewhere never qualify.
- Rejects duplicate JSON members before typed deserialization, matching Serde's behavior on the raw line.
- Null `message.model`, token counts, and nested objects are still rejected, and malformed members no longer trip the pre-check.
- Adds tests covering the #1710 repro line, scoping edge cases, malformed members, and duplicate member rejection.

<sup>Written for commit 11c5135df199b450ac6883a6dd362a858261c0c8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/ccusage/ccusage/pull/1719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved processing of usage data containing supported `null` values.
  * Usage records with malformed or unsupported data are safely skipped instead of causing processing failures.
  * JSON usage data with varied formatting and escaped property names continues to be handled correctly.
  * Unsupported nested `null` values remain rejected, while unrelated unsupported values continue to be ignored safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->